### PR TITLE
feat(garrafas): auditoría CreatedBy/UpdatedBy en Create/Update (#43)

### DIFF
--- a/src/ExtraGasMVC/Controllers/GarrafasController.cs
+++ b/src/ExtraGasMVC/Controllers/GarrafasController.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace ExtraGasMVC.Controllers;
 
 [Authorize(Policy = "OperadorOrAdmin")]
-public class GarrafasController : Controller
+public class GarrafasController : BaseController
 {
     private readonly IGarrafaService _garrafaService;
     private readonly IClienteService _clienteService;
@@ -80,7 +80,7 @@ public class GarrafasController : Controller
         if (!ModelState.IsValid) return View(garrafa);
         try
         {
-            await _garrafaService.CreateAsync(garrafa, ct);
+            await _garrafaService.CreateAsync(garrafa, GetCurrentUserId(), ct);
             TempData["Success"] = $"Garrafa {garrafa.Codigo} creada.";
             return RedirectToAction(nameof(Index));
         }
@@ -147,7 +147,7 @@ public class GarrafasController : Controller
         }
         try
         {
-            await _garrafaService.UpdateAsync(garrafa, ct);
+            await _garrafaService.UpdateAsync(garrafa, GetCurrentUserId(), ct);
             TempData["Success"] = $"Garrafa {garrafa.Codigo} actualizada.";
             return RedirectToAction(nameof(Index));
         }

--- a/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
@@ -85,7 +85,7 @@ public class GarrafaService : IGarrafaService
         return _mapper.Map<IEnumerable<EstadoGarrafaDto>>(estados);
     }
 
-    public async Task<GarrafaDto> CreateAsync(CreateGarrafaDto garrafaDto, CancellationToken ct = default)
+    public async Task<GarrafaDto> CreateAsync(CreateGarrafaDto garrafaDto, ulong? usuarioId, CancellationToken ct = default)
     {
         if (await _context.Garrafas.AnyAsync(g => g.Codigo == garrafaDto.Codigo, ct))
             throw new InvalidOperationException($"Ya existe una garrafa con el código {garrafaDto.Codigo}.");
@@ -93,6 +93,8 @@ public class GarrafaService : IGarrafaService
         var garrafa = _mapper.Map<Garrafa>(garrafaDto);
         garrafa.CreatedAt = DateTime.UtcNow;
         garrafa.UpdatedAt = DateTime.UtcNow;
+        garrafa.CreatedBy = usuarioId;
+        garrafa.UpdatedBy = usuarioId;
 
         _context.Garrafas.Add(garrafa);
         await SaveOrThrowDuplicateAsync(garrafaDto.Codigo, ct);
@@ -100,7 +102,7 @@ public class GarrafaService : IGarrafaService
         return _mapper.Map<GarrafaDto>(garrafa);
     }
 
-    public async Task<GarrafaDto> UpdateAsync(UpdateGarrafaDto garrafaDto, CancellationToken ct = default)
+    public async Task<GarrafaDto> UpdateAsync(UpdateGarrafaDto garrafaDto, ulong? usuarioId, CancellationToken ct = default)
     {
         var garrafa = await _context.Garrafas.FindAsync(new object[] { garrafaDto.Id }, ct);
         if (garrafa == null)
@@ -111,6 +113,7 @@ public class GarrafaService : IGarrafaService
 
         _mapper.Map(garrafaDto, garrafa);
         garrafa.UpdatedAt = DateTime.UtcNow;
+        garrafa.UpdatedBy = usuarioId;
 
         await SaveOrThrowDuplicateAsync(garrafaDto.Codigo, ct);
 

--- a/src/ExtraGasMVC/Services/Interfaces/IGarrafaService.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IGarrafaService.cs
@@ -10,8 +10,8 @@ public interface IGarrafaService
     Task<IEnumerable<GarrafaDto>> GetByClienteAsync(ulong clienteId, CancellationToken ct = default);
     Task<IEnumerable<GarrafaDto>> GetByEstadoAsync(ulong estadoId, CancellationToken ct = default);
     Task<IEnumerable<EstadoGarrafaDto>> GetEstadosAsync(CancellationToken ct = default);
-    Task<GarrafaDto> CreateAsync(CreateGarrafaDto garrafa, CancellationToken ct = default);
-    Task<GarrafaDto> UpdateAsync(UpdateGarrafaDto garrafa, CancellationToken ct = default);
+    Task<GarrafaDto> CreateAsync(CreateGarrafaDto garrafa, ulong? usuarioId, CancellationToken ct = default);
+    Task<GarrafaDto> UpdateAsync(UpdateGarrafaDto garrafa, ulong? usuarioId, CancellationToken ct = default);
     Task<bool> CambiarEstadoAsync(ulong id, CambiarEstadoGarrafaDto dto, CancellationToken ct = default);
     Task<bool> DeleteAsync(ulong id, CancellationToken ct = default);
 


### PR DESCRIPTION
## Issue

Closes #43

## Resumen

Hacer que `GarrafasController` herede de `BaseController` y propague `GetCurrentUserId()` a `GarrafaService.CreateAsync` y `UpdateAsync`, para registrar quién crea o modifica una garrafa. Mismo patrón ya implementado en `ProductoService` / `ProductosController`.

## Cambios

| Archivo | Qué |
|---|---|
| `Services/Interfaces/IGarrafaService.cs` | `CreateAsync` y `UpdateAsync` aceptan `ulong? usuarioId` |
| `Services/Implementations/GarrafaService.cs` | Asigna `CreatedBy`/`UpdatedBy` en `CreateAsync` (ambos = `usuarioId`); asigna `UpdatedBy` en `UpdateAsync` |
| `Controllers/GarrafasController.cs` | Hereda de `BaseController` en lugar de `Controller`; pasa `GetCurrentUserId()` a los 2 métodos |

3 archivos cambiados, 10 inserciones, 7 borradas.

## Notas

- **Naming `ulong? usuarioId`** (no `userId` literal de la issue, ni `createdBy`/`updatedBy` separados): tomado del patrón vigente en `ProductoService`/`PedidoService` que ya usan este nombre. `GetCurrentUserId()` devuelve `ulong?`, así que `null` se propaga y queda registrado como `NULL` en BD — aceptable porque las columnas son nullable (lo son desde el seed).
- **Scope acotado a Create/Update.** La issue sólo pide esos dos métodos. `CambiarEstado` y `Delete` siguen seteando `UpdatedAt` sin `UpdatedBy` — fuera de scope, queda como follow-up si el equipo lo pide.
- **No se tocaron DTOs** (`CreateGarrafaDto`/`UpdateGarrafaDto`): el `userId` viaja como parámetro separado y NO aparece en formularios. Los DTOs no exponen `CreatedBy`/`UpdatedBy` (consistente con el patrón existente).
- **No se tocaron entities ni migraciones**: `Garrafa.CreatedBy`/`UpdatedBy` ya existían (líneas 18-19 de `Garrafa.cs`).

## Criterios de aceptación (issue #43)

- [x] `GarrafasController` hereda de `BaseController`
- [x] `CreateAsync` acepta parámetro `ulong? usuarioId` y lo setea en `CreatedBy`
- [x] `UpdateAsync` acepta parámetro `ulong? usuarioId` y lo setea en `UpdatedBy`
- [x] El controller pasa `GetCurrentUserId()` a los métodos del servicio

## Verificación

`dotnet build` → **Build succeeded**, 0 errores. Los 2 warnings NU1903 (paquete `AutoMapper 12.0.1` con vulnerabilidad conocida) son preexistentes y no son introducidos por este PR.