### PR TITLE
feat(garrafas): auditar CambiarEstadoAsync con EmpleadoId y CreatedBy (#43)

### DIFF
--- a/src/ExtraGasMVC/Controllers/GarrafasController.cs
+++ b/src/ExtraGasMVC/Controllers/GarrafasController.cs
@@ -233,7 +233,8 @@ public class GarrafasController : BaseController
 
         try
         {
-            var ok = await _garrafaService.CambiarEstadoAsync(id, dto, ct);
+            var currentUserId = GetCurrentUserId();
+            var ok = await _garrafaService.CambiarEstadoAsync(id, dto, currentUserId, ct);
             if (!ok) return NotFound();
             TempData["Success"] = $"Estado de la garrafa {garrafa.Codigo} actualizado correctamente.";
             return RedirectToAction(nameof(Details), new { id });

--- a/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
@@ -120,7 +120,7 @@ public class GarrafaService : IGarrafaService
         return _mapper.Map<GarrafaDto>(garrafa);
     }
 
-    public async Task<bool> CambiarEstadoAsync(ulong id, CambiarEstadoGarrafaDto dto, CancellationToken ct = default)
+    public async Task<bool> CambiarEstadoAsync(ulong id, CambiarEstadoGarrafaDto dto, ulong? currentUserId = null, CancellationToken ct = default)
     {
         var garrafa = await _context.Garrafas.FindAsync(new object[] { id }, ct);
         if (garrafa == null)
@@ -174,6 +174,20 @@ public class GarrafaService : IGarrafaService
 
         var estadoOrigen = garrafa.EstadoGarrafaId;
 
+        // Resolver el empleado asociado al usuario autenticado (issue #43 -
+        // auditoría completa de CambiarEstadoAsync). Si el usuario no tiene
+        // empleado activo vinculado, el movimiento queda con EmpleadoId null
+        // pero igual registra CreatedBy.
+        ulong? empleadoId = null;
+        if (currentUserId.HasValue)
+        {
+            empleadoId = await _context.Empleados
+                .AsNoTracking()
+                .Where(e => e.UsuarioId == currentUserId.Value && e.Activo)
+                .Select(e => (ulong?)e.Id)
+                .FirstOrDefaultAsync(ct);
+        }
+
         await using var transaction = await _context.Database.BeginTransactionAsync(ct);
 
         try
@@ -193,6 +207,8 @@ public class GarrafaService : IGarrafaService
                 ClienteId = dto.ClienteId,
                 EstadoOrigenId = estadoOrigen,
                 EstadoDestinoId = dto.NuevoEstadoId,
+                EmpleadoId = empleadoId,
+                CreatedBy = currentUserId,
                 Observaciones = dto.Observaciones
             };
 

--- a/src/ExtraGasMVC/Services/Interfaces/IGarrafaService.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IGarrafaService.cs
@@ -12,7 +12,7 @@ public interface IGarrafaService
     Task<IEnumerable<EstadoGarrafaDto>> GetEstadosAsync(CancellationToken ct = default);
     Task<GarrafaDto> CreateAsync(CreateGarrafaDto garrafa, ulong? usuarioId, CancellationToken ct = default);
     Task<GarrafaDto> UpdateAsync(UpdateGarrafaDto garrafa, ulong? usuarioId, CancellationToken ct = default);
-    Task<bool> CambiarEstadoAsync(ulong id, CambiarEstadoGarrafaDto dto, CancellationToken ct = default);
+    Task<bool> CambiarEstadoAsync(ulong id, CambiarEstadoGarrafaDto dto, ulong? currentUserId = null, CancellationToken ct = default);
     Task<bool> DeleteAsync(ulong id, CancellationToken ct = default);
 
     /// <summary>


### PR DESCRIPTION
## Resumen

Cierra la parte pendiente de #43. El PR #70 (`1f14072`) mergeó la auditoría de `CreateAsync`/`UpdateAsync` de garrafas pero omitió `CambiarEstadoAsync`: el cambio manual de estado desde la UI no estaba registrando `EmpleadoId` ni `CreatedBy` en `movimientos_garrafa`.

Este PR completa el trabajo del stash `!!GitHub_Desktop<feature/garrafas-fase-1-correcciones-criticas>` que estaba pendiente desde la rama original.

## Cambios

- `IGarrafaService.CambiarEstadoAsync`: acepta `ulong? currentUserId = null`
- `GarrafaService.CambiarEstadoAsync`: resuelve `empleadoId` desde `Empleados` filtrando por `UsuarioId == currentUserId` y `Activo`; setea `EmpleadoId` y `CreatedBy` en el `MovimientoGarrafa`
- `GarrafasController.CambiarEstado`: propaga `GetCurrentUserId()` (ya heredaba de `BaseController` por PR #70)

## Patrón

Idéntico al de PR #70 (`CreateAsync`/`UpdateAsync`) y a `RegistrarMovimientoPorCanjeAsync` del PR #71. Si el usuario autenticado no tiene empleado activo vinculado, `EmpleadoId` queda `null` pero `CreatedBy` se persiste igual.

## Diff

```
 src/ExtraGasMVC/Controllers/GarrafasController.cs      |  3 ++-
 src/ExtraGasMVC/Services/Implementations/GarrafaService.cs | 18 +++++++++++++++++-
 src/ExtraGasMVC/Services/Interfaces/IGarrafaService.cs |  2 +-
 3 files changed, 20 insertions(+), 3 deletions(-)
```

## Cómo verificar

1. `dotnet build src/ExtraGasMVC` → debe pasar (ya verificado localmente).
2. Smoke query después de un cambio manual de estado:
   ```sql
   SELECT m.id, m.garrafa_id, m.estado_destino_id, m.empleado_id, m.created_by, m.created_at
   FROM movimientos_garrafa m
   WHERE m.tipo_movimiento_id = (SELECT id FROM tipos_movimiento_garrafa WHERE codigo = 'CAMBIO_ESTADO')
   ORDER BY m.id DESC
   LIMIT 5;
   ```
   `empleado_id` y `created_by` deben estar poblados para los movimientos nuevos.

Closes #43