### PR TITLE
feat(garrafas): indicadores de obligatoriedad en Create y Edit (#50)

### DIFF
--- a/src/ExtraGasMVC/Views/Garrafas/Create.cshtml
+++ b/src/ExtraGasMVC/Views/Garrafas/Create.cshtml
@@ -21,13 +21,14 @@
         @Html.AntiForgeryToken()
         <div class="card-body">
             <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+            <div class="small text-secondary mb-3"><span class="text-danger">*</span> Campos obligatorios</div>
             <div class="row g-3">
                 <div class="col-md-3">
-                    <label asp-for="Codigo" class="form-label"></label>
+                    <label asp-for="Codigo" class="form-label"></label> <span class="text-danger">*</span>
                     <input asp-for="Codigo" class="form-control" required />
                 </div>
                 <div class="col-md-2">
-                    <label asp-for="CapacidadKg" class="form-label"></label>
+                    <label asp-for="CapacidadKg" class="form-label"></label> <span class="text-danger">*</span>
                     <select asp-for="CapacidadKg" class="form-select" required>
                         <option value="">-- Seleccionar --</option>
                         <option value="10">10 kg</option>
@@ -36,7 +37,7 @@
                     </select>
                 </div>
                 <div class="col-md-3">
-                    <label asp-for="EstadoGarrafaId" class="form-label"></label>
+                    <label asp-for="EstadoGarrafaId" class="form-label"></label> <span class="text-danger">*</span>
                     <select asp-for="EstadoGarrafaId" class="form-select" required>
                         <option value="">-- Seleccionar estado --</option>
                         @foreach (var e in estados)
@@ -46,7 +47,7 @@
                     </select>
                 </div>
                 <div class="col-md-4">
-                    <label asp-for="FechaCompra" class="form-label"></label>
+                    <label asp-for="FechaCompra" class="form-label"></label> <span class="text-danger">*</span>
                     <input asp-for="FechaCompra" type="date" class="form-control" required />
                 </div>
                 <div class="col-md-6">

--- a/src/ExtraGasMVC/Views/Garrafas/Edit.cshtml
+++ b/src/ExtraGasMVC/Views/Garrafas/Edit.cshtml
@@ -23,13 +23,14 @@
         <input type="hidden" asp-for="Id" />
         <div class="card-body">
             <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+            <div class="small text-secondary mb-3"><span class="text-danger">*</span> Campos obligatorios</div>
             <div class="row g-3">
                 <div class="col-md-3">
-                    <label asp-for="Codigo" class="form-label"></label>
+                    <label asp-for="Codigo" class="form-label"></label> <span class="text-danger">*</span>
                     <input asp-for="Codigo" class="form-control" required />
                 </div>
                 <div class="col-md-2">
-                    <label asp-for="CapacidadKg" class="form-label"></label>
+                    <label asp-for="CapacidadKg" class="form-label"></label> <span class="text-danger">*</span>
                     <select asp-for="CapacidadKg" class="form-select" required>
                         <option value="">-- Seleccionar --</option>
                         <option value="10">10 kg</option>
@@ -38,7 +39,7 @@
                     </select>
                 </div>
                 <div class="col-md-3">
-                    <label asp-for="EstadoGarrafaId" class="form-label"></label>
+                    <label asp-for="EstadoGarrafaId" class="form-label"></label> <span class="text-danger">*</span>
                     <select asp-for="EstadoGarrafaId" class="form-select" required>
                         <option value="">-- Seleccionar estado --</option>
                         @foreach (var e in estados)
@@ -48,7 +49,7 @@
                     </select>
                 </div>
                 <div class="col-md-4">
-                    <label asp-for="FechaCompra" class="form-label"></label>
+                    <label asp-for="FechaCompra" class="form-label"></label> <span class="text-danger">*</span>
                     <input asp-for="FechaCompra" type="date" class="form-control" required />
                 </div>
                 <div class="col-md-6">


### PR DESCRIPTION
## Issue
Closes #50

## Descripción
Agrega asteriscos rojos (`) a los campos obligatorios en los formularios de Create y Edit de Garrafas, más una leyenda "Campos obligatorios" al inicio del formulario.

## Cambios

### `src/ExtraGasMVC/Views/Garrafas/Create.cshtml`
- Agregada leyenda "Campos obligatorios" tras el validation summary
- Asterisco en label de: Codigo, CapacidadKg, EstadoGarrafaId, FechaCompra

### `src/ExtraGasMVC/Views/Garrafas/Edit.cshtml`
- Mismos cambios que Create

## Consistencia
Patrón idéntico al usado en Clientes, Empleados, Usuarios y Pedidos.

## Validación
`dotnet build` pasa sin errores. Solo cambios de marcado, no se toca lógica ni DTOs.

## Checklist
- [x] Compila sin errores
- [x] Sigue el patrón de otros módulos
- [x] Marca solo campos realmente obligatorios del DTO (Codigo, CapacidadKg, EstadoGarrafaId, FechaCompra)
- [x] Campos opcionales del DTO (ProveedorId, RecepcionId, ClienteId, Observaciones) sin marcador