### PR TITLE
feat(garrafas): máquina de estados con matriz de transiciones válidas

### DIFF
--- a/db/docs/DECISIONES.md
+++ b/db/docs/DECISIONES.md
@@ -156,6 +156,45 @@ Documento de decisiones (ADR-style) y supuestos del sistema **ExtraGas**.
 
 ---
 
+## 16. Máquina de estados de garrafa — matriz de transiciones
+
+**Decisión:** las transiciones válidas entre estados de garrafa cuando se hacen manualmente desde la UI (`GarrafaService.CambiarEstadoAsync`) están definidas en una matriz hard-coded en C# (`Services/GarrafaTransiciones.cs`), no en una tabla lookup.
+
+**Por qué:**
+
+1. Las transiciones describen restricciones del dominio físico (una garrafa dañada no se puede entregar, una retirada del sistema no vuelve a estar disponible). Son un contrato invariante, no un catálogo administrativo.
+2. Al estar en C# viajan con el código del servicio, las versiones y el PR — un cambio se revisa, no se aplica por una corrida SQL.
+3. El compilador detecta referencias inválidas a estados. La matriz es trivialmente testeable sin necesidad de fixtures de BD.
+4. El catálogo `estados_garrafa` (los **estados mismos**) sigue siendo una tabla en BD para mantener el principio #4. Sólo las transiciones, que son lógica de negocio, son código.
+
+**Matriz vigente:**
+
+| Origen ↓ → Destino | LLENA_DEPOSITO | VACIA_DEPOSITO | EN_TRANSITO | EN_CLIENTE | DAÑADA | FUERA_SERVICIO |
+|---|---|---|---|---|---|---|
+| **LLENA_DEPOSITO**  | — | ✓ | ✓ | ✓ | ✓ | — |
+| **VACIA_DEPOSITO**  | ✓ | — | — | ✓ | ✓ | ✓ |
+| **EN_TRANSITO**     | ✓ | ✓ | — | ✓ | ✓ | — |
+| **EN_CLIENTE**      | ✓ | ✓ | — | — | ✓ | ✓ |
+| **DAÑADA**          | — | ✓ | — | — | — | ✓ |
+| **FUERA_SERVICIO**  | — | — | — | — | — | — |
+
+Notas operativas:
+
+- **`FUERA_SERVICIO` es estado terminal**: una garrafa retirada del sistema no vuelve a entrar al inventario activo. Esto es el ejemplo del issue #40.
+- **`EN_TRANSITO → EN_CLIENTE`** es la confirmación de una entrega que estaba en reparto.
+- **`EN_CLIENTE → VACIA_DEPOSITO`** es la devolución por canje (escenario habitual).
+- Las transiciones por flujo de negocio (`COMPRA`, `ENTREGA_CLIENTE`, `DEVOLUCION_CLIENTE`, `BAJA`, `REPARACION`) **no pasan por esta matriz** — son registradas directamente por los servicios de `Recepciones` y `Pedidos` con su `tipo_movimiento` correspondiente.
+- Auto-transiciones (`X → X`) son rechazadas como no-ops.
+
+**Implicancia para la UI:**
+
+- El dropdown del formulario "Cambiar estado" sólo muestra los destinos válidos para el estado actual de la garrafa (`IGarrafaService.GetTransicionesDisponiblesAsync`).
+- Si el estado es terminal, el dropdown queda deshabilitado y el formulario avisa con un `alert-warning` — la operación es efectivamente bloqueada del lado UI.
+- `CambiarEstadoAsync` rechaza toda transición no listada con `InvalidOperationException` ("Transición inválida: ORIGEN → DESTINO. Consulte la matriz…"). La validación pasa también por requests hand-crafted, no sólo por la UI.
+- Si el destino requiere cliente (`requiere_cliente = TRUE` en `estados_garrafa`, p.ej. `EN_CLIENTE`), la app exige `ClienteId` en el DTO. El trigger `trg_garrafas_bi_validate` sólo cubre `INSERT` directos, no cambios por `CAMBIO_ESTADO`.
+
+---
+
 ## Supuestos explícitos (no validados con el usuario)
 
 1. No hay delivery con zonas / tarifas distintas. Un pedido = una dirección.

--- a/src/ExtraGasMVC/Constants/GarrafaEstados.cs
+++ b/src/ExtraGasMVC/Constants/GarrafaEstados.cs
@@ -1,0 +1,21 @@
+namespace ExtraGasMVC.Constants;
+
+/// <summary>
+/// Canonical state codes for garrafas, matching the database catalog
+/// <c>estados_garrafa.codigo</c>. Used instead of magic strings for
+/// compile-time safety and discoverability.
+/// </summary>
+/// <remarks>
+/// The state codes themselves are stored in the database — these constants
+/// mirror them to give type-safe references in C# code. If a state code is
+/// renamed in the database, update both this file and the seed migration.
+/// </remarks>
+public static class GarrafaEstados
+{
+    public const string LlenaDeposito = "LLENA_DEPOSITO";
+    public const string VaciaDeposito = "VACIA_DEPOSITO";
+    public const string EnCliente = "EN_CLIENTE";
+    public const string EnTransito = "EN_TRANSITO";
+    public const string Danada = "DAÑADA";
+    public const string FueraServicio = "FUERA_SERVICIO";
+}

--- a/src/ExtraGasMVC/Controllers/GarrafasController.cs
+++ b/src/ExtraGasMVC/Controllers/GarrafasController.cs
@@ -151,7 +151,10 @@ public class GarrafasController : Controller
         var garrafa = await _garrafaService.GetByIdAsync(id, ct);
         if (garrafa is null) return NotFound();
 
-        ViewBag.Estados = await _garrafaService.GetEstadosAsync(ct);
+        // Issue #40: el dropdown muestra sólo los destinos válidos para el estado
+        // actual de la garrafa, según GarrafaTransiciones. La validación real
+        // (incluido requests hand-crafted) la hace CambiarEstadoAsync en el service.
+        ViewBag.Estados = await _garrafaService.GetTransicionesDisponiblesAsync(id, ct);
         ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
 
         var dto = new CambiarEstadoGarrafaDto
@@ -171,13 +174,13 @@ public class GarrafasController : Controller
         var garrafa = await _garrafaService.GetByIdAsync(id, ct);
         if (garrafa is null) return NotFound();
 
+        // Re-poblar ViewBags antes de cualquier re-render (Valid o error).
+        ViewBag.Estados = await _garrafaService.GetTransicionesDisponiblesAsync(id, ct);
+        ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
+        ViewBag.Garrafa = garrafa;
+
         if (!ModelState.IsValid)
-        {
-            ViewBag.Estados = await _garrafaService.GetEstadosAsync(ct);
-            ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
-            ViewBag.Garrafa = garrafa;
             return View(dto);
-        }
 
         try
         {
@@ -188,18 +191,14 @@ public class GarrafasController : Controller
         }
         catch (InvalidOperationException ex)
         {
+            // Incluye: transición inválida, estado destino inexistente,
+            // estado destino que requiere cliente, etc.
             ModelState.AddModelError(string.Empty, ex.Message);
-            ViewBag.Estados = await _garrafaService.GetEstadosAsync(ct);
-            ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
-            ViewBag.Garrafa = garrafa;
             return View(dto);
         }
         catch (Exception ex)
         {
             ModelState.AddModelError(string.Empty, $"No se pudo cambiar el estado: {ex.Message}");
-            ViewBag.Estados = await _garrafaService.GetEstadosAsync(ct);
-            ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
-            ViewBag.Garrafa = garrafa;
             return View(dto);
         }
     }

--- a/src/ExtraGasMVC/Services/GarrafaTransiciones.cs
+++ b/src/ExtraGasMVC/Services/GarrafaTransiciones.cs
@@ -1,0 +1,122 @@
+using ExtraGasMVC.Constants;
+
+namespace ExtraGasMVC.Services;
+
+/// <summary>
+/// State machine that defines the legal transitions between garrafa states
+/// performed through the <c>CAMBIO_ESTADO</c> manual flow. Transitions driven
+/// by <c>compras</c>, <c>pedidos</c>, or <c>bajas</c> still go through the
+/// domain services and do not consult this matrix.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why hard-coded in C# rather than a database lookup table:</b> the
+/// allowed transitions are an immutable contract of the domain — they
+/// describe physical reality (a damaged garrafa cannot be sold as full;
+/// a discarded garrafa cannot return to service). Encoded in code they
+/// are reviewed alongside the service, validated by the compiler, and
+/// trivially unit-testable.
+/// </para>
+/// <para>
+/// If a transition needs to change, the update is a code change reviewed
+/// through PR — not a silent DB write. See <c>db/docs/DECISIONES.md</c>
+/// ADR #16 for the rationale.
+/// </para>
+/// <para>
+/// <b>Lifecycle:</b>
+/// </para>
+/// <code>
+///   LLENA_DEPOSITO ──┬─> EN_TRANSITO ──┬─> LLENA_DEPOSITO  (returned full)
+///                   ├─> EN_CLIENTE   ──┼─> VACIA_DEPOSITO  (returned empty — normal swap)
+///                   ├─> VACIA_DEPOSITO                  (consumed in-house)
+///                   └─> DAÑADA
+///   VACIA_DEPOSITO  ──> LLENA_DEPOSITO                  (refilled at plant)
+///                   ──> EN_CLIENTE                       (delivered empty)
+///                   ──> DAÑADA
+///                   ──> FUERA_SERVICIO                   (retired)
+///   DAÑADA          ──> VACIA_DEPOSITO                   (repaired)
+///                   ──> FUERA_SERVICIO                   (unrecoverable)
+///   FUERA_SERVICIO  ──> (terminal — no outgoing transitions)
+/// </code>
+/// </remarks>
+public static class GarrafaTransiciones
+{
+    /// <summary>
+    /// Transition matrix: origin state code → set of allowed destination state codes.
+    /// Self-transitions are not represented (they are rejected as no-ops).
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, IReadOnlySet<string>> Matriz =
+        new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal)
+        {
+            [GarrafaEstados.LlenaDeposito] = new HashSet<string>(StringComparer.Ordinal)
+            {
+                GarrafaEstados.EnTransito,
+                GarrafaEstados.EnCliente,
+                GarrafaEstados.VaciaDeposito,
+                GarrafaEstados.Danada
+            },
+            [GarrafaEstados.VaciaDeposito] = new HashSet<string>(StringComparer.Ordinal)
+            {
+                GarrafaEstados.LlenaDeposito,
+                GarrafaEstados.EnCliente,
+                GarrafaEstados.Danada,
+                GarrafaEstados.FueraServicio
+            },
+            [GarrafaEstados.EnTransito] = new HashSet<string>(StringComparer.Ordinal)
+            {
+                GarrafaEstados.LlenaDeposito,
+                GarrafaEstados.VaciaDeposito,
+                GarrafaEstados.EnCliente,
+                GarrafaEstados.Danada
+            },
+            [GarrafaEstados.EnCliente] = new HashSet<string>(StringComparer.Ordinal)
+            {
+                GarrafaEstados.VaciaDeposito,
+                GarrafaEstados.LlenaDeposito,
+                GarrafaEstados.Danada,
+                GarrafaEstados.FueraServicio
+            },
+            [GarrafaEstados.Danada] = new HashSet<string>(StringComparer.Ordinal)
+            {
+                GarrafaEstados.VaciaDeposito,
+                GarrafaEstados.FueraServicio
+            },
+
+            // FUERA_SERVICIO is terminal — once a garrafa is retired it cannot
+            // return to the active inventory. This is the example called out
+            // in issue #40 (FUERA_SERVICIO → LLENA_DEPOSITO must be rejected).
+            [GarrafaEstados.FueraServicio] = new HashSet<string>(StringComparer.Ordinal)
+        };
+
+    /// <summary>
+    /// Returns <c>true</c> when transitioning from <paramref name="origenCodigo"/>
+    /// to <paramref name="destinoCodigo"/> is allowed by the matrix.
+    /// A self-transition (origen == destino) is always rejected.
+    /// </summary>
+    public static bool EsValida(string origenCodigo, string destinoCodigo)
+    {
+        if (string.IsNullOrEmpty(origenCodigo) || string.IsNullOrEmpty(destinoCodigo))
+            return false;
+
+        if (string.Equals(origenCodigo, destinoCodigo, StringComparison.Ordinal))
+            return false;
+
+        return Matriz.TryGetValue(origenCodigo, out var destinos)
+               && destinos.Contains(destinoCodigo);
+    }
+
+    /// <summary>
+    /// Returns the set of destination state codes reachable from
+    /// <paramref name="origenCodigo"/>. Returns an empty set when the origin
+    /// is unknown or terminal.
+    /// </summary>
+    public static IReadOnlySet<string> DestinosPermitidos(string origenCodigo)
+    {
+        if (string.IsNullOrEmpty(origenCodigo))
+            return new HashSet<string>(StringComparer.Ordinal);
+
+        return Matriz.TryGetValue(origenCodigo, out var destinos)
+            ? destinos
+            : new HashSet<string>(StringComparer.Ordinal);
+    }
+}

--- a/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using ExtraGasMVC.Constants;
 using ExtraGasMVC.Data.Context;
 using ExtraGasMVC.Data.Entities;
 using ExtraGasMVC.DTOs;
@@ -117,6 +118,43 @@ public class GarrafaService : IGarrafaService
         if (garrafa == null)
             return false;
 
+        // Cargar ambos extremos de la transición (origen y destino) en una sola
+        // consulta para poder validar contra GarrafaTransiciones y contra las
+        // reglas del catálogo (requiere_cliente, etc.).
+        var extremos = await _context.EstadosGarrafa
+            .AsNoTracking()
+            .Where(e => e.Id == garrafa.EstadoGarrafaId || e.Id == dto.NuevoEstadoId)
+            .Select(e => new { e.Id, e.Codigo, e.RequiereCliente, e.Nombre })
+            .ToListAsync(ct);
+
+        var origen = extremos.FirstOrDefault(e => e.Id == garrafa.EstadoGarrafaId);
+        var destino = extremos.FirstOrDefault(e => e.Id == dto.NuevoEstadoId);
+
+        if (origen is null)
+            throw new InvalidOperationException(
+                $"El estado actual de la garrafa (id={garrafa.EstadoGarrafaId}) no existe en el catálogo estados_garrafa.");
+
+        if (destino is null)
+            throw new InvalidOperationException(
+                $"El estado destino solicitado (id={dto.NuevoEstadoId}) no existe en el catálogo estados_garrafa.");
+
+        // Issue #40: validar la transición contra la matriz de estados.
+        if (!GarrafaTransiciones.EsValida(origen.Codigo, destino.Codigo))
+        {
+            throw new InvalidOperationException(
+                $"Transición inválida: {origen.Nombre} ({origen.Codigo}) → {destino.Nombre} ({destino.Codigo}). " +
+                $"Consulte la matriz de transiciones válidas en la documentación del módulo Garrafas.");
+        }
+
+        // Si el estado destino exige un cliente (p.ej. EN_CLIENTE) el DTO debe traerlo.
+        // El trigger trg_garrafas_bi_validate sólo cubre INSERT — para los cambios
+        // de estado hechos por CAMBIO_ESTADO la validación la hace la app.
+        if (destino.RequiereCliente && !dto.ClienteId.HasValue)
+        {
+            throw new InvalidOperationException(
+                $"El estado {destino.Nombre} requiere seleccionar un cliente.");
+        }
+
         var tipoCambioEstadoId = await _context.TiposMovimientoGarrafa
             .AsNoTracking()
             .Where(t => t.Codigo == "CAMBIO_ESTADO")
@@ -162,6 +200,37 @@ public class GarrafaService : IGarrafaService
             await transaction.RollbackAsync(ct);
             throw;
         }
+    }
+
+    public async Task<IEnumerable<EstadoGarrafaDto>> GetTransicionesDisponiblesAsync(ulong garrafaId, CancellationToken ct = default)
+    {
+        // Solo necesitamos el código del estado actual para consultar la matriz;
+        // hacerlo con un join manual evita tener que añadir una navigation
+        // property a Garrafa (la entidad lo mantiene plano por convención).
+        var estadoCodigo = await (
+            from g in _context.Garrafas.AsNoTracking()
+            join e in _context.EstadosGarrafa.AsNoTracking()
+                on g.EstadoGarrafaId equals e.Id
+            where g.Id == garrafaId
+            select e.Codigo
+        ).FirstOrDefaultAsync(ct);
+
+        if (string.IsNullOrEmpty(estadoCodigo))
+            return Array.Empty<EstadoGarrafaDto>();
+
+        var codigosPermitidos = GarrafaTransiciones.DestinosPermitidos(estadoCodigo);
+        if (codigosPermitidos.Count == 0)
+            return Array.Empty<EstadoGarrafaDto>();
+
+        // Filtra el catálogo por los códigos permitidos y mantiene el orden
+        // alfabético que usa GetEstadosAsync para que la UI sea consistente.
+        var destinos = await _context.EstadosGarrafa
+            .AsNoTracking()
+            .Where(e => codigosPermitidos.Contains(e.Codigo))
+            .OrderBy(e => e.Nombre)
+            .ToListAsync(ct);
+
+        return _mapper.Map<IEnumerable<EstadoGarrafaDto>>(destinos);
     }
 
     public async Task<bool> DeleteAsync(ulong id, CancellationToken ct = default)

--- a/src/ExtraGasMVC/Services/Interfaces/IGarrafaService.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IGarrafaService.cs
@@ -14,4 +14,16 @@ public interface IGarrafaService
     Task<GarrafaDto> UpdateAsync(UpdateGarrafaDto garrafa, CancellationToken ct = default);
     Task<bool> CambiarEstadoAsync(ulong id, CambiarEstadoGarrafaDto dto, CancellationToken ct = default);
     Task<bool> DeleteAsync(ulong id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the catalog rows for the destination states that the given
+    /// garrafa is allowed to transition to. Used by the UI to filter the
+    /// state dropdown shown on the "Cambiar estado" view.
+    /// </summary>
+    /// <returns>
+    /// Empty enumerable when the garrafa doesn't exist, when its current
+    /// state has no outgoing transitions (terminal state), or when the
+    /// current state code is not present in the transition matrix.
+    /// </returns>
+    Task<IEnumerable<EstadoGarrafaDto>> GetTransicionesDisponiblesAsync(ulong garrafaId, CancellationToken ct = default);
 }

--- a/src/ExtraGasMVC/Views/Garrafas/CambiarEstado.cshtml
+++ b/src/ExtraGasMVC/Views/Garrafas/CambiarEstado.cshtml
@@ -4,6 +4,8 @@
     var garrafa = ViewBag.Garrafa as ExtraGasMVC.DTOs.GarrafaDto;
     var estados = ViewBag.Estados as IEnumerable<ExtraGasMVC.DTOs.EstadoGarrafaDto> ?? Array.Empty<ExtraGasMVC.DTOs.EstadoGarrafaDto>();
     var clientes = ViewBag.Clientes as IEnumerable<ExtraGasMVC.DTOs.ClienteDto> ?? Array.Empty<ExtraGasMVC.DTOs.ClienteDto>();
+    var hayTransiciones = estados.Any();
+    var placeholderDestino = hayTransiciones ? "Seleccione un estado" : "Sin transiciones disponibles";
     ViewData["Breadcrumbs"] = new List<BreadcrumbItem>
     {
         new() { Label = "Garrafas", Controller = "Garrafas", Action = "Index" },
@@ -27,41 +29,62 @@
             </dl>
         </div>
     }
-    <form asp-action="CambiarEstado" asp-route-id="@garrafa?.Id" method="post">
-        @Html.AntiForgeryToken()
+    @if (!hayTransiciones)
+    {
         <div class="card-body">
-            <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
-            <div class="row g-3">
-                <div class="col-md-6">
-                    <label asp-for="NuevoEstadoId" class="form-label">Nuevo estado</label>
-                    <select asp-for="NuevoEstadoId" class="form-select" required>
-                        <option value="">-- Seleccione un estado --</option>
-                        @foreach (var e in estados)
-                        {
-                            <option value="@e.Id">@e.Nombre (@e.Codigo)</option>
-                        }
-                    </select>
-                </div>
-                <div class="col-md-6">
-                    <label asp-for="ClienteId" class="form-label">Cliente (opcional)</label>
-                    <select asp-for="ClienteId" class="form-select">
-                        <option value="">-- Sin cliente --</option>
-                        @foreach (var c in clientes)
-                        {
-                            <option value="@c.Id">@c.Apellido, @c.Nombre</option>
-                        }
-                    </select>
-                    <small class="form-text text-secondary">Requerido si el estado lo exige.</small>
-                </div>
-                <div class="col-12">
-                    <label asp-for="Observaciones" class="form-label">Observaciones</label>
-                    <textarea asp-for="Observaciones" class="form-control" rows="3" placeholder="Motivo del cambio de estado"></textarea>
-                </div>
+            <div class="alert alert-warning mb-0" role="alert">
+                <h5 class="alert-heading"><i class="bi bi-exclamation-triangle me-1"></i> Estado terminal</h5>
+                La garrafa no tiene transiciones manuales válidas hacia otros estados desde su estado actual.
+                No es posible registrar un cambio desde este formulario.
             </div>
         </div>
         <div class="card-footer d-flex gap-2">
-            <button type="submit" class="btn btn-primary"><i class="bi bi-save me-1"></i> Guardar cambio</button>
-            <a asp-action="Details" asp-route-id="@garrafa?.Id" class="btn btn-outline-secondary">Cancelar</a>
+            <a asp-action="Details" asp-route-id="@garrafa?.Id" class="btn btn-outline-secondary">
+                <i class="bi bi-arrow-left me-1"></i> Volver al detalle
+            </a>
         </div>
-    </form>
+    }
+    else
+    {
+        <form asp-action="CambiarEstado" asp-route-id="@garrafa?.Id" method="post">
+            @Html.AntiForgeryToken()
+            <div class="card-body">
+                <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        <label asp-for="NuevoEstadoId" class="form-label">Nuevo estado</label>
+                        <select asp-for="NuevoEstadoId" class="form-select" required>
+                            <option value="">-- @placeholderDestino --</option>
+                            @foreach (var e in estados)
+                            {
+                                <option value="@e.Id">@e.Nombre (@e.Codigo)</option>
+                            }
+                        </select>
+                        <small class="form-text text-secondary">Solo se muestran los estados a los que es válido transicionar.</small>
+                    </div>
+                    <div class="col-md-6">
+                        <label asp-for="ClienteId" class="form-label">Cliente (opcional)</label>
+                        <select asp-for="ClienteId" class="form-select">
+                            <option value="">-- Sin cliente --</option>
+                            @foreach (var c in clientes)
+                            {
+                                <option value="@c.Id">@c.Apellido, @c.Nombre</option>
+                            }
+                        </select>
+                        <small class="form-text text-secondary">Requerido si el estado lo exige.</small>
+                    </div>
+                    <div class="col-12">
+                        <label asp-for="Observaciones" class="form-label">Observaciones</label>
+                        <textarea asp-for="Observaciones" class="form-control" rows="3" placeholder="Motivo del cambio de estado"></textarea>
+                    </div>
+                </div>
+            </div>
+            <div class="card-footer d-flex gap-2">
+                <button type="submit" class="btn btn-primary">
+                    <i class="bi bi-save me-1"></i> Guardar cambio
+                </button>
+                <a asp-action="Details" asp-route-id="@garrafa?.Id" class="btn btn-outline-secondary">Cancelar</a>
+            </div>
+        </form>
+    }
 </div>


### PR DESCRIPTION
## Resumen

Implementa la **máquina de estados del módulo Garrafas** validando las transiciones manuales contra una matriz explícita en código. Cierra #40.

Antes, `GarrafaService.CambiarEstadoAsync` aceptaba cualquier transición (incluido el ejemplo del issue: `FUERA_SERVICIO → LLENA_DEPOSITO`). Ahora cada cambio se valida contra `GarrafaTransiciones` y se rechaza con un mensaje claro si no está permitida.

## Cambios principales

| Área | Antes | Después |
|---|---|---|
| **Matriz de transiciones** | inexistente | hard-coded en `Services/GarrafaTransiciones.cs` con helpers `EsValida` y `DestinosPermitidos` |
| **`CambiarEstadoAsync`** | acepta cualquier `NuevoEstadoId` | valida origen→destino, rechaza auto-transiciones, exige `ClienteId` cuando el destino `requiere_cliente=TRUE` |
| **Dropdown del formulario** | muestra los 6 estados siempre | muestra sólo los destinos válidos para el estado actual; si es terminal, renderiza un `alert` en lugar del form |
| **API para la UI** | n/a | `IGarrafaService.GetTransicionesDisponiblesAsync(garrafaId)` |
| **Documentación** | n/a | `db/docs/DECISIONES.md` ADR #16 con la matriz vigente y la justificación |

## Decisión de diseño (matriz en C#, no en tabla BD)

ADR #16 argumenta por qué las transiciones viven en código y no en una lookup table `transiciones_estado_garrafa`:
- Son un **contrato invariante del dominio** (una garrafa dañada no se entrega), no un catálogo administrativo.
- Encapsuladas en C# son revisables vía PR, validadas por el compilador, y trivialmente testeables sin fixtures de BD.
- El catálogo de **estados** (`estados_garrafa`) sigue siendo tabla (consistente con ADR #4). Sólo las **transiciones** son código.

## Matriz vigente

```
              | LLENA | VACIA | TRANS | EN_CL | DANADA | F.SERV |
LLENA_DEPOSITO|   —   |   ✓   |   ✓   |   ✓   |   ✓    |   —    |
VACIA_DEPOSITO|   ✓   |   —   |   —   |   ✓   |   ✓    |   ✓    |
EN_TRANSITO   |   ✓   |   ✓   |   —   |   ✓   |   ✓    |   —    |
EN_CLIENTE    |   ✓   |   ✓   |   —   |   —   |   ✓    |   ✓    |
DAÑADA        |   —   |   ✓   |   —   |   —   |   —    |   ✓    |
FUERA_SERVICIO|   —   |   —   |   —   |   —   |   —    |   —    |  ← terminal
```

## Archivos tocados

- **Nuevos:** `Constants/GarrafaEstados.cs`, `Services/GarrafaTransiciones.cs`
- **Modificados:** `Services/Interfaces/IGarrafaService.cs`, `Services/Implementations/GarrafaService.cs`, `Controllers/GarrafasController.cs`, `Views/Garrafas/CambiarEstado.cshtml`, `db/docs/DECISIONES.md`

## Criterios de aceptación del issue #40

- [x] Definir matriz de transiciones válidas → `GarrafaTransiciones.Matriz`
- [x] Validar en `CambiarEstadoAsync` que la transición sea válida → lanza `InvalidOperationException`
- [x] Si la transición no es válida, lanzar excepción con mensaje claro → `"Transición inválida: ORIGEN → DESTINO. Consulte la matriz…"`
- [x] Documentar las transiciones válidas → ADR #16 en `DECISIONES.md` con tabla completa

## Notas para review

- La validación es **defensa en profundidad**: aunque la UI filtra el dropdown, `CambiarEstadoAsync` sigue rechazando transiciones inválidas si alguien construye un POST hand-crafted.
- No agrega migración SQL. La matriz está en código — versionada con el servicio, revisada en el mismo PR.
- `GarrafaTransiciones` es `static` y sin estado; no requiere DI ni registro en `Program.cs`.
- El comportamiento del trigger `trg_mov_garrafa_ai` no se toca: el estado del `garrafa` sigue siendo actualizado por el trigger desde el movimiento, no por la app.

## Verificación

- `dotnet build` sin errores (sólo warnings preexistentes del paquete `AutoMapper 12.0.1`).

Resolve #40