### PR TITLE
feat(garrafas): dropdown de capacidad (10/15/45 kg) en Create y Edit

### DIFF
--- a/src/ExtraGasMVC/Views/Garrafas/Create.cshtml
+++ b/src/ExtraGasMVC/Views/Garrafas/Create.cshtml
@@ -28,7 +28,12 @@
                 </div>
                 <div class="col-md-2">
                     <label asp-for="CapacidadKg" class="form-label"></label>
-                    <input asp-for="CapacidadKg" type="number" class="form-control" required />
+                    <select asp-for="CapacidadKg" class="form-select" required>
+                        <option value="">-- Seleccionar --</option>
+                        <option value="10">10 kg</option>
+                        <option value="15">15 kg</option>
+                        <option value="45">45 kg</option>
+                    </select>
                 </div>
                 <div class="col-md-3">
                     <label asp-for="EstadoGarrafaId" class="form-label"></label>

--- a/src/ExtraGasMVC/Views/Garrafas/Edit.cshtml
+++ b/src/ExtraGasMVC/Views/Garrafas/Edit.cshtml
@@ -30,7 +30,12 @@
                 </div>
                 <div class="col-md-2">
                     <label asp-for="CapacidadKg" class="form-label"></label>
-                    <input asp-for="CapacidadKg" type="number" class="form-control" required />
+                    <select asp-for="CapacidadKg" class="form-select" required>
+                        <option value="">-- Seleccionar --</option>
+                        <option value="10">10 kg</option>
+                        <option value="15">15 kg</option>
+                        <option value="45">45 kg</option>
+                    </select>
                 </div>
                 <div class="col-md-3">
                     <label asp-for="EstadoGarrafaId" class="form-label"></label>


### PR DESCRIPTION
## Resumen

Reemplaza el `<input type="number">` libre por `<select>` con las 3 capacidades válidas (10/15/45 kg) en los formularios Create y Edit de Garrafas.

## Cambios

- `Views/Garrafas/Create.cshtml` — input → select con opciones 10/15/45 kg
- `Views/Garrafas/Edit.cshtml` — input → select (asp-for pre-selecciona el valor actual)

## Por qué

El input libre aceptaba cualquier valor aunque la BD tiene CHECK constraint; el usuario recibía error 500 del trigger en lugar de feedback inmediato. El dropdown previene valores inválidos antes de submit.

## Validación

- `dotnet build` → 0 errores (warnings preexistentes no relacionados)
- Diff: +12/-2 líneas, 2 archivos
- Sigue el mismo patrón visual que los dropdowns de Estado/Proveedor/Recepción agregados en #48

Closes #49