### PR TITLE
feat(pedidos): add pagination to GetByClienteAsync and GetByEstadoAsync

### DIFF
--- a/src/ExtraGasMVC/Services/Implementations/PedidoService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/PedidoService.cs
@@ -108,26 +108,50 @@ public class PedidoService : IPedidoService
         return _mapper.Map<IEnumerable<PedidoDto>>(pedidos);
     }
 
-    public async Task<IEnumerable<PedidoDto>> GetByClienteAsync(ulong clienteId, CancellationToken ct = default)
+    public async Task<SearchResultDto<PedidoDto>> GetByClienteAsync(ulong clienteId, int pagina, int tamanio, CancellationToken ct = default)
     {
-        var pedidos = await GetWithIncludes()
+        var query = GetWithIncludes()
             .AsNoTracking()
-            .Where(p => p.ClienteId == clienteId)
+            .Where(p => p.ClienteId == clienteId);
+
+        var total = await query.CountAsync(ct);
+
+        var pedidos = await query
             .OrderByDescending(p => p.Fecha)
+            .Skip((pagina - 1) * tamanio)
+            .Take(tamanio)
             .ToListAsync(ct);
 
-        return _mapper.Map<IEnumerable<PedidoDto>>(pedidos);
+        return new SearchResultDto<PedidoDto>
+        {
+            Items = _mapper.Map<List<PedidoDto>>(pedidos),
+            Total = total,
+            Pagina = pagina,
+            Tamanio = tamanio
+        };
     }
 
-    public async Task<IEnumerable<PedidoDto>> GetByEstadoAsync(ulong estadoId, CancellationToken ct = default)
+    public async Task<SearchResultDto<PedidoDto>> GetByEstadoAsync(ulong estadoId, int pagina, int tamanio, CancellationToken ct = default)
     {
-        var pedidos = await GetWithIncludes()
+        var query = GetWithIncludes()
             .AsNoTracking()
-            .Where(p => p.EstadoPedidoId == estadoId)
+            .Where(p => p.EstadoPedidoId == estadoId);
+
+        var total = await query.CountAsync(ct);
+
+        var pedidos = await query
             .OrderByDescending(p => p.Fecha)
+            .Skip((pagina - 1) * tamanio)
+            .Take(tamanio)
             .ToListAsync(ct);
 
-        return _mapper.Map<IEnumerable<PedidoDto>>(pedidos);
+        return new SearchResultDto<PedidoDto>
+        {
+            Items = _mapper.Map<List<PedidoDto>>(pedidos),
+            Total = total,
+            Pagina = pagina,
+            Tamanio = tamanio
+        };
     }
 
     public async Task<IEnumerable<PedidoDto>> GetPendientesAsync(CancellationToken ct = default)

--- a/src/ExtraGasMVC/Services/Interfaces/IPedidoService.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IPedidoService.cs
@@ -10,8 +10,19 @@ public interface IPedidoService
         DateTime? desde, DateTime? hasta,
         int pagina, int tamanio, CancellationToken ct = default);
     Task<IEnumerable<PedidoDto>> GetAllAsync(CancellationToken ct = default);
-    Task<IEnumerable<PedidoDto>> GetByClienteAsync(ulong clienteId, CancellationToken ct = default);
-    Task<IEnumerable<PedidoDto>> GetByEstadoAsync(ulong estadoId, CancellationToken ct = default);
+    Task<SearchResultDto<PedidoDto>> GetByClienteAsync(ulong clienteId, int pagina, int tamanio, CancellationToken ct = default);
+    Task<SearchResultDto<PedidoDto>> GetByEstadoAsync(ulong estadoId, int pagina, int tamanio, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns pedidos with saldo pendiente (saldo &gt; 0). Used by the dashboard
+    /// dropdown in <c>PagosController</c> and the <c>Pendientes</c> view.
+    /// <para>
+    /// Not paginated by design — the dataset is bounded by pedidos with debt,
+    /// which is small in practice. If this grows large, add pagination
+    /// parameters and return a <see cref="SearchResultDto{T}"/> like
+    /// <see cref="SearchAsync"/> does.
+    /// </para>
+    /// </summary>
     Task<IEnumerable<PedidoDto>> GetPendientesAsync(CancellationToken ct = default);
     Task<IEnumerable<PedidoItemDto>> GetItemsByPedidoAsync(ulong pedidoId, CancellationToken ct = default);
 


### PR DESCRIPTION
## Contexto

Issue #24 (priority: low, area: service, performance). Los métodos `GetByClienteAsync`, `GetByEstadoAsync`, `GetAllAsync` y `GetPendientesAsync` retornaban todo el set sin paginar. `SearchAsync` ya estaba paginado, pero estos cuatro no.

## Cambios

- **`GetByClienteAsync` y `GetByEstadoAsync`** ahora retornan `SearchResultDto<PedidoDto>` y aceptan `int pagina, int tamanio`. Implementan `Count` + `Skip/Take` con `OrderByDescending(Fecha)`, mismo patrón que `SearchAsync`.
- **`GetPendientesAsync`** mantiene su firma (`IEnumerable<PedidoDto>`) por diseño — el dataset está acotado por pedidos con saldo pendiente. Se agregó un comentario XML en la interface explicando la decisión y cómo migrarlo si crece.
- **`GetAllAsync`** NO se marcó como `[Obsolete]`. Su único consumidor (`HomeController.Index`) hace agregaciones (`Count`, `Sum`) sobre todo el set para el dashboard. Reemplazarlo por `SearchAsync` rompería esa semántica. Cuando exista un método de métricas dedicado, ese será el momento.

## Archivos

- `src/ExtraGasMVC/Services/Interfaces/IPedidoService.cs`
- `src/ExtraGasMVC/Services/Implementations/PedidoService.cs`

+45 / -10 líneas.

## Blast radius

Cero consumidores activos de `GetByClienteAsync`/`GetByEstadoAsync` en el código actual. El cambio es 100% backward-compatible a nivel de call sites.

`HomeController` y `PedidosController`/`PagosController` no requieren cambios (las firmas que consumen siguen iguales).

## Verificación

- `dotnet build src/ExtraGasMVC` → OK, 0 errores. Los 2 warnings son preexistentes (vulnerabilidad conocida de AutoMapper 12.0.1, no relacionada).

## Notas

Cierra la issue #24.