### PR TITLE
fix(garrafas): loguear error antes de rollback en CambiarEstadoAsync

### DIFF
--- a/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
@@ -7,6 +7,7 @@ using ExtraGasMVC.DTOs;
 using ExtraGasMVC.Models.ViewModels;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using MySqlConnector;
 
 namespace ExtraGasMVC.Services.Implementations;
@@ -15,11 +16,13 @@ public class GarrafaService : IGarrafaService
 {
     private readonly ExtraGasDbContext _context;
     private readonly IMapper _mapper;
+    private readonly ILogger<GarrafaService> _logger;
 
-    public GarrafaService(ExtraGasDbContext context, IMapper mapper)
+    public GarrafaService(ExtraGasDbContext context, IMapper mapper, ILogger<GarrafaService> logger)
     {
         _context = context;
         _mapper = mapper;
+        _logger = logger;
     }
 
     public async Task<GarrafaDto?> GetByIdAsync(ulong id, CancellationToken ct = default)
@@ -330,8 +333,15 @@ public class GarrafaService : IGarrafaService
 
             return true;
         }
-        catch
+        catch (Exception ex)
         {
+            // Issue #56: registrar el error antes del rollback para auditoría
+            // y diagnóstico — sin este log, un fallo transaccional queda invisible
+            // porque la excepción se re-lanza pero la causa queda enterrada en
+            // logs internos de MySQL/EF que no llegan al operador.
+            _logger.LogError(ex,
+                "Error al cambiar estado de la garrafa {GarrafaId} (origen={EstadoOrigenId}, destino={EstadoDestinoId}). Se realiza rollback de la transacción.",
+                id, estadoOrigen, dto.NuevoEstadoId);
             await transaction.RollbackAsync(ct);
             throw;
         }


### PR DESCRIPTION
## Resumen

Agrega `ILogger<GarrafaService>` y registra el error antes del rollback en `CambiarEstadoAsync`. La transacción explícita ya existía desde el cierre de #36 (commit `e900ac2`); solo faltaba el log de error.

## Cambios

| Archivo | Cambio |
|---|---|
| `src/ExtraGasMVC/Services/Implementations/GarrafaService.cs` | Inyectar `ILogger<GarrafaService>` y emitir `LogError` con `garrafaId` / estado origen / estado destino antes del `RollbackAsync` en `CambiarEstadoAsync`. |

## Detalle

- **Criterio #56.1** (transacción explícita) → ya estaba desde #36.
- **Criterio #56.2** (cambio + creación de movimiento en la transacción) → ya estaba desde #36.
- **Criterio #56.3** (`CommitAsync` al final) → ya estaba desde #36.
- **Criterio #56.4** (rollback automático en fallo) → ya estaba desde #36.
- **Criterio #56.5** (log de error antes del rollback) → **implementado en este PR**.

```csharp
catch (Exception ex)
{
    _logger.LogError(ex,
        "Error al cambiar estado de la garrafa {GarrafaId} (origen={EstadoOrigenId}, destino={EstadoDestinoId}). Se realiza rollback de la transacción.",
        id, estadoOrigen, dto.NuevoEstadoId);
    await transaction.RollbackAsync(ct);
    throw;
}
```

## Plan de prueba

- [x] `dotnet build` sin errores (warnings pre-existentes no relacionados).
- [ ] Cambio manual: forzar fallo en el `SaveChangesAsync` (p. ej. violando una FK o un CHECK del trigger) y verificar que aparece el log con la `garrafaId` y los IDs de estado, y que el rollback deja la fila sin cambios.
- [ ] Verificar que `movimientos_garrafa` no recibe el INSERT cuando falla la transacción (atomicidad).

## Notas

- Riesgo: medio (toca un camino transaccional crítico). El cambio es aditivo: agrega un log sin modificar la lógica de éxito.
- Sin cambios de esquema, sin migraciones, sin cambios de API pública.

Closes #56