### PR TITLE
feat(garrafas): dropdowns de Estado/Proveedor/Recepcion en Create y Edit (#48)

### DIFF
--- a/src/ExtraGasMVC/Controllers/GarrafasController.cs
+++ b/src/ExtraGasMVC/Controllers/GarrafasController.cs
@@ -10,13 +10,23 @@ namespace ExtraGasMVC.Controllers;
 [Authorize(Policy = "OperadorOrAdmin")]
 public class GarrafasController : BaseController
 {
+    private const int RecepcionesDropdownCantidad = 100;
+
     private readonly IGarrafaService _garrafaService;
     private readonly IClienteService _clienteService;
+    private readonly IProveedorService _proveedorService;
+    private readonly IRecepcionService _recepcionService;
 
-    public GarrafasController(IGarrafaService garrafaService, IClienteService clienteService)
+    public GarrafasController(
+        IGarrafaService garrafaService,
+        IClienteService clienteService,
+        IProveedorService proveedorService,
+        IRecepcionService recepcionService)
     {
         _garrafaService = garrafaService;
         _clienteService = clienteService;
+        _proveedorService = proveedorService;
+        _recepcionService = recepcionService;
     }
 
     /// <summary>
@@ -39,6 +49,27 @@ public class GarrafasController : BaseController
     {
         TempData["Error"] = "No se puede editar una garrafa dada de baja.";
         return RedirectToAction(nameof(Details), new { id });
+    }
+
+    /// <summary>
+    /// Puebla los 4 ViewBags que alimentan los dropdowns de los formularios
+    /// Create/Edit de garrafas (issue #48): Clientes, Estados, Proveedores y
+    /// Recepciones. Lookups SECUENCIALES: los 4 servicios comparten el mismo
+    /// DbContext Scoped dentro del request, y EF no permite operaciones
+    /// concurrentes sobre un único DbContext (mismo motivo que en
+    /// <c>RecepcionesController.BuildCreateViewModelAsync</c>).
+    /// </summary>
+    private async Task CargarDropdownsFormularioAsync(CancellationToken ct)
+    {
+        ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
+        ViewBag.Estados = await _garrafaService.GetEstadosAsync(ct);
+
+        var proveedoresResult = await _proveedorService.SearchAsync(
+            null, soloActivos: true, pagina: 1, tamanio: 1000, ct);
+        ViewBag.Proveedores = proveedoresResult.Items;
+
+        ViewBag.Recepciones = await _recepcionService.GetRecientesAsync(
+            RecepcionesDropdownCantidad, ct);
     }
 
     public async Task<IActionResult> Index(string? codigo, byte? capacidad, CancellationToken ct = default)
@@ -71,13 +102,26 @@ public class GarrafasController : BaseController
         return View(movimientos);
     }
 
-    public IActionResult Create() => View(new CreateGarrafaDto { EstadoGarrafaId = 1, Activo = true, FechaCompra = DateOnly.FromDateTime(DateTime.UtcNow) });
+    public async Task<IActionResult> Create(CancellationToken ct = default)
+    {
+        await CargarDropdownsFormularioAsync(ct);
+        return View(new CreateGarrafaDto
+        {
+            EstadoGarrafaId = 1,
+            Activo = true,
+            FechaCompra = DateOnly.FromDateTime(DateTime.UtcNow)
+        });
+    }
 
     [HttpPost]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Create(CreateGarrafaDto garrafa, CancellationToken ct = default)
     {
-        if (!ModelState.IsValid) return View(garrafa);
+        if (!ModelState.IsValid)
+        {
+            await CargarDropdownsFormularioAsync(ct);
+            return View(garrafa);
+        }
         try
         {
             await _garrafaService.CreateAsync(garrafa, GetCurrentUserId(), ct);
@@ -87,11 +131,13 @@ public class GarrafasController : BaseController
         catch (InvalidOperationException ex)
         {
             ModelState.AddModelError(string.Empty, ex.Message);
+            await CargarDropdownsFormularioAsync(ct);
             return View(garrafa);
         }
         catch (Exception ex)
         {
             ModelState.AddModelError(string.Empty, $"No se pudo crear la garrafa: {ex.Message}");
+            await CargarDropdownsFormularioAsync(ct);
             return View(garrafa);
         }
     }
@@ -107,7 +153,7 @@ public class GarrafasController : BaseController
         if (garrafa.EstadoCodigo == GarrafaEstados.FueraServicio)
             return RedirectBloqueadoPorEstado(id);
 
-        ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
+        await CargarDropdownsFormularioAsync(ct);
 
         var updateDto = new UpdateGarrafaDto
         {
@@ -142,7 +188,7 @@ public class GarrafasController : BaseController
 
         if (!ModelState.IsValid)
         {
-            ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
+            await CargarDropdownsFormularioAsync(ct);
             return View(garrafa);
         }
         try
@@ -154,13 +200,13 @@ public class GarrafasController : BaseController
         catch (InvalidOperationException ex)
         {
             ModelState.AddModelError(string.Empty, ex.Message);
-            ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
+            await CargarDropdownsFormularioAsync(ct);
             return View(garrafa);
         }
         catch (Exception ex)
         {
             ModelState.AddModelError(string.Empty, $"No se pudo actualizar la garrafa: {ex.Message}");
-            ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
+            await CargarDropdownsFormularioAsync(ct);
             return View(garrafa);
         }
     }

--- a/src/ExtraGasMVC/Services/Implementations/RecepcionService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/RecepcionService.cs
@@ -193,6 +193,53 @@ public class RecepcionService : IRecepcionService
     public Task<IEnumerable<ProductoDto>> GetProductosActivosAsync(CancellationToken ct = default)
         => _productoService.GetActivosAsync(ct);
 
+    public async Task<IEnumerable<RecepcionDto>> GetRecientesAsync(int cantidad, CancellationToken ct = default)
+    {
+        // Issue #48: dropdown de Recepción en formularios de Garrafa. Filtramos
+        // soft-deleted (una recepción reversada ya no debe ser elegible) y
+        // ordenamos por fecha desc para que el operador vea primero lo más
+        // reciente. Sin items: el selector solo necesita número + proveedor.
+        if (cantidad <= 0) return Array.Empty<RecepcionDto>();
+
+        var headers = await _context.RecepcionesProveedor.AsNoTracking()
+            .Where(r => r.DeletedAt == null)
+            .OrderByDescending(r => r.Fecha)
+            .Take(cantidad)
+            .ToListAsync(ct);
+
+        if (headers.Count == 0) return Array.Empty<RecepcionDto>();
+
+        var proveedorIds = headers.Select(h => h.ProveedorId).Distinct().ToList();
+        var empleadoIds = headers.Select(h => h.EmpleadoId).Distinct().ToList();
+
+        var proveedoresById = await _context.Proveedores.AsNoTracking()
+            .Where(p => proveedorIds.Contains(p.Id))
+            .ToDictionaryAsync(p => p.Id, p => p.RazonSocial, ct);
+
+        var empleadosById = await _context.Empleados.AsNoTracking()
+            .Where(e => empleadoIds.Contains(e.Id))
+            .ToDictionaryAsync(e => e.Id, e => $"{e.Apellido}, {e.Nombre}", ct);
+
+        return headers.Select(h => new RecepcionDto
+        {
+            Id = h.Id,
+            Numero = h.Numero,
+            Fecha = h.Fecha,
+            ProveedorId = h.ProveedorId,
+            ProveedorNombre = proveedoresById.TryGetValue(h.ProveedorId, out var pn) ? pn : null,
+            EmpleadoId = h.EmpleadoId,
+            EmpleadoNombre = empleadosById.TryGetValue(h.EmpleadoId, out var en) ? en : null,
+            NumeroFacturaProveedor = h.NumeroFacturaProveedor,
+            Subtotal = h.Subtotal,
+            Descuento = h.Descuento,
+            Total = h.Total,
+            MontoPagado = h.MontoPagado,
+            Saldo = h.Saldo,
+            Observaciones = h.Observaciones,
+            Items = new List<RecepcionItemDto>(),
+        }).ToList();
+    }
+
     private async Task<ulong?> ResolverEmpleadoIdAsync(ulong? usuarioId, CancellationToken ct)
     {
         if (!usuarioId.HasValue) return null;

--- a/src/ExtraGasMVC/Services/Interfaces/IRecepcionService.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IRecepcionService.cs
@@ -40,4 +40,13 @@ public interface IRecepcionService
     /// mantiene el contrato cohesivo del servicio de recepciones.
     /// </summary>
     Task<IEnumerable<ProductoDto>> GetProductosActivosAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Devuelve las recepciones activas (no soft-deleted) ordenadas por fecha
+    /// descendente, limitadas a <paramref name="cantidad"/>. Usado para poblar
+    /// el dropdown de Recepción en formularios de Garrafa (issue #48). Cada
+    /// <see cref="RecepcionDto"/> trae el nombre del proveedor y del empleado,
+    /// pero no los items (no se necesitan para un selector).
+    /// </summary>
+    Task<IEnumerable<RecepcionDto>> GetRecientesAsync(int cantidad, CancellationToken ct = default);
 }

--- a/src/ExtraGasMVC/Views/Garrafas/Create.cshtml
+++ b/src/ExtraGasMVC/Views/Garrafas/Create.cshtml
@@ -6,6 +6,9 @@
         new() { Label = "Garrafas", Controller = "Garrafas", Action = "Index" },
         new() { Label = "Nueva" }
     };
+    var estados = ViewBag.Estados as IEnumerable<ExtraGasMVC.DTOs.EstadoGarrafaDto> ?? Array.Empty<ExtraGasMVC.DTOs.EstadoGarrafaDto>();
+    var proveedores = ViewBag.Proveedores as IEnumerable<ExtraGasMVC.DTOs.ProveedorDto> ?? Array.Empty<ExtraGasMVC.DTOs.ProveedorDto>();
+    var recepciones = ViewBag.Recepciones as IEnumerable<ExtraGasMVC.DTOs.RecepcionDto> ?? Array.Empty<ExtraGasMVC.DTOs.RecepcionDto>();
 }
 @section PageHeader {
     <div class="mb-3">
@@ -29,7 +32,13 @@
                 </div>
                 <div class="col-md-3">
                     <label asp-for="EstadoGarrafaId" class="form-label"></label>
-                    <input asp-for="EstadoGarrafaId" type="number" class="form-control" value="@Model.EstadoGarrafaId" />
+                    <select asp-for="EstadoGarrafaId" class="form-select" required>
+                        <option value="">-- Seleccionar estado --</option>
+                        @foreach (var e in estados)
+                        {
+                            <option value="@e.Id">@e.Nombre</option>
+                        }
+                    </select>
                 </div>
                 <div class="col-md-4">
                     <label asp-for="FechaCompra" class="form-label"></label>
@@ -37,11 +46,23 @@
                 </div>
                 <div class="col-md-6">
                     <label asp-for="ProveedorId" class="form-label"></label>
-                    <input asp-for="ProveedorId" type="number" class="form-control" />
+                    <select asp-for="ProveedorId" class="form-select">
+                        <option value="">-- Sin proveedor --</option>
+                        @foreach (var p in proveedores)
+                        {
+                            <option value="@p.Id">@p.RazonSocial</option>
+                        }
+                    </select>
                 </div>
                 <div class="col-md-6">
                     <label asp-for="RecepcionId" class="form-label"></label>
-                    <input asp-for="RecepcionId" type="number" class="form-control" />
+                    <select asp-for="RecepcionId" class="form-select">
+                        <option value="">-- Sin recepción --</option>
+                        @foreach (var r in recepciones)
+                        {
+                            <option value="@r.Id">@((r.Numero ?? $"#{r.Id}")) — @r.Fecha.ToShortDateString() — @(r.ProveedorNombre ?? "?")</option>
+                        }
+                    </select>
                 </div>
                 <div class="col-md-12 d-flex align-items-end">
                     <div class="form-check">

--- a/src/ExtraGasMVC/Views/Garrafas/Edit.cshtml
+++ b/src/ExtraGasMVC/Views/Garrafas/Edit.cshtml
@@ -7,6 +7,9 @@
         new() { Label = "Editar" }
     };
     var clientes = ViewBag.Clientes as IEnumerable<ExtraGasMVC.DTOs.ClienteDto> ?? Array.Empty<ExtraGasMVC.DTOs.ClienteDto>();
+    var estados = ViewBag.Estados as IEnumerable<ExtraGasMVC.DTOs.EstadoGarrafaDto> ?? Array.Empty<ExtraGasMVC.DTOs.EstadoGarrafaDto>();
+    var proveedores = ViewBag.Proveedores as IEnumerable<ExtraGasMVC.DTOs.ProveedorDto> ?? Array.Empty<ExtraGasMVC.DTOs.ProveedorDto>();
+    var recepciones = ViewBag.Recepciones as IEnumerable<ExtraGasMVC.DTOs.RecepcionDto> ?? Array.Empty<ExtraGasMVC.DTOs.RecepcionDto>();
 }
 @section PageHeader {
     <div class="mb-3">
@@ -31,7 +34,13 @@
                 </div>
                 <div class="col-md-3">
                     <label asp-for="EstadoGarrafaId" class="form-label"></label>
-                    <input asp-for="EstadoGarrafaId" type="number" class="form-control" />
+                    <select asp-for="EstadoGarrafaId" class="form-select" required>
+                        <option value="">-- Seleccionar estado --</option>
+                        @foreach (var e in estados)
+                        {
+                            <option value="@e.Id">@e.Nombre</option>
+                        }
+                    </select>
                 </div>
                 <div class="col-md-4">
                     <label asp-for="FechaCompra" class="form-label"></label>
@@ -49,11 +58,23 @@
                 </div>
                 <div class="col-md-3">
                     <label asp-for="ProveedorId" class="form-label"></label>
-                    <input asp-for="ProveedorId" type="number" class="form-control" />
+                    <select asp-for="ProveedorId" class="form-select">
+                        <option value="">-- Sin proveedor --</option>
+                        @foreach (var p in proveedores)
+                        {
+                            <option value="@p.Id">@p.RazonSocial</option>
+                        }
+                    </select>
                 </div>
                 <div class="col-md-3">
                     <label asp-for="RecepcionId" class="form-label"></label>
-                    <input asp-for="RecepcionId" type="number" class="form-control" />
+                    <select asp-for="RecepcionId" class="form-select">
+                        <option value="">-- Sin recepción --</option>
+                        @foreach (var r in recepciones)
+                        {
+                            <option value="@r.Id">@((r.Numero ?? $"#{r.Id}")) — @r.Fecha.ToShortDateString() — @(r.ProveedorNombre ?? "?")</option>
+                        }
+                    </select>
                 </div>
                 <div class="col-md-12 d-flex align-items-end">
                     <div class="form-check">


### PR DESCRIPTION
## Issue #48 — Dropdowns en formularios Create y Edit de Garrafas

### Cambios

- **`IRecepcionService.GetRecientesAsync(int cantidad)`**: nuevo método que devuelve recepciones activas (no soft-deleted), ordenadas por fecha descendente, con proveedor/empleado nombres. Sin items (no hacen falta para un selector).
- **`GarrafasController`**: helper privado `CargarDropdownsFormularioAsync()` que pobla los 4 ViewBags (`Clientes`, `Estados`, `Proveedores`, `Recepciones`) con lookups **secuenciales** (los servicios comparten el mismo `DbContext` Scoped — EF no permite lookups concurrentes sobre un único DbContext, mismo motivo que `RecepcionesController.BuildCreateViewModelAsync`).
- **`Create.cshtml` y `Edit.cshtml`**: los 3 inputs numéricos (`EstadoGarrafaId`, `ProveedorId`, `RecepcionId`) reemplazados por `<select>` con placeholder. `EstadoGarrafaId` queda como `required` (es NOT NULL en BD), `ProveedorId` y `RecepcionId` con option `-- Sin --` porque son FKs opcionales.

### Archivos

| Archivo | Delta |
|---|---|
| `Controllers/GarrafasController.cs` | +50/-12 |
| `Services/Implementations/RecepcionService.cs` | +47/-0 |
| `Services/Interfaces/IRecepcionService.cs` | +9/-0 |
| `Views/Garrafas/Create.cshtml` | +20/-9 |
| `Views/Garrafas/Edit.cshtml` | +20/-9 |

**Total:** 160 insertions, 16 deletions, 5 archivos.

### Smoke

- `dotnet build` → 0 errores. Warnings preexistentes (AutoMapper NuGet1903 y CS8602 en `Views/Recepciones/Create.cshtml:62` que no se tocó).

### Criterios de aceptación

- [x] Cargar lista de estados en `ViewBag.Estados`
- [x] Cargar lista de proveedores activos en `ViewBag.Proveedores`
- [x] Cargar lista de recepciones pendientes en `ViewBag.Recepciones` (interpretado como recepciones activas, no soft-deleted, ordenadas por fecha desc)
- [x] En Create y Edit: dropdowns para Estado, Proveedor, Recepción
- [x] Seleccionar valor actual en Edit (`asp-for` resuelve el `selected` automáticamente)

Closes #48