### PR TITLE
feat(garrafas): ordenamiento configurable en Index (#53)

### DIFF
--- a/src/ExtraGasMVC/Controllers/GarrafasController.cs
+++ b/src/ExtraGasMVC/Controllers/GarrafasController.cs
@@ -72,15 +72,24 @@ public class GarrafasController : BaseController
             RecepcionesDropdownCantidad, ct);
     }
 
-    public async Task<IActionResult> Index(string? codigo, byte? capacidad, int page = 1, int pageSize = 20, CancellationToken ct = default)
+    public async Task<IActionResult> Index(
+        string? codigo, byte? capacidad,
+        int page = 1, int pageSize = 20,
+        string sortBy = "codigo", string sortDir = "asc",
+        CancellationToken ct = default)
     {
         // Issue #52: el service pagina y filtra en SQL. ViewBag expone los
         // filtros actuales para que la vista los mantenga en los links de
         // paginación y en el form.
-        var resultado = await _garrafaService.GetPagedAsync(codigo, capacidad, page, pageSize, ct);
+        // Issue #53: sortBy/sortDir viajan del query string al service y se
+        // exponen a la vista para los headers clickeables.
+        var resultado = await _garrafaService.GetPagedAsync(
+            codigo, capacidad, page, pageSize, sortBy, sortDir, ct);
 
         ViewBag.Codigo = codigo;
         ViewBag.Capacidad = capacidad;
+        ViewBag.SortBy = sortBy;
+        ViewBag.SortDir = sortDir;
         return View(resultado);
     }
 

--- a/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
@@ -97,7 +97,9 @@ public class GarrafaService : IGarrafaService
     }
 
     public async Task<PagedResult<GarrafaDto>> GetPagedAsync(
-        string? codigo, byte? capacidad, int page, int pageSize, CancellationToken ct = default)
+        string? codigo, byte? capacidad, int page, int pageSize,
+        string sortBy = "codigo", string sortDir = "asc",
+        CancellationToken ct = default)
     {
         // Normalización defensiva: page y pageSize llegan del query string
         // (no son confiables). Si el usuario manda pageSize=10000 o page=-3,
@@ -132,8 +134,45 @@ public class GarrafaService : IGarrafaService
         // sobre el WHERE aplicado, sin cargar filas.
         var total = await query.CountAsync(ct);
 
-        var items = await query
-            .OrderBy(g => g.Codigo)
+        // Issue #53: ordenar por el campo pedido. Defaults seguros (cualquier
+        // sortBy desconocido cae a "codigo", cualquier sortDir != "desc" a
+        // "asc"). Cada case arma el IOrderedQueryable en su tipo concreto para
+        // que EF genere SQL específico por campo — no usamos reflection ni
+        // expression trees dinámicas porque romperían la traducción a SQL.
+        // ThenBy(Id) en todos los casos = tiebreaker estable para paginación.
+        var desc = string.Equals(sortDir, "desc", StringComparison.OrdinalIgnoreCase);
+        IOrderedQueryable<Garrafa> ordered = sortBy.ToLowerInvariant() switch
+        {
+            "capacidad" => desc
+                ? query.OrderByDescending(g => g.CapacidadKg).ThenBy(g => g.Id)
+                : query.OrderBy(g => g.CapacidadKg).ThenBy(g => g.Id),
+            "estado" => desc
+                ? query.OrderByDescending(g => g.EstadoGarrafa!.Nombre).ThenBy(g => g.Id)
+                : query.OrderBy(g => g.EstadoGarrafa!.Nombre).ThenBy(g => g.Id),
+            // Cliente es nullable: ordenar por Apellido, luego Nombre. EF
+            // traduce el acceso a navegación como LEFT JOIN; las filas sin
+            // cliente quedan con NULL y MySQL las pone al inicio en ASC.
+            "cliente" => desc
+                ? query.OrderByDescending(g => g.Cliente!.Apellido)
+                       .ThenByDescending(g => g.Cliente!.Nombre)
+                       .ThenBy(g => g.Id)
+                : query.OrderBy(g => g.Cliente!.Apellido)
+                       .ThenBy(g => g.Cliente!.Nombre)
+                       .ThenBy(g => g.Id),
+            "fechacompra" => desc
+                ? query.OrderByDescending(g => g.FechaCompra).ThenBy(g => g.Id)
+                : query.OrderBy(g => g.FechaCompra).ThenBy(g => g.Id),
+            // FechaUltimoMovimiento es DateTime? — los NULL van primero en ASC
+            // (semántica de MySQL), lo cual es razonable para "último mov."
+            "ultimomov" => desc
+                ? query.OrderByDescending(g => g.FechaUltimoMovimiento).ThenBy(g => g.Id)
+                : query.OrderBy(g => g.FechaUltimoMovimiento).ThenBy(g => g.Id),
+            "codigo" or _ => desc
+                ? query.OrderByDescending(g => g.Codigo).ThenBy(g => g.Id)
+                : query.OrderBy(g => g.Codigo).ThenBy(g => g.Id),
+        };
+
+        var items = await ordered
             .Skip((page - 1) * pageSize)
             .Take(pageSize)
             .ToListAsync(ct);

--- a/src/ExtraGasMVC/Services/Interfaces/IGarrafaService.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IGarrafaService.cs
@@ -25,11 +25,25 @@ public interface IGarrafaService
     /// normalizan a 1.</param>
     /// <param name="pageSize">Tamaño de página. Default 20. Se aplica un
     /// tope máximo de 100 para evitar queries enormes accidentales.</param>
+    /// <param name="sortBy">
+    /// Campo por el que se ordena la página. Valores reconocidos:
+    /// <c>codigo</c> (default), <c>capacidad</c>, <c>estado</c>,
+    /// <c>cliente</c>, <c>fechacompra</c>, <c>ultimomov</c>. Cualquier otro
+    /// valor cae al default (issue #53).
+    /// </param>
+    /// <param name="sortDir">
+    /// <c>asc</c> o <c>desc</c>. Cualquier otro valor cae a <c>asc</c>.
+    /// El ordenamiento por <c>cliente</c> usa apellido + nombre como
+    /// desempate; todos los campos llevan <c>Id</c> como tiebreaker para
+    /// que la paginación sea estable entre requests.
+    /// </param>
     Task<PagedResult<GarrafaDto>> GetPagedAsync(
         string? codigo,
         byte? capacidad,
         int page = 1,
         int pageSize = 20,
+        string sortBy = "codigo",
+        string sortDir = "asc",
         CancellationToken ct = default);
     Task<IEnumerable<EstadoGarrafaDto>> GetEstadosAsync(CancellationToken ct = default);
     Task<GarrafaDto> CreateAsync(CreateGarrafaDto garrafa, ulong? usuarioId, CancellationToken ct = default);

--- a/src/ExtraGasMVC/Views/Garrafas/Index.cshtml
+++ b/src/ExtraGasMVC/Views/Garrafas/Index.cshtml
@@ -3,6 +3,8 @@
     ViewData["Title"] = "Garrafas";
     var codigo = ViewBag.Codigo as string;
     var capacidad = ViewBag.Capacidad as byte?;
+    var sortBy = ViewBag.SortBy as string ?? "codigo";
+    var sortDir = ViewBag.SortDir as string ?? "asc";
     var currentPage = Model.Page;
     var totalPages = Model.TotalPages;
     var pageSize = Model.PageSize;
@@ -10,9 +12,15 @@
 
     // Issue #52: los links de paginación preservan los filtros en el query
     // string para que cambiar de página no reinicie la búsqueda.
+    // Issue #53: también preservan el orden activo (sortBy/sortDir) para
+    // que cambiar de página no reinicie el orden.
     // asp-all-route-data requiere IDictionary<string, string>, por eso los
     // valores van casteados a string explícitamente.
-    var routeValues = new Dictionary<string, string>();
+    var routeValues = new Dictionary<string, string>
+    {
+        ["sortBy"] = sortBy,
+        ["sortDir"] = sortDir
+    };
     if (!string.IsNullOrWhiteSpace(codigo)) routeValues["codigo"] = codigo;
     if (capacidad.HasValue) routeValues["capacidad"] = capacidad.Value.ToString();
 
@@ -21,6 +29,38 @@
     {
         var copy = new Dictionary<string, string>(baseValues) { ["page"] = pageNumber.ToString() };
         return copy;
+    }
+
+    // Issue #53: helper para construir los routeValues de un click de sort.
+    // - Si la columna clickeada ya es la activa: toggle de dirección.
+    // - Si es otra columna: arranca en asc.
+    // - page=1 siempre: cambiar de orden vuelve a la primera página, así no
+    //   dejamos al usuario en una página que podría quedar vacía con el
+    //   nuevo orden.
+    Dictionary<string, string> BuildSortLink(string column)
+    {
+        var copy = new Dictionary<string, string>(routeValues)
+        {
+            ["sortBy"] = column,
+            ["sortDir"] = column == sortBy && sortDir == "asc" ? "desc" : "asc",
+            ["page"] = "1"
+        };
+        return copy;
+    }
+
+    // Issue #53: ícono indicador del orden actual. La columna activa muestra
+    // la flecha correspondiente; las demás muestran un ícono atenuado de
+    // "ordenable" para sugerir visualmente que son clickeables.
+    // HtmlString se referencia con namespace completo porque _ViewImports no
+    // importa Microsoft.AspNetCore.Html (no queremos tocar el global por
+    // una sola vista).
+    Microsoft.AspNetCore.Html.IHtmlContent SortIcon(string column)
+    {
+        if (column == sortBy)
+            return new Microsoft.AspNetCore.Html.HtmlString(
+                $"<i class=\"bi bi-arrow-{(sortDir == "asc" ? "up" : "down")}\"></i>");
+        return new Microsoft.AspNetCore.Html.HtmlString(
+            "<i class=\"bi bi-arrow-down-up text-secondary opacity-50\"></i>");
     }
 
     // Mostrando X-Y de Z: si total == 0 mostramos "0" en ambos extremos.
@@ -64,19 +104,49 @@
                 <button type="submit" class="btn btn-primary flex-fill"><i class="bi bi-search me-1"></i>Buscar</button>
                 <a asp-action="Index" class="btn btn-outline-secondary"><i class="bi bi-arrow-counterclockwise"></i></a>
             </div>
+            @* Issue #53: hidden inputs para que el submit del filtro conserve
+               el orden activo. Sin esto, aplicar un filtro resetea el sort. *@
+            <input type="hidden" name="sortBy" value="@sortBy" />
+            <input type="hidden" name="sortDir" value="@sortDir" />
         </form>
     </div>
     <div class="card-body table-responsive p-0">
         <table class="table table-hover table-striped align-middle mb-0">
             <thead>
                 <tr>
-                    <th>Codigo</th>
-                    <th class="text-end">Capacidad (kg)</th>
-                    <th>Estado</th>
-                    <th>Cliente</th>
+                    @* Issue #53: cada th es un link que cambia el sort. El
+                       helper BuildSortLink preserva filtros y resetea page=1. *@
+                    <th>
+                        <a asp-action="Index" asp-all-route-data="@BuildSortLink("codigo")" class="text-decoration-none text-body">
+                            Codigo @SortIcon("codigo")
+                        </a>
+                    </th>
+                    <th class="text-end">
+                        <a asp-action="Index" asp-all-route-data="@BuildSortLink("capacidad")" class="text-decoration-none text-body">
+                            Capacidad (kg) @SortIcon("capacidad")
+                        </a>
+                    </th>
+                    <th>
+                        <a asp-action="Index" asp-all-route-data="@BuildSortLink("estado")" class="text-decoration-none text-body">
+                            Estado @SortIcon("estado")
+                        </a>
+                    </th>
+                    <th>
+                        <a asp-action="Index" asp-all-route-data="@BuildSortLink("cliente")" class="text-decoration-none text-body">
+                            Cliente @SortIcon("cliente")
+                        </a>
+                    </th>
                     <th>Proveedor</th>
-                    <th>F. compra</th>
-                    <th>F. ultimo mov.</th>
+                    <th>
+                        <a asp-action="Index" asp-all-route-data="@BuildSortLink("fechacompra")" class="text-decoration-none text-body">
+                            F. compra @SortIcon("fechacompra")
+                        </a>
+                    </th>
+                    <th>
+                        <a asp-action="Index" asp-all-route-data="@BuildSortLink("ultimomov")" class="text-decoration-none text-body">
+                            F. ultimo mov. @SortIcon("ultimomov")
+                        </a>
+                    </th>
                     <th class="text-end" style="width: 180px;">Acciones</th>
                 </tr>
             </thead>
@@ -120,7 +190,8 @@
     @if (total > 0)
     {
         @* Issue #52: pie de tabla con controles de paginación. Los links
-           preservan filtros vía los routeValues del bloque superior. *@
+           preservan filtros y (issue #53) sortBy/sortDir vía los
+           routeValues del bloque superior. *@
         <div class="card-footer d-flex flex-wrap justify-content-between align-items-center gap-2">
             <div class="text-secondary small">
                 Mostrando <strong>@firstItem-@lastItem</strong> de <strong>@total</strong> garrafas.


### PR DESCRIPTION
## Resumen

Implementa ordenamiento configurable en el Index de garrafas (issue #53). El usuario ahora puede ordenar el listado por código, capacidad, estado, cliente, fecha de compra o último movimiento, tanto ascendente como descendente.

## Cambios

**Service (`GarrafaService.GetPagedAsync`)**
- Nuevos parámetros `sortBy = "codigo"` y `sortDir = "asc"` (defaults seguros — cualquier valor inválido cae al default, no rompe la query).
- Switch tipado por campo que arma el `IOrderedQueryable` en cada case. Cada case usa el `OrderBy/OrderByDescending` específico del campo para que EF genere SQL limpio, sin expression trees dinámicas.
- Todos los casos llevan `ThenBy(g => g.Id)` como tiebreaker para paginación estable entre requests.

**Controller (`GarrafasController.Index`)**
- Agrega `sortBy` y `sortDir` a la firma, los pasa al service y los expone en `ViewBag`.

**Vista (`Views/Garrafas/Index.cshtml`)**
- Headers clickeables: cada `<th>` ahora es un anchor que llama al helper `BuildSortLink`, que arma los routeValues preservando filtros y reseteando a `page=1`.
- Toggle asc/desc al re-clickear la misma columna; otras columnas arrancan en asc.
- Iconos: `bi-arrow-up` / `bi-arrow-down` para la columna activa, `bi-arrow-down-up` atenuado para las demás (señal visual de "ordenable").
- `sortBy`/`sortDir` se preservan en la paginación (vienen en `routeValues`) y como hidden inputs en el form de filtros para que aplicar un filtro no resetee el orden.

## Detalles técnicos

- **Cliente es nullable**: ordenar por `Cliente.Apellido` y `Cliente.Nombre` funciona vía LEFT JOIN de EF; las garrafas sin cliente quedan con NULL y MySQL las pone al inicio en ASC (semántica estándar).
- **`FechaUltimoMovimiento` es `DateTime?`**: las garrafas sin movimiento quedan con NULL, igual que cliente. MySQL pone NULLs primero en ASC.
- **Sin nuevos archivos**: el cambio se concentra en service + controller + una sola vista.
- **Build**: pasa sin warnings nuevos (los 3 warnings son pre-existentes: AutoMapper 12.0.1 vulnerable y un null-deref en `Recepciones/Create.cshtml` que no toqué).

## Cómo probarlo

1. Levantar la app y entrar a `/Garrafas`.
2. Click en cada header — debe alternar asc/desc y mostrar la flecha correspondiente.
3. Aplicar un filtro (ej. capacidad 10 kg) — el orden debe sobrevivir al submit.
4. Cambiar de página con el orden activo — debe mantener el orden entre páginas.
5. Probar `?sortBy=basura&sortDir=lateral` por URL — debe comportarse como `codigo`/`asc` (defaults).

## Issue

Closes #53