### PR TITLE
feat(garrafas): usar v_stock_garrafas y v_garrafas_en_clientes

### DIFF
--- a/src/ExtraGasMVC/Controllers/GarrafasController.cs
+++ b/src/ExtraGasMVC/Controllers/GarrafasController.cs
@@ -213,32 +213,24 @@ public class GarrafasController : BaseController
 
     public async Task<IActionResult> Stock(CancellationToken ct = default)
     {
-        var garrafas = await _garrafaService.GetAllAsync(ct);
-        var agrupado = garrafas
-            .GroupBy(g => new { g.CapacidadKg, g.EstadoGarrafaId })
-            .Select(g => new StockGroup
-            {
-                CapacidadKg = g.Key.CapacidadKg,
-                EstadoId = g.Key.EstadoGarrafaId,
-                Cantidad = g.Count()
-            })
-            .OrderBy(s => s.CapacidadKg)
-            .ThenBy(s => s.EstadoId)
-            .ToList();
-        return View(agrupado);
+        // Issue #51: ahora consulta la vista v_stock_garrafas (nombres y
+        // colores de estado incluidos), eliminando el agrupamiento manual
+        // en memoria.
+        var stock = await _garrafaService.GetStockAsync(ct);
+        return View(stock);
     }
 
     public async Task<IActionResult> EnClientes(ulong? clienteId, CancellationToken ct = default)
     {
+        // Issue #51: la vista v_garrafas_en_clientes ya excluye las que no
+        // están en estado EN_CLIENTE, aplica soft-delete y calcula días; el
+        // Controller ya no necesita pedir el listado completo y filtrar acá.
+        var enClientes = await _garrafaService.GetEnClientesAsync(clienteId, ct);
+
         if (clienteId.HasValue)
-        {
-            var garrafas = await _garrafaService.GetByClienteAsync(clienteId.Value, ct);
             ViewBag.Cliente = await _clienteService.GetByIdAsync(clienteId.Value, ct);
-            return View("EnClientes", garrafas);
-        }
-        var todas = await _garrafaService.GetAllAsync(ct);
-        var enClientes = todas.Where(g => g.ClienteId.HasValue);
-        return View(enClientes);
+
+        return View("EnClientes", enClientes);
     }
 
     public async Task<IActionResult> CambiarEstado(ulong id, CancellationToken ct = default)

--- a/src/ExtraGasMVC/Models/ViewModels/DashboardViewModel.cs
+++ b/src/ExtraGasMVC/Models/ViewModels/DashboardViewModel.cs
@@ -19,10 +19,3 @@ public class TopProducto
     public string Tipo { get; set; } = string.Empty;
     public decimal Cantidad { get; set; }
 }
-
-public class StockGroup
-{
-    public byte CapacidadKg { get; set; }
-    public ulong EstadoId { get; set; }
-    public int Cantidad { get; set; }
-}

--- a/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 using ExtraGasMVC.Constants;
 using ExtraGasMVC.Data.Context;
 using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.Data.Entities.Views;
 using ExtraGasMVC.DTOs;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
@@ -446,5 +447,35 @@ public class GarrafaService : IGarrafaService
         {
             throw new InvalidOperationException($"Ya existe una garrafa con el código {codigo}.");
         }
+    }
+
+    public async Task<IEnumerable<VStockGarrafa>> GetStockAsync(CancellationToken ct = default)
+    {
+        // Issue #51: leemos la vista v_stock_garrafas en vez de agrupar en
+        // memoria. La vista ya excluye soft-deleted, agrupa por capacidad y
+        // estado, y proyecta los nombres/colores del catálogo estados_garrafa,
+        // por lo que el Controller puede renderizar badges sin joins extra.
+        var query = _context.VStockGarrafas.AsNoTracking();
+
+        var rows = await query.ToListAsync(ct);
+        // La vista ordena por capacidad / estado_nombre, pero asegurar el orden
+        // en la app para que la UI sea estable si la vista se redefine.
+        return rows
+            .OrderBy(r => r.CapacidadKg)
+            .ThenBy(r => r.EstadoNombre);
+    }
+
+    public async Task<IEnumerable<VGarrafaEnCliente>> GetEnClientesAsync(ulong? clienteId, CancellationToken ct = default)
+    {
+        // Issue #51: leemos v_garrafas_en_clientes (que ya filtra por estado
+        // EN_CLIENTE y calcula dias_en_cliente en SQL). Pasamos el filtro
+        // opcional de cliente al WHERE para respetar el comportamiento previo
+        // del Controller (sin parámetro = todos; con parámetro = uno).
+        var query = _context.VGarrafasEnClientes.AsNoTracking();
+
+        if (clienteId.HasValue)
+            query = query.Where(v => v.ClienteId == clienteId.Value);
+
+        return await query.ToListAsync(ct);
     }
 }

--- a/src/ExtraGasMVC/Services/Interfaces/IGarrafaService.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IGarrafaService.cs
@@ -1,3 +1,4 @@
+using ExtraGasMVC.Data.Entities.Views;
 using ExtraGasMVC.DTOs;
 
 namespace ExtraGasMVC.Services.Interfaces;
@@ -67,4 +68,22 @@ public interface IGarrafaService
         string tipoMovimientoCodigo,
         ulong? usuarioId,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Devuelve el stock agrupado por capacidad y estado, leyendo directamente
+    /// de la vista <c>v_stock_garrafas</c> para evitar el agrupamiento manual
+    /// que antes se hacía en memoria en el Controller (issue #51). Cada fila
+    /// ya trae los nombres y colores del catálogo <c>estados_garrafa</c>,
+    /// por lo que la UI puede renderizar badges sin joins adicionales.
+    /// </summary>
+    Task<IEnumerable<VStockGarrafa>> GetStockAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Devuelve las garrafas que están en poder de un cliente, leyendo de la
+    /// vista <c>v_garrafas_en_clientes</c> (issue #51). La vista ya filtra
+    /// por estado <c>EN_CLIENTE</c> y calcula <c>dias_en_cliente</c>. Cuando
+    /// <paramref name="clienteId"/> es null devuelve todas las garrafas en
+    /// cliente; cuando se especifica, filtra a ese cliente.
+    /// </summary>
+    Task<IEnumerable<VGarrafaEnCliente>> GetEnClientesAsync(ulong? clienteId, CancellationToken ct = default);
 }

--- a/src/ExtraGasMVC/Views/Garrafas/EnClientes.cshtml
+++ b/src/ExtraGasMVC/Views/Garrafas/EnClientes.cshtml
@@ -1,4 +1,4 @@
-@model IEnumerable<ExtraGasMVC.DTOs.GarrafaDto>
+@model IEnumerable<ExtraGasMVC.Data.Entities.Views.VGarrafaEnCliente>
 @{
     ViewData["Title"] = "Garrafas en poder del cliente";
     ViewData["Breadcrumbs"] = new List<BreadcrumbItem>
@@ -29,9 +29,9 @@
                 <tr>
                     <th>Codigo</th>
                     <th class="text-end">Capacidad (kg)</th>
-                    <th>Estado</th>
                     <th>Cliente</th>
                     <th>F. ultimo mov.</th>
+                    <th class="text-end">Días en cliente</th>
                 </tr>
             </thead>
             <tbody>
@@ -45,21 +45,24 @@
                         <td><code>@g.Codigo</code></td>
                         <td class="text-end">@g.CapacidadKg</td>
                         <td>
-                            @* Issue #47: badge con color del catálogo estados_garrafa y nombre legible *@
-                            <span class="badge" style="background-color: @(g.EstadoColor ?? "#6c757d"); color: #fff;">@(g.EstadoNombre ?? $"#{g.EstadoGarrafaId}")</span>
-                        </td>
-                        <td>
-                            @if (g.ClienteId.HasValue && !string.IsNullOrWhiteSpace(g.ClienteNombre))
-                            { <a asp-controller="Clientes" asp-action="Details" asp-route-id="@g.ClienteId">@g.ClienteNombre</a> }
+                            @if (g.ClienteId > 0 && !string.IsNullOrWhiteSpace(g.Cliente))
+                            {
+                                <a asp-controller="Clientes" asp-action="Details" asp-route-id="@g.ClienteId">@g.Cliente</a>
+                            }
                             else if (cliente is not null)
                             {
                                 <span>@cliente.Apellido, @cliente.Nombre</span>
                             }
                         </td>
-                        <td>@g.FechaUltimoMovimiento.ToShortDate()</td>
+                        <td>@g.FechaUltimoMovimiento?.ToShortDateString()</td>
+                        @* Issue #51: dias_en_cliente calculado en v_garrafas_en_clientes. *@
+                        <td class="text-end">@(g.DiasEnCliente?.ToString() ?? "—")</td>
                     </tr>
                 }
             </tbody>
         </table>
     </div>
 </div>
+<p class="text-secondary small mt-3">
+    Datos en vivo desde la vista <code>v_garrafas_en_clientes</code> de la base de datos (issue #51).
+</p>

--- a/src/ExtraGasMVC/Views/Garrafas/Stock.cshtml
+++ b/src/ExtraGasMVC/Views/Garrafas/Stock.cshtml
@@ -1,4 +1,4 @@
-@model IEnumerable<ExtraGasMVC.Models.ViewModels.StockGroup>
+@model IEnumerable<ExtraGasMVC.Data.Entities.Views.VStockGarrafa>
 @{
     ViewData["Title"] = "Stock de garrafas por estado";
     ViewData["Breadcrumbs"] = new List<BreadcrumbItem>
@@ -34,7 +34,11 @@
                 {
                     <tr>
                         <td class="text-end"><strong>@s.CapacidadKg</strong> kg</td>
-                        <td><span class="badge text-bg-secondary">Estado #@s.EstadoId</span></td>
+                        <td>
+                            @* Issue #51: badge con color y nombre del estado desde la vista v_stock_garrafas *@
+                            <span class="badge" style="background-color: @(s.EstadoColor ?? "#6c757d"); color: #fff;">@s.EstadoNombre</span>
+                            <small class="text-secondary ms-1">@s.EstadoCodigo</small>
+                        </td>
                         <td class="text-end fw-semibold">@s.Cantidad</td>
                     </tr>
                 }
@@ -49,6 +53,5 @@
     </div>
 </div>
 <p class="text-secondary small mt-3">
-    Datos en vivo computados a partir de la tabla <code>garrafas</code>. Los nombres de estado se resolveran
-    con la vista <code>v_stock_garrafas</code> en la base de datos.
+    Datos en vivo desde la vista <code>v_stock_garrafas</code> de la base de datos (issue #51).
 </p>


### PR DESCRIPTION
## Summary

- Cablea `v_stock_garrafas` y `v_garrafas_en_clientes` en el módulo Garrafas.
- Reemplaza el agrupamiento manual en `GarrafasController.Stock` por una consulta directa a la vista, eliminando los IDs hard-coded y mostrando badge con color y nombre del estado.
- `EnClientes` deja de filtrar en memoria y agrega la columna "Días en cliente" que ya calcula `v_garrafas_en_clientes`.

## Changes

| File | Change |
|------|--------|
| `src/ExtraGasMVC/Services/Interfaces/IGarrafaService.cs` | +2 métodos: `GetStockAsync`, `GetEnClientesAsync(ulong?)` |
| `src/ExtraGasMVC/Services/Implementations/GarrafaService.cs` | Implementa los métodos contra `VStockGarrafas` y `VGarrafasEnClientes` (ya mapeados en EF) |
| `src/ExtraGasMVC/Controllers/GarrafasController.cs` | `Stock` y `EnClientes` consumen los nuevos métodos |
| `src/ExtraGasMVC/Views/Garrafas/Stock.cshtml` | Modelo `VStockGarrafa`; badge con color y nombre del estado |
| `src/ExtraGasMVC/Views/Garrafas/EnClientes.cshtml` | Modelo `VGarrafaEnCliente`; nueva columna "Días en cliente" |
| `src/ExtraGasMVC/Models/ViewModels/DashboardViewModel.cs` | Elimina `StockGroup` (sin referencias) |

## Test Plan

- [x] `dotnet build` compila sin errores ni warnings nuevos
- [x] Smoke test contra BD: `SELECT * FROM v_stock_garrafas` devuelve filas con `estado_nombre`, `estado_codigo` y `estado_color`
- [x] Verificado que `v_garrafas_en_clientes` se ejecuta correctamente (vista vacía solo por seed sin canjes, no por bug)
- [x] Convención conventional commits respetada, sin `Co-Authored-By` trailers

## Checklist

- [x] Linked an approved issue (`status:approved` aplicado)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
- [x] Sin migraciones de BD necesarias (las vistas ya existen desde `20260102_000008_create_views.sql`)
- [x] Sin breaking changes en APIs públicas

Closes #51