### PR TITLE
feat(garrafas): paginación en Index (#52)

### DIFF
--- a/src/ExtraGasMVC/Controllers/GarrafasController.cs
+++ b/src/ExtraGasMVC/Controllers/GarrafasController.cs
@@ -72,17 +72,16 @@ public class GarrafasController : BaseController
             RecepcionesDropdownCantidad, ct);
     }
 
-    public async Task<IActionResult> Index(string? codigo, byte? capacidad, CancellationToken ct = default)
+    public async Task<IActionResult> Index(string? codigo, byte? capacidad, int page = 1, int pageSize = 20, CancellationToken ct = default)
     {
-        var garrafas = await _garrafaService.GetAllAsync(ct);
-        if (!string.IsNullOrWhiteSpace(codigo))
-            garrafas = garrafas.Where(g => g.Codigo.Contains(codigo.Trim(), StringComparison.OrdinalIgnoreCase));
-        if (capacidad.HasValue)
-            garrafas = garrafas.Where(g => g.CapacidadKg == capacidad.Value);
+        // Issue #52: el service pagina y filtra en SQL. ViewBag expone los
+        // filtros actuales para que la vista los mantenga en los links de
+        // paginación y en el form.
+        var resultado = await _garrafaService.GetPagedAsync(codigo, capacidad, page, pageSize, ct);
 
         ViewBag.Codigo = codigo;
         ViewBag.Capacidad = capacidad;
-        return View(garrafas.OrderBy(g => g.Codigo).ToList());
+        return View(resultado);
     }
 
     public async Task<IActionResult> Details(ulong id, CancellationToken ct = default)

--- a/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
@@ -4,6 +4,7 @@ using ExtraGasMVC.Data.Context;
 using ExtraGasMVC.Data.Entities;
 using ExtraGasMVC.Data.Entities.Views;
 using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Models.ViewModels;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using MySqlConnector;
@@ -93,6 +94,57 @@ public class GarrafaService : IGarrafaService
             .ToListAsync(ct);
 
         return _mapper.Map<IEnumerable<GarrafaDto>>(garrafas);
+    }
+
+    public async Task<PagedResult<GarrafaDto>> GetPagedAsync(
+        string? codigo, byte? capacidad, int page, int pageSize, CancellationToken ct = default)
+    {
+        // Normalización defensiva: page y pageSize llegan del query string
+        // (no son confiables). Si el usuario manda pageSize=10000 o page=-3,
+        // la query no debería explotar ni devolver el universo entero.
+        if (page < 1) page = 1;
+        if (pageSize < 1) pageSize = 20;
+        if (pageSize > 100) pageSize = 100;
+
+        // Issue #52: filtrado y conteo en SQL, no en memoria como hacía
+        // GetAllAsync + LINQ-to-Objects. Las navegaciones se cargan aquí
+        // mismo (mismo patrón que el resto de los Get*) para que la UI
+        // muestre nombres sin joins adicionales.
+        IQueryable<Garrafa> query = _context.Garrafas
+            .AsNoTracking()
+            .Include(g => g.EstadoGarrafa)
+            .Include(g => g.Cliente)
+            .Include(g => g.Proveedor);
+
+        if (!string.IsNullOrWhiteSpace(codigo))
+        {
+            // EF.Functions.Like compila a un LIKE nativo de MySQL. La
+            // collation utf8mb4_unicode_ci del schema ya hace la comparación
+            // case-insensitive, así que no hace falta lower() en ambos lados.
+            var pattern = $"%{codigo.Trim()}%";
+            query = query.Where(g => EF.Functions.Like(g.Codigo, pattern));
+        }
+
+        if (capacidad.HasValue)
+            query = query.Where(g => g.CapacidadKg == capacidad.Value);
+
+        // Total antes de paginar — CountAsync traduce a SELECT COUNT(*)
+        // sobre el WHERE aplicado, sin cargar filas.
+        var total = await query.CountAsync(ct);
+
+        var items = await query
+            .OrderBy(g => g.Codigo)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(ct);
+
+        return new PagedResult<GarrafaDto>
+        {
+            Items = _mapper.Map<List<GarrafaDto>>(items),
+            Page = page,
+            PageSize = pageSize,
+            Total = total
+        };
     }
 
     public async Task<IEnumerable<EstadoGarrafaDto>> GetEstadosAsync(CancellationToken ct = default)

--- a/src/ExtraGasMVC/Services/Interfaces/IGarrafaService.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IGarrafaService.cs
@@ -1,5 +1,6 @@
 using ExtraGasMVC.Data.Entities.Views;
 using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Models.ViewModels;
 
 namespace ExtraGasMVC.Services.Interfaces;
 
@@ -10,6 +11,26 @@ public interface IGarrafaService
     Task<IEnumerable<GarrafaDto>> GetAllAsync(CancellationToken ct = default);
     Task<IEnumerable<GarrafaDto>> GetByClienteAsync(ulong clienteId, CancellationToken ct = default);
     Task<IEnumerable<GarrafaDto>> GetByEstadoAsync(ulong estadoId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Devuelve una página de garrafas filtrando en SQL (no en memoria) y
+    /// contando el total de filas que satisfacen los filtros para alimentar
+    /// los controles de paginación. Usado por <c>GarrafasController.Index</c>
+    /// (issue #52). Los filtros <paramref name="codigo"/> y
+    /// <paramref name="capacidad"/> son opcionales; cuando ambos son null,
+    /// equivale a contar todas las garrafas activas (soft-deleted excluidas
+    /// por el filtro global del DbContext).
+    /// </summary>
+    /// <param name="page">Número de página 1-based. Valores &lt; 1 se
+    /// normalizan a 1.</param>
+    /// <param name="pageSize">Tamaño de página. Default 20. Se aplica un
+    /// tope máximo de 100 para evitar queries enormes accidentales.</param>
+    Task<PagedResult<GarrafaDto>> GetPagedAsync(
+        string? codigo,
+        byte? capacidad,
+        int page = 1,
+        int pageSize = 20,
+        CancellationToken ct = default);
     Task<IEnumerable<EstadoGarrafaDto>> GetEstadosAsync(CancellationToken ct = default);
     Task<GarrafaDto> CreateAsync(CreateGarrafaDto garrafa, ulong? usuarioId, CancellationToken ct = default);
     Task<GarrafaDto> UpdateAsync(UpdateGarrafaDto garrafa, ulong? usuarioId, CancellationToken ct = default);

--- a/src/ExtraGasMVC/Views/Garrafas/Index.cshtml
+++ b/src/ExtraGasMVC/Views/Garrafas/Index.cshtml
@@ -1,8 +1,38 @@
-@model IEnumerable<ExtraGasMVC.DTOs.GarrafaDto>
+@model ExtraGasMVC.Models.ViewModels.PagedResult<ExtraGasMVC.DTOs.GarrafaDto>
 @{
     ViewData["Title"] = "Garrafas";
     var codigo = ViewBag.Codigo as string;
     var capacidad = ViewBag.Capacidad as byte?;
+    var currentPage = Model.Page;
+    var totalPages = Model.TotalPages;
+    var pageSize = Model.PageSize;
+    var total = Model.Total;
+
+    // Issue #52: los links de paginación preservan los filtros en el query
+    // string para que cambiar de página no reinicie la búsqueda.
+    // asp-all-route-data requiere IDictionary<string, string>, por eso los
+    // valores van casteados a string explícitamente.
+    var routeValues = new Dictionary<string, string>();
+    if (!string.IsNullOrWhiteSpace(codigo)) routeValues["codigo"] = codigo;
+    if (capacidad.HasValue) routeValues["capacidad"] = capacidad.Value.ToString();
+
+    // Helper local: clona los filtros y agrega la página destino.
+    IDictionary<string, string> BuildPageLink(Dictionary<string, string> baseValues, int pageNumber)
+    {
+        var copy = new Dictionary<string, string>(baseValues) { ["page"] = pageNumber.ToString() };
+        return copy;
+    }
+
+    // Mostrando X-Y de Z: si total == 0 mostramos "0" en ambos extremos.
+    int firstItem = total == 0 ? 0 : ((currentPage - 1) * pageSize) + 1;
+    int lastItem = total == 0 ? 0 : Math.Min(currentPage * pageSize, total);
+
+    // Ventana de números de página centrada en la actual (max 5 botones).
+    const int windowSize = 5;
+    int startPage = Math.Max(1, currentPage - windowSize / 2);
+    int endPage = Math.Min(totalPages, startPage + windowSize - 1);
+    if (endPage - startPage + 1 < windowSize && totalPages >= windowSize)
+        startPage = Math.Max(1, endPage - windowSize + 1);
 }
 @section PageHeader {
     <div class="mb-3">
@@ -51,11 +81,11 @@
                 </tr>
             </thead>
             <tbody>
-                @if (!Model.Any())
+                @if (!Model.Items.Any())
                 {
                     <tr><td colspan="8" class="text-center py-4 text-secondary">No hay garrafas.</td></tr>
                 }
-                @foreach (var g in Model)
+                @foreach (var g in Model.Items)
                 {
                     <tr>
                         <td><strong><code>@g.Codigo</code></strong></td>
@@ -87,4 +117,35 @@
             </tbody>
         </table>
     </div>
+    @if (total > 0)
+    {
+        @* Issue #52: pie de tabla con controles de paginación. Los links
+           preservan filtros vía los routeValues del bloque superior. *@
+        <div class="card-footer d-flex flex-wrap justify-content-between align-items-center gap-2">
+            <div class="text-secondary small">
+                Mostrando <strong>@firstItem-@lastItem</strong> de <strong>@total</strong> garrafas.
+                Pagina <strong>@currentPage</strong> de <strong>@totalPages</strong>.
+            </div>
+            <nav>
+                <ul class="pagination pagination-sm mb-0">
+                    <li class="page-item @(Model.HasPrevious ? string.Empty : "disabled")">
+                        <a class="page-link" asp-action="Index" asp-all-route-data="@(BuildPageLink(routeValues, Math.Max(1, currentPage - 1)))">
+                            <i class="bi bi-chevron-left"></i> Anterior
+                        </a>
+                    </li>
+                    @for (int p = startPage; p <= endPage; p++)
+                    {
+                        <li class="page-item @(p == currentPage ? "active" : string.Empty)">
+                            <a class="page-link" asp-action="Index" asp-all-route-data="@(BuildPageLink(routeValues, p))">@p</a>
+                        </li>
+                    }
+                    <li class="page-item @(Model.HasNext ? string.Empty : "disabled")">
+                        <a class="page-link" asp-action="Index" asp-all-route-data="@(BuildPageLink(routeValues, Math.Min(totalPages, currentPage + 1)))">
+                            Siguiente <i class="bi bi-chevron-right"></i>
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+        </div>
+    }
 </div>

--- a/src/ExtraGasMVC/Views/_ViewImports.cshtml
+++ b/src/ExtraGasMVC/Views/_ViewImports.cshtml
@@ -2,4 +2,5 @@
 @using ExtraGasMVC.Models
 @using ExtraGasMVC.Models.ViewModels
 @using ExtraGasMVC.Extensions
+@using Microsoft.AspNetCore.Routing
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
## Resumen

Implementa paginación en `Garrafas/Index` para evitar cargar todas las garrafas en memoria y filtrar con LINQ to Objects (lento con miles de filas). El service ahora pagina y filtra en SQL.

## Cambios

- **`IGarrafaService` / `GarrafaService`** — nuevo `GetPagedAsync(codigo, capacidad, page, pageSize, ct)` que arma un `IQueryable<Garrafa>`, aplica los filtros opcionales, hace `CountAsync` (total) y luego `Skip/Take` sobre la página solicitada. Tope defensivo `pageSize` en 100.
- **`GarrafasController.Index`** — nueva signature con `int page = 1, int pageSize = 20`. Llama al service paginado y pasa el `PagedResult<GarrafaDto>` a la vista. Mantiene los filtros en `ViewBag` para que la vista los preserve al paginar.
- **`Views/Garrafas/Index.cshtml`** — modelo pasa a `PagedResult<GarrafaDto>`. Footer nuevo con "Mostrando X-Y de Z garrafas", "Página X de Y" y un `pagination` de AdminLTE con Anterior + rango centrado de 5 números + Siguiente. Los links preservan `codigo` y `capacidad` en el query string.
- **`Views/_ViewImports.cshtml`** — agregado `@using Microsoft.AspNetCore.Routing` (no se usaba, pero queda disponible).

## Criterios de la issue

- [x] Parámetro `int page = 1` en Index
- [x] Parámetro `int pageSize = 20` (configurable por query string, default 20)
- [x] Filtrado en BD (`IQueryable.Where` → SQL nativo, no en memoria)
- [x] Controles: Anterior, Siguiente, números de página (rango de 5 centrado en la actual)
- [x] "Página X de Y" y "Mostrando X-Y de Z garrafas"
- [x] Filtros se mantienen al cambiar de página (vía `asp-all-route-data` con `codigo`/`capacidad`)

## Cómo probar

1. `dotnet run --project src/ExtraGasMVC`
2. Ir a `/Garrafas` con la base cargada — debería verse el footer con la primera página (20 filas, página 1 de N).
3. Click "Siguiente" → debe ir a `?page=2` y mantener filtros previos si los había.
4. Probar `?page=999` con pageSize manual (`?page=999&pageSize=200`) → tope a 100 filas efectivas; el `Math.Max(1, page-1)` en "Anterior" evita números negativos.
5. Probar `?capacidad=10` → filtra en SQL, contador total refleja solo las de 10 kg.

## Notas

- El service respeta el filtro global de soft-delete (`HasQueryFilter` del DbContext) — no hace falta `Where(g => g.DeletedAt == null)`.
- Soft-deleted excluidas en el conteo y en la página.
- `pageSize > 100` se normaliza a 100 para evitar queries enormes accidentales desde el query string.

Closes #52