### PR TITLE
fix(garrafas): bloquear edición de garrafas en estado FUERA_SERVICIO (#41)

### DIFF
--- a/src/ExtraGasMVC/Controllers/GarrafasController.cs
+++ b/src/ExtraGasMVC/Controllers/GarrafasController.cs
@@ -1,3 +1,4 @@
+using ExtraGasMVC.Constants;
 using ExtraGasMVC.DTOs;
 using ExtraGasMVC.Models.ViewModels;
 using ExtraGasMVC.Services.Interfaces;
@@ -16,6 +17,28 @@ public class GarrafasController : Controller
     {
         _garrafaService = garrafaService;
         _clienteService = clienteService;
+    }
+
+    /// <summary>
+    /// Devuelve el código del estado actual de la garrafa leyendo directamente
+    /// de la base de datos. Se usa en Edit (GET y POST) para validar contra la
+    /// máquina de estados sin depender del valor que el cliente envío en el form.
+    /// </summary>
+    private async Task<string?> GetEstadoCodigoActualAsync(ulong id, CancellationToken ct)
+    {
+        var garrafa = await _garrafaService.GetByIdAsync(id, ct);
+        return garrafa?.EstadoCodigo;
+    }
+
+    /// <summary>
+    /// Construye el redirect estándar a Details con un mensaje de error en
+    /// TempData para los casos en los que se intenta editar una garrafa en
+    /// un estado que lo prohíbe (ver issue #41).
+    /// </summary>
+    private IActionResult RedirectBloqueadoPorEstado(ulong id)
+    {
+        TempData["Error"] = "No se puede editar una garrafa dada de baja.";
+        return RedirectToAction(nameof(Details), new { id });
     }
 
     public async Task<IActionResult> Index(string? codigo, byte? capacidad, CancellationToken ct = default)
@@ -67,8 +90,15 @@ public class GarrafasController : Controller
     {
         var garrafa = await _garrafaService.GetByIdAsync(id, ct);
         if (garrafa is null) return NotFound();
+
+        // Issue #41: una garrafa en FUERA_SERVICIO es inmutable. Si alguien
+        // llega por URL directa, lo mandamos a Details con el mismo mensaje
+        // de error que vería si la UI tuviera el botón oculto.
+        if (garrafa.EstadoCodigo == GarrafaEstados.FueraServicio)
+            return RedirectBloqueadoPorEstado(id);
+
         ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
-        
+
         var updateDto = new UpdateGarrafaDto
         {
             Id = garrafa.Id,
@@ -82,7 +112,7 @@ public class GarrafasController : Controller
             Activo = garrafa.Activo,
             Observaciones = garrafa.Observaciones
         };
-        
+
         return View(updateDto);
     }
 
@@ -91,6 +121,15 @@ public class GarrafasController : Controller
     public async Task<IActionResult> Edit(ulong id, UpdateGarrafaDto garrafa, CancellationToken ct = default)
     {
         if (id != garrafa.Id) return BadRequest();
+
+        // Issue #41: validar contra el estado actual en BD (no contra el
+        // valor que envía el form) para que un POST hand-crafted con un
+        // EstadoGarrafaId != FUERA_SERVICIO no sirva para esquivar la regla.
+        var estadoCodigo = await GetEstadoCodigoActualAsync(id, ct);
+        if (estadoCodigo == null) return NotFound();
+        if (estadoCodigo == GarrafaEstados.FueraServicio)
+            return RedirectBloqueadoPorEstado(id);
+
         if (!ModelState.IsValid)
         {
             ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);

--- a/src/ExtraGasMVC/DTOs/GarrafaDto.cs
+++ b/src/ExtraGasMVC/DTOs/GarrafaDto.cs
@@ -13,6 +13,13 @@ public class GarrafaDto
     public bool Activo { get; set; }
     public DateTime? FechaUltimoMovimiento { get; set; }
     public string? Observaciones { get; set; }
+
+    /// <summary>
+    /// Código canónico del estado actual (ej. <c>FUERA_SERVICIO</c>). Se usa
+    /// en la UI para condicionar acciones (editar, cambiar estado) según la
+    /// máquina de estados del módulo Garrafas.
+    /// </summary>
+    public string? EstadoCodigo { get; set; }
 }
 
 public class CreateGarrafaDto

--- a/src/ExtraGasMVC/Data/Entities/Garrafa.cs
+++ b/src/ExtraGasMVC/Data/Entities/Garrafa.cs
@@ -18,4 +18,6 @@ public class Garrafa
     public ulong? CreatedBy { get; set; }
     public ulong? UpdatedBy { get; set; }
     public DateTime? DeletedAt { get; set; }
+
+    public virtual EstadoGarrafa? EstadoGarrafa { get; set; }
 }

--- a/src/ExtraGasMVC/Mappings/MappingProfile.cs
+++ b/src/ExtraGasMVC/Mappings/MappingProfile.cs
@@ -76,7 +76,10 @@ public class MappingProfile : Profile
         CreateMap<UpdatePagoDto, Pago>();
 
         // Garrafa mappings
-        CreateMap<Garrafa, GarrafaDto>().ReverseMap();
+        CreateMap<Garrafa, GarrafaDto>()
+            .ForMember(d => d.EstadoCodigo, o => o.MapFrom(s =>
+                s.EstadoGarrafa != null ? s.EstadoGarrafa.Codigo : null))
+            .ReverseMap();
         CreateMap<CreateGarrafaDto, Garrafa>();
         CreateMap<UpdateGarrafaDto, Garrafa>();
 

--- a/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
@@ -24,8 +24,9 @@ public class GarrafaService : IGarrafaService
     {
         var garrafa = await _context.Garrafas
             .AsNoTracking()
+            .Include(g => g.EstadoGarrafa)
             .FirstOrDefaultAsync(g => g.Id == id, ct);
-        
+
         return garrafa is null ? null : _mapper.Map<GarrafaDto>(garrafa);
     }
 
@@ -33,8 +34,9 @@ public class GarrafaService : IGarrafaService
     {
         var garrafa = await _context.Garrafas
             .AsNoTracking()
+            .Include(g => g.EstadoGarrafa)
             .FirstOrDefaultAsync(g => g.Codigo == codigo, ct);
-        
+
         return garrafa is null ? null : _mapper.Map<GarrafaDto>(garrafa);
     }
 
@@ -42,9 +44,10 @@ public class GarrafaService : IGarrafaService
     {
         var garrafas = await _context.Garrafas
             .AsNoTracking()
+            .Include(g => g.EstadoGarrafa)
             .OrderBy(g => g.Codigo)
             .ToListAsync(ct);
-        
+
         return _mapper.Map<IEnumerable<GarrafaDto>>(garrafas);
     }
 
@@ -52,10 +55,11 @@ public class GarrafaService : IGarrafaService
     {
         var garrafas = await _context.Garrafas
             .AsNoTracking()
+            .Include(g => g.EstadoGarrafa)
             .Where(g => g.ClienteId == clienteId)
             .OrderBy(g => g.Codigo)
             .ToListAsync(ct);
-        
+
         return _mapper.Map<IEnumerable<GarrafaDto>>(garrafas);
     }
 
@@ -63,6 +67,7 @@ public class GarrafaService : IGarrafaService
     {
         var garrafas = await _context.Garrafas
             .AsNoTracking()
+            .Include(g => g.EstadoGarrafa)
             .Where(g => g.EstadoGarrafaId == estadoId)
             .OrderBy(g => g.Codigo)
             .ToListAsync(ct);

--- a/src/ExtraGasMVC/Views/Garrafas/Details.cshtml
+++ b/src/ExtraGasMVC/Views/Garrafas/Details.cshtml
@@ -10,7 +10,13 @@
 @section PageHeader {
     <div class="mb-3 d-flex gap-2">
         <a asp-action="Index" class="btn btn-outline-secondary"><i class="bi bi-arrow-left me-1"></i> Volver</a>
-        <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-primary"><i class="bi bi-pencil me-1"></i> Editar</a>
+        @* Issue #41: una garrafa en estado final (FUERA_SERVICIO) es inmutable.
+            El botón Editar se oculta en la UI; el controller también rechaza
+            GET/POST a Edit por defensa en profundidad. *@
+        @if (Model.EstadoCodigo != "FUERA_SERVICIO")
+        {
+            <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-primary"><i class="bi bi-pencil me-1"></i> Editar</a>
+        }
         <a asp-action="CambiarEstado" asp-route-id="@Model.Id" class="btn btn-warning"><i class="bi bi-arrow-repeat me-1"></i> Cambiar estado</a>
     </div>
 }


### PR DESCRIPTION
## Issue

Closes #41

## Resumen

Una garrafa en estado `FUERA_SERVICIO` debe ser inmutable, pero el form de edición seguía aceptando cambios. Se bloquea la edición en tres capas:

1. **UI**: `Details.cshtml` oculta el botón "Editar" cuando `EstadoCodigo == "FUERA_SERVICIO"`.
2. **Controller (GET)**: `Edit` GET redirige a Details con `TempData["Error"]` si la garrafa está en estado final.
3. **Controller (POST)**: `Edit` POST valida contra el estado actual en BD (no contra el valor del form) y rechaza igual si está en estado final.

## Cambios

| Archivo | Qué |
|---|---|
| `DTOs/GarrafaDto.cs` | Agrega `EstadoCodigo` para que la UI pueda condicionar. |
| `Mappings/MappingProfile.cs` | Mapea `EstadoGarrafa.Codigo → GarrafaDto.EstadoCodigo`. |
| `Data/Entities/Garrafa.cs` | Agrega navigation property `EstadoGarrafa` (mismo patrón que `Pedido`/`Producto`). |
| `Services/Implementations/GarrafaService.cs` | `Include(g => g.EstadoGarrafa)` en los `Get*Async` para que el DTO se popule. |
| `Controllers/GarrafasController.cs` | Helpers privados `GetEstadoCodigoActualAsync` / `RedirectBloqueadoPorEstado`; bloqueo en `Edit` GET y POST. |
| `Views/Garrafas/Details.cshtml` | Botón "Editar" condicionado a `EstadoCodigo != "FUERA_SERVICIO"`. |

## Decisiones

- **Validar contra la BD, no contra el form**: un POST hand-crafted con `EstadoGarrafaId = LLENA_DEPOSITO` no debe servir para esquivar la regla. El lookup se hace al inicio del POST.
- **Redirect + TempData en lugar de `BadRequest`**: la vista MVC necesita una respuesta navegable para mostrar el mensaje en el layout (status message).
- **El botón "Cambiar estado" se queda visible**: la matriz de transiciones del #40 ya hace que el dropdown quede vacío en `FUERA_SERVICIO`. Ocultar también ese botón sería scope creep.
- **Estado final == `FUERA_SERVICIO`**: hoy es el único estado terminal de la matriz; si en el futuro se agrega otro, se cambia el único `if` en el controller.

## Criterios de aceptación (issue #41)

- [x] Validar en `Edit` POST que la garrafa no esté en estado `FUERA_SERVICIO`
- [x] Si está en estado final, redirect con mensaje de error
- [x] En la vista Details, ocultar botón "Editar" si la garrafa está en estado final
- [x] Mensaje claro: "No se puede editar una garrafa dada de baja"

## Verificación

- `dotnet build` → Build succeeded (0 errors, 2 warnings preexistentes de AutoMapper).