### PR TITLE
feat(recepciones): UI para captura de códigos GARRAFA en recepciones

### DIFF
--- a/src/ExtraGasMVC/Views/Recepciones/Create.cshtml
+++ b/src/ExtraGasMVC/Views/Recepciones/Create.cshtml
@@ -1,4 +1,6 @@
 @model ExtraGasMVC.Models.ViewModels.CrearRecepcionViewModel
+@using ExtraGasMVC.DTOs
+@using ExtraGasMVC.Extensions
 @{
     ViewData["Title"] = "Nueva recepcion";
     ViewData["Breadcrumbs"] = new List<BreadcrumbItem>
@@ -6,53 +8,199 @@
         new() { Label = "Recepciones", Controller = "Recepciones", Action = "Index" },
         new() { Label = "Nueva" }
     };
+
+    // JSON de productos activos para que el JS alimente el dropdown por fila
+    // y detecte `maneja_garrafa_individual` sin endpoint adicional.
+    var productosJson = Json.Serialize(Model.Productos.Select(p => new
+    {
+        id = p.Id,
+        nombre = p.Nombre,
+        codigo = p.Codigo,
+        capacidadKg = p.CapacidadKg,
+        precioActual = p.PrecioActual,
+        manejaGarrafaIndividual = p.ManejaGarrafaIndividual,
+    }));
+
+    // Snapshot de items para que el JS pueda repoblar la tabla si la view se
+    // re-renderiza con un error de validación del server (escenario raro,
+    // porque el JS bloquea submit inválidos).
+    var itemsPreview = Model.Recepcion?.Items ?? new List<CrearRecepcionItemDto>();
+    var itemsPreviewJson = Json.Serialize(itemsPreview.Select(it => new
+    {
+        productoId = it.ProductoId,
+        cantidad = it.Cantidad,
+        precioUnitario = it.PrecioUnitario,
+        codigosGarrafa = it.CodigosGarrafa ?? new List<string>(),
+    }));
 }
 @section PageHeader {
-    <div class="mb-3">
-        <a asp-action="Index" class="btn btn-outline-secondary"><i class="bi bi-arrow-left me-1"></i> Volver</a>
+    <div class="mb-3 d-flex justify-content-between align-items-center">
+        <a asp-action="Index" class="btn btn-outline-secondary">
+            <i class="bi bi-arrow-left me-1"></i> Volver
+        </a>
+        <span class="text-muted small">Issue #45 · PR2 UI</span>
     </div>
 }
-@* Placeholder funcional para PR1 (issue #45). El diseño completo — tabla
-   dinámica de items, textarea GARRAFA por fila, modal SweetAlert2 — sale
-   en PR2 sobre develop. PR1 solo necesita el form bindable para que el
-   POST funcione y el catch del controller pueda re-renderizar con errores. *@
-<div class="card">
-    <div class="card-header"><h3 class="card-title">Registrar recepcion de proveedor</h3></div>
-    <form asp-action="Create" method="post">
-        @Html.AntiForgeryToken()
+
+<form id="recepcion-form" asp-action="Create" method="post">
+    @Html.AntiForgeryToken()
+    <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+
+    <!-- ===== Card 1: Encabezado ===== -->
+    <div class="card card-primary mb-3">
+        <div class="card-header">
+            <h3 class="card-title">Encabezado de la recepcion</h3>
+        </div>
         <div class="card-body">
-            <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
             <div class="row g-3">
                 <div class="col-md-3">
-                    <label asp-for="Recepcion.Fecha" class="form-label"></label>
-                    <input asp-for="Recepcion.Fecha" type="datetime-local" class="form-control" required />
+                    <label for="Recepcion_Fecha" class="form-label">Fecha <span class="text-danger">*</span></label>
+                    <input id="Recepcion_Fecha"
+                           name="Fecha"
+                           type="datetime-local"
+                           class="form-control"
+                           value="@(Model.Recepcion.Fecha.ToString("yyyy-MM-ddTHH:mm"))"
+                           required />
                 </div>
-                <div class="col-md-3">
-                    <label asp-for="Recepcion.ProveedorId" class="form-label"></label>
-                    <select asp-for="Recepcion.ProveedorId" class="form-select" required>
-                        <option value="">— seleccione —</option>
-                        @foreach (var p in Model.Proveedores) { <option value="@p.Id">@p.RazonSocial</option> }
+                <div class="col-md-5">
+                    <label for="Recepcion_ProveedorId" class="form-label">Proveedor <span class="text-danger">*</span></label>
+                    <select id="Recepcion_ProveedorId" name="ProveedorId" class="form-select" required>
+                        <option value="">-- Seleccione proveedor --</option>
+                        @foreach (var p in Model.Proveedores)
+                        {
+                            <option value="@p.Id" selected="@(Model.Recepcion.ProveedorId == p.Id)">
+                                @p.RazonSocial @(string.IsNullOrEmpty(p.Cuit) ? "" : $"({p.Cuit})")
+                            </option>
+                        }
                     </select>
                 </div>
-                <div class="col-md-3">
-                    <label asp-for="Recepcion.NumeroFacturaProveedor" class="form-label"></label>
-                    <input asp-for="Recepcion.NumeroFacturaProveedor" class="form-control" />
+                <div class="col-md-4">
+                    <label for="Recepcion_NumeroFacturaProveedor" class="form-label">Numero de factura del proveedor</label>
+                    <input id="Recepcion_NumeroFacturaProveedor"
+                           name="NumeroFacturaProveedor"
+                           type="text"
+                           maxlength="50"
+                           class="form-control"
+                           value="@(Model.Recepcion.NumeroFacturaProveedor ?? "")" />
                 </div>
-                <div class="col-md-3">
-                    <label asp-for="Recepcion.Total" class="form-label"></label>
-                    <input asp-for="Recepcion.Total" type="number" step="0.01" class="form-control" required />
+                <div class="col-md-4">
+                    <label for="Recepcion_Subtotal" class="form-label">Subtotal <span class="text-danger">*</span></label>
+                    <div class="input-group">
+                        <span class="input-group-text"><i class="bi bi-currency-dollar"></i></span>
+                        <input id="Recepcion_Subtotal"
+                               name="Subtotal"
+                               type="number" min="0" step="0.01"
+                               class="form-control"
+                               value="@Model.Recepcion.Subtotal.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture)"
+                               required />
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <label for="Recepcion_Descuento" class="form-label">Descuento <span class="text-danger">*</span></label>
+                    <div class="input-group">
+                        <span class="input-group-text"><i class="bi bi-percent"></i></span>
+                        <input id="Recepcion_Descuento"
+                               name="Descuento"
+                               type="number" min="0" step="0.01"
+                               class="form-control"
+                               value="@Model.Recepcion.Descuento.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture)"
+                               required />
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <label for="Recepcion_Total" class="form-label">Total <span class="text-danger">*</span></label>
+                    <div class="input-group">
+                        <span class="input-group-text"><i class="bi bi-currency-dollar"></i></span>
+                        <input id="Recepcion_Total"
+                               name="Total"
+                               type="number" min="0" step="0.01"
+                               class="form-control"
+                               value="@Model.Recepcion.Total.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture)"
+                               required />
+                    </div>
                 </div>
                 <div class="col-12">
-                    <label asp-for="Recepcion.Observaciones" class="form-label"></label>
-                    <textarea asp-for="Recepcion.Observaciones" class="form-control" rows="2"></textarea>
+                    <label for="Recepcion_Observaciones" class="form-label">Observaciones</label>
+                    <textarea id="Recepcion_Observaciones"
+                              name="Observaciones"
+                              class="form-control"
+                              rows="2"
+                              maxlength="2000">@(Model.Recepcion.Observaciones ?? "")</textarea>
                 </div>
             </div>
         </div>
-        <div class="card-footer d-flex gap-2">
-            <button type="submit" class="btn btn-primary" disabled>
-                <i class="bi bi-save me-1"></i> Guardar (habilitado en PR2)
+    </div>
+
+    <!-- ===== Card 2: Items ===== -->
+    <div class="card card-primary mb-3">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <h3 class="card-title mb-0">Items de la recepcion</h3>
+            <button type="button" id="btn-agregar-item" class="btn btn-sm btn-primary">
+                <i class="bi bi-plus-circle me-1"></i> Agregar item
             </button>
-            <a asp-action="Index" class="btn btn-outline-secondary">Cancelar</a>
         </div>
-    </form>
-</div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-hover table-striped align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th style="width: 28%">Producto <span class="text-danger">*</span></th>
+                            <th style="width: 10%">Cantidad <span class="text-danger">*</span></th>
+                            <th style="width: 14%">Precio unit. <span class="text-danger">*</span></th>
+                            <th style="width: 12%" class="text-end">Subtotal</th>
+                            <th>Codigos GARRAFA</th>
+                            <th style="width: 56px"></th>
+                        </tr>
+                    </thead>
+                    <tbody id="items-tbody">
+                        <tr id="items-empty-row">
+                            <td colspan="6" class="text-center text-muted py-4">
+                                <i class="bi bi-inbox fs-3 d-block mb-2"></i>
+                                Sin items cargados. Haga clic en <strong>Agregar item</strong> para empezar.
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="card-footer d-flex justify-content-between align-items-center flex-wrap gap-2">
+            <span class="text-muted small">
+                <i class="bi bi-info-circle me-1"></i>
+                Los productos con <strong>tracking individual</strong> muestran un cuadro para codigos unicos por garrafa.
+                La cantidad debe coincidir con los codigos.
+            </span>
+            <div>
+                <span class="text-muted small me-2">Total garrafas a crear:</span>
+                <span class="badge text-bg-info fs-6 js-total-garrafas">0</span>
+            </div>
+        </div>
+    </div>
+
+    <!-- ===== Card 3: Acciones ===== -->
+    <div class="card mb-3">
+        <div class="card-body d-flex gap-2 flex-wrap">
+            <button type="submit" id="btn-confirmar" class="btn btn-primary" disabled>
+                <i class="bi bi-check2-circle me-1"></i> Confirmar recepcion
+            </button>
+            <a asp-action="Index" class="btn btn-outline-secondary">
+                <i class="bi bi-x-circle me-1"></i> Cancelar
+            </a>
+            <span class="ms-auto text-muted small align-self-center">
+                <i class="bi bi-shield-check me-1"></i> Operacion atomica: recepciones + items + garrafas + movimientos
+            </span>
+        </div>
+    </div>
+
+    <!-- El JS inyecta aca los inputs hidden de items y codigos al confirmar -->
+    <div id="js-hidden-mount"></div>
+
+    <!-- Datos para el JS -->
+    <script>
+        window.__RECEPCIONES_PRODUCTOS__ = @Html.Raw(productosJson);
+        window.__RECEPCIONES_ITEMS_PREVIEW__ = @Html.Raw(itemsPreviewJson);
+    </script>
+</form>
+
+@section Scripts {
+    <script src="~/js/recepciones.js" asp-append-version="true"></script>
+}

--- a/src/ExtraGasMVC/wwwroot/js/recepciones.js
+++ b/src/ExtraGasMVC/wwwroot/js/recepciones.js
@@ -1,0 +1,274 @@
+// Recepciones — items dinámicos con binding GARRAFA (issue #45, PR2 UI).
+// Reescribe los items del tbody como hidden inputs `Items[i].X` y
+// `Items[i].CodigosGarrafa[j]` para que el DefaultModelBinder mapee a
+// CrearRecepcionDto.
+
+(function () {
+    'use strict';
+
+    var form = document.getElementById('recepcion-form');
+    if (!form) return;
+
+    var tbody = document.getElementById('items-tbody');
+    var emptyRow = document.getElementById('items-empty-row');
+    var btnAdd = document.getElementById('btn-agregar-item');
+    var btnConfirm = document.getElementById('btn-confirmar');
+    var totalGarrafasBadge = document.querySelector('.js-total-garrafas');
+    var hiddenMount = document.getElementById('js-hidden-mount');
+
+    var productos = (Array.isArray(window.__RECEPCIONES_PRODUCTOS__)
+        ? window.__RECEPCIONES_PRODUCTOS__ : []).map(function (p) {
+        return {
+            id: String(p.id),
+            nombre: String(p.nombre || ''),
+            capacidadKg: p.capacidadKg != null ? Number(p.capacidadKg) : null,
+            precioActual: Number(p.precioActual) || 0,
+            manejaGarrafaIndividual: !!p.manejaGarrafaIndividual,
+        };
+    });
+    var productoById = Object.create(null);
+    productos.forEach(function (p) { productoById[p.id] = p; });
+
+    var dataPreCargada = Array.isArray(window.__RECEPCIONES_ITEMS_PREVIEW__)
+        ? window.__RECEPCIONES_ITEMS_PREVIEW__ : [];
+
+    function esc(s) {
+        return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) {
+            return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+        });
+    }
+    function money(n) { return '$' + (Number(n) || 0).toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }); }
+    function splitCodigos(t) { return (t || '').split(/[\r\n,;]+/).map(function (s) { return s.trim(); }).filter(Boolean); }
+
+    function opcionesProductos() {
+        var html = '<option value="">-- Seleccione producto --</option>';
+        productos.forEach(function (p) {
+            var cap = p.capacidadKg != null ? ' (' + p.capacidadKg + ' kg)' : '';
+            html += '<option value="' + esc(p.id) + '" data-precio="' + p.precioActual + '"'
+                + ' data-garrafa="' + (p.manejaGarrafaIndividual ? 1 : 0) + '">'
+                + esc(p.nombre) + esc(cap) + '</option>';
+        });
+        return html;
+    }
+
+    function filaHtml() {
+        return ''
+            + '<tr data-row>'
+            +   '<td><select class="form-select form-select-sm js-producto" required>' + opcionesProductos() + '</select></td>'
+            +   '<td><input type="number" min="0.01" step="0.01" class="form-control form-control-sm js-cantidad" required /></td>'
+            +   '<td><input type="number" min="0" step="0.01" class="form-control form-control-sm js-precio" required /></td>'
+            +   '<td class="text-end js-subtotal">$0,00</td>'
+            +   '<td class="js-codigos-cell d-none">'
+            +     '<textarea class="form-control form-control-sm js-codigos" rows="3" placeholder="Una línea por código: G001, G002, ..."></textarea>'
+            +     '<div class="form-text small js-codigos-help"></div>'
+            +   '</td>'
+            +   '<td class="text-end"><button type="button" class="btn btn-sm btn-outline-danger js-eliminar" title="Eliminar fila"><i class="bi bi-trash"></i></button></td>'
+            + '</tr>';
+    }
+
+    function wireFila(tr) {
+        var sel = tr.querySelector('.js-producto');
+        var cant = tr.querySelector('.js-cantidad');
+        var precio = tr.querySelector('.js-precio');
+        var sub = tr.querySelector('.js-subtotal');
+        var cell = tr.querySelector('.js-codigos-cell');
+        var area = tr.querySelector('.js-codigos');
+        var help = tr.querySelector('.js-codigos-help');
+
+        function subtotal() { sub.textContent = money(Number(cant.value) * Number(precio.value)); }
+
+        function onChangeProducto() {
+            var p = productoById[sel.value];
+            if (p) {
+                if (precio.value === '' || Number(precio.value) === 0) precio.value = p.precioActual.toFixed(2);
+                cell.classList.toggle('d-none', !p.manejaGarrafaIndividual);
+                area.required = p.manejaGarrafaIndividual;
+                if (!p.manejaGarrafaIndividual) { area.value = ''; help.textContent = ''; }
+            } else {
+                cell.classList.add('d-none');
+            }
+            subtotal();
+            actualizarTotal();
+        }
+
+        function validarDuplicados() {
+            var codes = splitCodigos(area.value);
+            var seen = {}, dupes = [];
+            codes.forEach(function (c) {
+                var k = c.toLowerCase();
+                if (seen[k]) dupes.push(c); else seen[k] = true;
+            });
+            help.textContent = dupes.length > 0 ? 'Duplicados: ' + Array.from(new Set(dupes.map(function (d) { return d.toLowerCase(); }))).join(', ') : '';
+            help.classList.toggle('text-danger', dupes.length > 0);
+        }
+
+        sel.addEventListener('change', onChangeProducto);
+        cant.addEventListener('input', function () { subtotal(); actualizarTotal(); });
+        precio.addEventListener('input', subtotal);
+        area.addEventListener('input', function () { validarDuplicados(); actualizarTotal(); });
+
+        tr.querySelector('.js-eliminar').addEventListener('click', function () {
+            tr.remove();
+            if (!tbody.querySelector('tr[data-row]') && emptyRow) emptyRow.style.display = '';
+            actualizarTotal();
+        });
+    }
+
+    function agregarFila(prefill) {
+        if (emptyRow) emptyRow.style.display = 'none';
+        var wrap = document.createElement('tbody');
+        wrap.innerHTML = filaHtml();
+        var tr = wrap.firstElementChild;
+        tbody.appendChild(tr);
+        wireFila(tr);
+
+        if (prefill) {
+            tr.querySelector('.js-producto').value = String(prefill.productoId || '');
+            tr.querySelector('.js-cantidad').value = prefill.cantidad != null ? Number(prefill.cantidad) : '';
+            tr.querySelector('.js-precio').value = prefill.precioUnitario != null ? Number(prefill.precioUnitario) : '';
+            tr.querySelector('.js-producto').dispatchEvent(new Event('change'));
+            if (Array.isArray(prefill.codigosGarrafa)) tr.querySelector('.js-codigos').value = prefill.codigosGarrafa.join('\n');
+            tr.querySelector('.js-cantidad').dispatchEvent(new Event('input'));
+        }
+        actualizarTotal();
+    }
+
+    function actualizarTotal() {
+        var total = 0, conProducto = 0;
+        tbody.querySelectorAll('tr[data-row]').forEach(function (tr) {
+            var p = productoById[tr.querySelector('.js-producto').value];
+            if (p) {
+                conProducto++;
+                if (p.manejaGarrafaIndividual) total += splitCodigos(tr.querySelector('.js-codigos').value).length;
+            }
+        });
+        if (totalGarrafasBadge) totalGarrafasBadge.textContent = String(total);
+        if (btnConfirm) btnConfirm.disabled = conProducto === 0;
+    }
+
+    function itemsFromForm() {
+        var items = [];
+        tbody.querySelectorAll('tr[data-row]').forEach(function (tr) {
+            var pid = tr.querySelector('.js-producto').value;
+            if (!pid) return;
+            var p = productoById[pid];
+            items.push({
+                productoId: pid,
+                productoNombre: p ? p.nombre : '',
+                manejaGarrafaIndividual: !!(p && p.manejaGarrafaIndividual),
+                cantidad: Number(tr.querySelector('.js-cantidad').value) || 0,
+                precioUnitario: Number(tr.querySelector('.js-precio').value) || 0,
+                codigosGarrafa: splitCodigos(tr.querySelector('.js-codigos').value),
+            });
+        });
+        return items;
+    }
+
+    function validarCliente(items) {
+        if (items.length === 0) return 'Debe agregar al menos un item antes de confirmar.';
+        for (var i = 0; i < items.length; i++) {
+            var it = items[i];
+            if (!(it.cantidad > 0)) return 'Item ' + (i + 1) + ': la cantidad debe ser mayor a 0.';
+            if (it.precioUnitario < 0) return 'Item ' + (i + 1) + ': el precio unitario no puede ser negativo.';
+            if (it.manejaGarrafaIndividual) {
+                if (Math.trunc(it.cantidad) !== it.cantidad)
+                    return 'Item ' + (i + 1) + ' (' + it.productoNombre + '): la cantidad debe ser entera para GARRAFA.';
+                var esp = Math.trunc(it.cantidad);
+                if (esp !== it.codigosGarrafa.length)
+                    return 'Item ' + (i + 1) + ' (' + it.productoNombre + '): esperaba ' + esp + ' código(s) y recibió ' + it.codigosGarrafa.length + '.';
+                var seen = {}, dupes = [];
+                it.codigosGarrafa.forEach(function (c) {
+                    var k = c.toLowerCase();
+                    if (seen[k]) dupes.push(c); else seen[k] = true;
+                });
+                if (dupes.length > 0)
+                    return 'Item ' + (i + 1) + ' (' + it.productoNombre + '): códigos duplicados: ' + Array.from(new Set(dupes)).join(', ') + '.';
+            }
+        }
+        return null;
+    }
+
+    function resumenHtml(items, totales) {
+        var totG = items.filter(function (i) { return i.manejaGarrafaIndividual; }).reduce(function (a, b) { return a + b.codigosGarrafa.length; }, 0);
+        var totNoG = items.filter(function (i) { return !i.manejaGarrafaIndividual; }).length;
+        var html = '<p class="text-start mb-3">Items: <strong>' + items.length + '</strong>';
+        if (totG > 0) html += ' · <strong>' + totG + '</strong> garrafa(s) nueva(s) en <em>Llena Depósito</em>';
+        if (totNoG > 0) html += ' · <strong>' + totNoG + '</strong> item(s) sin tracking';
+        html += '.</p>';
+        html += '<table class="table table-sm table-bordered mb-2 text-start"><thead><tr><th>#</th><th>Producto</th><th>Cant.</th><th>Precio</th><th>Subtotal</th><th>Códigos</th></tr></thead><tbody>';
+        items.forEach(function (it, idx) {
+            html += '<tr><td>' + (idx + 1) + '</td><td>' + esc(it.productoNombre) + '</td>'
+                + '<td>' + it.cantidad + '</td><td>' + money(it.precioUnitario) + '</td>'
+                + '<td>' + money(it.cantidad * it.precioUnitario) + '</td>'
+                + '<td>' + (it.manejaGarrafaIndividual ? it.codigosGarrafa.length + '<br><small class="text-muted">' + esc(it.codigosGarrafa.join(', ')) + '</small>' : '<span class="text-muted">—</span>') + '</td></tr>';
+        });
+        html += '</tbody></table>';
+        html += '<p class="text-start mb-0 small text-muted">Subtotal: <strong>' + money(totales.subtotal) + '</strong>'
+            + ' · Descuento: <strong>' + money(totales.descuento) + '</strong>'
+            + ' · Total: <strong>' + money(totales.total) + '</strong></p>';
+        return html;
+    }
+
+    function leerTotales() {
+        return {
+            subtotal: Number((document.getElementById('Recepcion_Subtotal') || {}).value) || 0,
+            descuento: Number((document.getElementById('Recepcion_Descuento') || {}).value) || 0,
+            total: Number((document.getElementById('Recepcion_Total') || {}).value) || 0,
+        };
+    }
+
+    function hidden(name, value) {
+        var i = document.createElement('input');
+        i.type = 'hidden'; i.name = name; i.value = value == null ? '' : String(value);
+        return i;
+    }
+
+    function serializar(items) {
+        hiddenMount.innerHTML = '';
+        items.forEach(function (it, i) {
+            hiddenMount.appendChild(hidden('Items[' + i + '].ProductoId', it.productoId));
+            hiddenMount.appendChild(hidden('Items[' + i + '].Cantidad', it.cantidad.toFixed(2)));
+            hiddenMount.appendChild(hidden('Items[' + i + '].PrecioUnitario', it.precioUnitario.toFixed(2)));
+            if (it.manejaGarrafaIndividual) {
+                it.codigosGarrafa.forEach(function (c, j) {
+                    hiddenMount.appendChild(hidden('Items[' + i + '].CodigosGarrafa[' + j + ']', c));
+                });
+            }
+        });
+    }
+
+    form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        var items = itemsFromForm();
+        var error = validarCliente(items);
+        if (error) {
+            if (typeof Swal !== 'undefined') Swal.fire({ icon: 'warning', title: 'Datos incompletos', text: error, confirmButtonColor: '#0d6efd' });
+            else alert(error);
+            return;
+        }
+        serializar(items);
+        // Los hidden deben quedar dentro del <form> para que el binder los recorra.
+        Array.from(hiddenMount.querySelectorAll('input')).forEach(function (i) { form.appendChild(i); });
+        hiddenMount.innerHTML = '';
+
+        if (typeof Swal === 'undefined') { form.submit(); return; }
+        Swal.fire({
+            title: '¿Confirmar recepción?',
+            html: resumenHtml(items, leerTotales()),
+            icon: 'question',
+            showCancelButton: true,
+            confirmButtonColor: '#0d6efd', cancelButtonColor: '#6c757d',
+            confirmButtonText: 'Sí, confirmar', cancelButtonText: 'Cancelar',
+            reverseButtons: true, width: 720,
+        }).then(function (result) {
+            if (result.isConfirmed) form.submit();
+            else form.querySelectorAll('input[name^="Items["]').forEach(function (i) { i.remove(); });
+        });
+    });
+
+    if (btnAdd) btnAdd.addEventListener('click', function () { agregarFila(); });
+    if (dataPreCargada.length > 0) dataPreCargada.forEach(function (it) { agregarFila(it); });
+    actualizarTotal();
+
+    window.__recepciones = { agregarFila: agregarFila, itemsFromForm: itemsFromForm };
+})();


### PR DESCRIPTION
## Resumen

UI para captura de códigos GARRAFA en recepciones de proveedor — completa la issue #45. PR2 de 2 sobre `develop` (stack: este PR depende de #73 mergeado).

## Cambios

- **Nuevo `src/ExtraGasMVC/wwwroot/js/recepciones.js`** (~274 LOC):
  - Lee `window.__RECEPCIONES_PRODUCTOS__` (JSON inyectado por Razor con id, nombre, capacidad_kg, precio_actual, `maneja_garrafa_individual`).
  - Items dinámicos: agregar/eliminar filas; precio auto-rellenado al cambiar producto.
  - Toggle de textarea códigos según `manejaGarrafaIndividual` del producto.
  - Validaciones cliente (espejo de las del service): cantidad entera para GARRAFA, cantidad == códigos.count, dupes case-insensitive.
  - Pre-submit: arma hidden inputs `Items[i].ProductoId/Cantidad/PrecioUnitario` y `Items[i].CodigosGarrafa[j]` para que el `DefaultModelBinder` mapee a `CrearRecepcionDto`.
  - Modal `SweetAlert2` con tabla-resumen (items, garrafas a crear, totales del header) antes de submit.

- **Rediseño de `src/ExtraGasMVC/Views/Recepciones/Create.cshtml`** (+180 / -32):
  - **Card 1 — Encabezado**: Fecha, Proveedor (select), Número de factura, Subtotal/Descuento/Total, Observaciones.
  - **Card 2 — Items**: tabla con Producto / Cantidad / Precio / Subtotal computed / Códigos GARRAFA (visible solo para GARRAFA) / Eliminar. Botón "Agregar item" en el header. Footer: badge "Total garrafas a crear".
  - **Card 3 — Acciones**: botón "Confirmar recepción" (se deshabilita hasta que haya al menos un item cargado) + link "Cancelar".
  - Inputs top-level con `name="Fecha|ProveedorId|..."` (sin prefijo) para enlazar al parámetro `CrearRecepcionDto input` del controller.
  - `@section Scripts { <script src="~/js/recepciones.js" asp-append-version="true"></script> }`.

- **Cero cambios al backend**: `IRecepcionService`, `RecepcionService.CreateAsync`, `RecepcionDto`, `CrearRecepcionViewModel`, `RecepcionesController`, `Program.cs` quedaron intactos (los dejó PR1).

## Cómo probar

1. Login como admin (cambiar temporalmente `usuarios.activo=1` para el seed admin, y bindear `empleado.usuario_id`).
2. `GET /Recepciones/Create` → ver 3 cards, dropdown de proveedores, tabla items vacía con mensaje "Sin items cargados".
3. Click **Agregar item** → fila con dropdown de productos.
4. Seleccionar **GAS-10** (GARRAFA) → aparece la columna "Códigos GARRAFA" con textarea, precio auto-rellenado.
5. Seleccionar **CAR-3** (carbón) → NO aparece la columna códigos.
6. Cargar 2 códigos para GAS-10, submit, confirmar en `SweetAlert2`.
7. Verificar en BD:
   ```sql
   SELECT * FROM recepciones_proveedor ORDER BY id DESC LIMIT 1;
   SELECT * FROM recepcion_items WHERE recepcion_id = (SELECT MAX(id) FROM recepciones_proveedor);
   SELECT codigo, estado_garrafa_id, capacidad_kg, proveedor_id, recepcion_id, fecha_compra, activo
     FROM garrafas WHERE deleted_at IS NULL ORDER BY id DESC LIMIT 5;
   SELECT id, garrafa_id, tipo_movimiento_id, estado_origen_id, estado_destino_id, cliente_id, empleado_id, recepcion_id
     FROM movimientos_garrafa WHERE recepcion_id = (SELECT MAX(id) FROM recepciones_proveedor);
   ```
8. **Rechazos** verificados (todos dejan la BD sin cambios):
   - Cantidad ≠ códigos → "esperaba X código(s) y recibió Y".
   - Códigos duplicados case-insensitive en submit → "código(s) duplicado(s): …".
   - Código ya existente en `garrafas` (case-insensitive, incluyendo soft-deleted) → "código(s) ya existente(s): …".

## Notas

- PR1 cubrió el backend (transaccional, validaciones, auditoría, reversión). Esta PR solo agrega la captura de códigos en la UI.
- Endpoint POST `/Recepciones/Create` ya estaba operativo desde PR1.
- Smoke test E2E ejecutado vía curl simulando exactamente el payload que el JS produce en `serializarParaSubmit`: 1 GARRAFA cant=2 + 1 carbón cant=3 → 1 recepción `REC-PROV-2026-XXXXX`, 2 items, 2 garrafas `LLENA_DEPOSITO`, 2 movimientos `COMPRA` con `cliente_id IS NULL`. BD revertida a su estado inicial tras la verificación.
- **LOC del PR**: 486 changed lines (Create.cshtml +180/-32 + recepciones.js +274 — archivo nuevo). Sobre el umbral de 400 del budget de review. La estimación del design fue ~320 (design.md §11); el sobre-costo viene del JS que incluye validación client-side espejada del service y del modal de confirmación detallado.

## Dependency Diagram (stacked-to-main)

```
main  ─────────────────────────────●─── (merge PR2)
                                      ▲
develop ─────●───────────────────────●─── merge #73 (PR1)
                ▲
                feature/issue-45-recepciones-garrafas-backend (#73) (PR1)
                            
                ▲
                feature/issue-45-recepciones-garrafas-ui (PR2 — esta) 📍
```

Closes #45