### PR TITLE
feat(garrafas): confirmación de eliminación con SweetAlert2 (#54)

### DIFF
--- a/src/ExtraGasMVC/Controllers/GarrafasController.cs
+++ b/src/ExtraGasMVC/Controllers/GarrafasController.cs
@@ -311,9 +311,14 @@ public class GarrafasController : BaseController
     [ActionName("Delete")]
     public async Task<IActionResult> DeleteConfirmed(ulong id, CancellationToken ct = default)
     {
+        // Issue #54: confirmación se hace en Index vía SweetAlert2 (helper
+        // confirmarAccion), por eso el flujo siempre vuelve a Index. Si la
+        // garrafa está en estado bloqueado (EN_CLIENTE / EN_TRANSITO) el
+        // service tira InvalidOperationException y mostramos el motivo en
+        // TempData para que el usuario sepa por qué no se eliminó.
         try
         {
-            var ok = await _garrafaService.DeleteAsync(id, ct);
+            var ok = await _garrafaService.DeleteAsync(id, GetCurrentUserId(), ct);
             if (!ok) return NotFound();
             TempData["Success"] = "Garrafa eliminada correctamente.";
             return RedirectToAction(nameof(Index));
@@ -321,12 +326,12 @@ public class GarrafasController : BaseController
         catch (InvalidOperationException ex)
         {
             TempData["Error"] = ex.Message;
-            return RedirectToAction(nameof(Delete), new { id });
+            return RedirectToAction(nameof(Index));
         }
         catch (Exception ex)
         {
             TempData["Error"] = $"No se pudo eliminar la garrafa: {ex.Message}";
-            return RedirectToAction(nameof(Delete), new { id });
+            return RedirectToAction(nameof(Index));
         }
     }
 }

--- a/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
@@ -368,7 +368,7 @@ public class GarrafaService : IGarrafaService
         return _mapper.Map<IEnumerable<EstadoGarrafaDto>>(destinos);
     }
 
-    public async Task<bool> DeleteAsync(ulong id, CancellationToken ct = default)
+    public async Task<bool> DeleteAsync(ulong id, ulong? updatedBy, CancellationToken ct = default)
     {
         var garrafa = await _context.Garrafas
             .IgnoreQueryFilters()
@@ -388,9 +388,12 @@ public class GarrafaService : IGarrafaService
             throw new InvalidOperationException(
                 $"No se puede eliminar una garrafa en estado {estadoCodigo}. Primero cambie su estado.");
 
+        // Issue #54: registrar quién ejecuta la baja para auditoría (mismo
+        // criterio que ClienteService.DeleteAsync).
         garrafa.DeletedAt = DateTime.UtcNow;
         garrafa.Activo = false;
         garrafa.UpdatedAt = DateTime.UtcNow;
+        garrafa.UpdatedBy = updatedBy;
 
         await _context.SaveChangesAsync(ct);
 

--- a/src/ExtraGasMVC/Services/Interfaces/IGarrafaService.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IGarrafaService.cs
@@ -49,7 +49,17 @@ public interface IGarrafaService
     Task<GarrafaDto> CreateAsync(CreateGarrafaDto garrafa, ulong? usuarioId, CancellationToken ct = default);
     Task<GarrafaDto> UpdateAsync(UpdateGarrafaDto garrafa, ulong? usuarioId, CancellationToken ct = default);
     Task<bool> CambiarEstadoAsync(ulong id, CambiarEstadoGarrafaDto dto, ulong? currentUserId = null, CancellationToken ct = default);
-    Task<bool> DeleteAsync(ulong id, CancellationToken ct = default);
+    /// <summary>
+    /// Soft-delete de la garrafa: setea <c>deleted_at</c>, baja <c>activo</c> y
+    /// actualiza <c>updated_at</c>/<c>updated_by</c>. Bloquea garrafas en estado
+    /// EN_CLIENTE o EN_TRANSITO para preservar la trazabilidad de movimientos
+    /// de canje (ver <c>DECISIONES.md</c>, regla de tracking individual).
+    /// </summary>
+    /// <param name="updatedBy">
+    /// <c>UserId</c> que ejecuta la baja. Queda registrado en <c>updated_by</c>
+    /// para auditoría. Coincide con la firma de <see cref="IClienteService.DeleteAsync"/>.
+    /// </param>
+    Task<bool> DeleteAsync(ulong id, ulong? updatedBy, CancellationToken ct = default);
 
     /// <summary>
     /// Returns the catalog rows for the destination states that the given

--- a/src/ExtraGasMVC/Views/Garrafas/Index.cshtml
+++ b/src/ExtraGasMVC/Views/Garrafas/Index.cshtml
@@ -180,7 +180,21 @@
                         <td class="text-end">
                             <a asp-action="Details" asp-route-id="@g.Id" class="btn btn-sm btn-info" title="Ver"><i class="bi bi-eye"></i></a>
                             <a asp-action="Edit" asp-route-id="@g.Id" class="btn btn-sm btn-primary" title="Editar"><i class="bi bi-pencil"></i></a>
-                            <a asp-action="Delete" asp-route-id="@g.Id" class="btn btn-sm btn-danger" title="Eliminar"><i class="bi bi-trash"></i></a>
+                            @* Issue #54: confirmación con SweetAlert2 (mismo patrón
+                               que Clientes/Proveedores/Empleados). El form apunta
+                               a Delete (POST) y el helper global confirmarAccion
+                               gatilla el Swal antes de submitear. Solo se muestra
+                               para garrafas activas — las dadas de baja (soft-delete)
+                               no deberían volver a eliminarse desde acá. *@
+                            @if (g.Activo)
+                            {
+                                <form asp-action="Delete" asp-route-id="@g.Id" method="post" class="d-inline js-confirm-form" data-name="esta garrafa">
+                                    @Html.AntiForgeryToken()
+                                    <button type="button" class="btn btn-sm btn-danger" title="Eliminar" onclick="confirmarAccion(this)">
+                                        <i class="bi bi-trash"></i>
+                                    </button>
+                                </form>
+                            }
                         </td>
                     </tr>
                 }


### PR DESCRIPTION
## Issue

Closes #54

## Resumen

Reemplaza el link directo a la página de confirmación `Delete` por un **form POST con SweetAlert2** inline en el Index de Garrafas, usando el helper global `confirmarAccion` (mismo patrón que Clientes, Proveedores y Empleados).

## Cambios

- **`Views/Garrafas/Index.cshtml`** — botón "Eliminar" reemplazado por `<form js-confirm-form>` con `@Html.AntiForgeryToken()` y `onclick="confirmarAccion(this)"`. Solo se renderiza para garrafas activas (`g.Activo`).
- **`IGarrafaService.DeleteAsync`** — la firma ahora recibe `ulong? updatedBy` (alineada con `IClienteService.DeleteAsync`).
- **`GarrafaService.DeleteAsync`** — setea `garrafa.UpdatedBy = updatedBy` para auditoría de quién ejecutó la baja.
- **`GarrafasController.DeleteConfirmed`** — pasa `GetCurrentUserId()`, y los errores (incluido el caso de estado bloqueado EN_CLIENTE / EN_TRANSITO) redirigen a Index con `TempData["Error"]` → toast SweetAlert2, ya que la confirmación vive en Index.

## Criterios de aceptación (issue #54)

- [x] Botón "Eliminar" en cada fila activa de Index
- [x] Click muestra SweetAlert2 de confirmación (vía helper `confirmarAccion`)
- [x] Al confirmar, ejecuta POST a `/Garrafas/Delete/{id}` (form con antiforgery)
- [x] Consistencia con Clientes, Proveedores, Empleados (mismo helper, mismas clases CSS, mismo flujo)

## Bonus (alineado con el criterio "consistencia")

- Auditoría: ahora `updated_by` se setea en el soft-delete (antes quedaba en NULL aunque la app sabía quién lo ejecutó).

## Cómo verificar

1. Levantar MySQL + `dotnet run --project src/ExtraGasMVC`.
2. Navegar a `/Garrafas`.
3. Click en el botón rojo de tacho de una fila activa → debería aparecer el SweetAlert2 "¿Eliminar esta garrafa?".
4. Confirmar → toast de éxito y la fila desaparece del Index.
5. Para una garrafa EN_CLIENTE o EN_TRANSITO: el POST devuelve redirect a Index con toast de error explicando el motivo.

## Notas

- El view `Views/Garrafas/Delete.cshtml` queda accesible vía URL directa (GET `/Garrafas/Delete/{id}`) como fallback. No se elimina para mantener compatibilidad con cualquier link externo o bookmark; un cleanup posterior puede removerlo si se decide.
- Build verde: `dotnet build` exit 0, 0 errores.