### PR TITLE
[#57] feat: validaciones de modelo en DTOs de garrafas

### DIFF
--- a/src/ExtraGasMVC/DTOs/GarrafaDto.cs
+++ b/src/ExtraGasMVC/DTOs/GarrafaDto.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace ExtraGasMVC.DTOs;
 
 public class GarrafaDto
@@ -48,28 +50,67 @@ public class GarrafaDto
 
 public class CreateGarrafaDto
 {
+    [Display(Name = "Código")]
+    [Required(ErrorMessage = "El código es obligatorio.")]
+    [MaxLength(50, ErrorMessage = "El código no puede superar 50 caracteres.")]
     public string Codigo { get; set; } = null!;
+
+    [Display(Name = "Capacidad (kg)")]
+    [Required(ErrorMessage = "La capacidad es obligatoria.")]
+    [Range(10, 45, ErrorMessage = "La capacidad debe estar entre 10 y 45 kg.")]
     public byte CapacidadKg { get; set; }
+
     public ulong? ProveedorId { get; set; }
+
     public ulong? RecepcionId { get; set; }
+
+    [Display(Name = "Fecha de compra")]
+    [Required(ErrorMessage = "La fecha de compra es obligatoria.")]
     public DateOnly FechaCompra { get; set; }
+
+    [Display(Name = "Estado")]
+    [Required(ErrorMessage = "El estado de la garrafa es obligatorio.")]
+    [Range(1, ulong.MaxValue, ErrorMessage = "Seleccione un estado válido.")]
     public ulong EstadoGarrafaId { get; set; }
+
     public ulong? ClienteId { get; set; }
+
     public bool Activo { get; set; }
+
     public string? Observaciones { get; set; }
 }
 
 public class UpdateGarrafaDto
 {
     public ulong Id { get; set; }
+
+    [Display(Name = "Código")]
+    [Required(ErrorMessage = "El código es obligatorio.")]
+    [MaxLength(50, ErrorMessage = "El código no puede superar 50 caracteres.")]
     public string Codigo { get; set; } = null!;
+
+    [Display(Name = "Capacidad (kg)")]
+    [Required(ErrorMessage = "La capacidad es obligatoria.")]
+    [Range(10, 45, ErrorMessage = "La capacidad debe estar entre 10 y 45 kg.")]
     public byte CapacidadKg { get; set; }
+
     public ulong? ProveedorId { get; set; }
+
     public ulong? RecepcionId { get; set; }
+
+    [Display(Name = "Fecha de compra")]
+    [Required(ErrorMessage = "La fecha de compra es obligatoria.")]
     public DateOnly FechaCompra { get; set; }
+
+    [Display(Name = "Estado")]
+    [Required(ErrorMessage = "El estado de la garrafa es obligatorio.")]
+    [Range(1, ulong.MaxValue, ErrorMessage = "Seleccione un estado válido.")]
     public ulong EstadoGarrafaId { get; set; }
+
     public ulong? ClienteId { get; set; }
+
     public bool Activo { get; set; }
+
     public string? Observaciones { get; set; }
 }
 

--- a/src/ExtraGasMVC/Views/Garrafas/Create.cshtml
+++ b/src/ExtraGasMVC/Views/Garrafas/Create.cshtml
@@ -26,6 +26,7 @@
                 <div class="col-md-3">
                     <label asp-for="Codigo" class="form-label"></label> <span class="text-danger">*</span>
                     <input asp-for="Codigo" class="form-control" required />
+                    <span asp-validation-for="Codigo" class="text-danger small"></span>
                 </div>
                 <div class="col-md-2">
                     <label asp-for="CapacidadKg" class="form-label"></label> <span class="text-danger">*</span>
@@ -35,6 +36,7 @@
                         <option value="15">15 kg</option>
                         <option value="45">45 kg</option>
                     </select>
+                    <span asp-validation-for="CapacidadKg" class="text-danger small"></span>
                 </div>
                 <div class="col-md-3">
                     <label asp-for="EstadoGarrafaId" class="form-label"></label> <span class="text-danger">*</span>
@@ -45,10 +47,12 @@
                             <option value="@e.Id">@e.Nombre</option>
                         }
                     </select>
+                    <span asp-validation-for="EstadoGarrafaId" class="text-danger small"></span>
                 </div>
                 <div class="col-md-4">
                     <label asp-for="FechaCompra" class="form-label"></label> <span class="text-danger">*</span>
                     <input asp-for="FechaCompra" type="date" class="form-control" required />
+                    <span asp-validation-for="FechaCompra" class="text-danger small"></span>
                 </div>
                 <div class="col-md-6">
                     <label asp-for="ProveedorId" class="form-label"></label>

--- a/src/ExtraGasMVC/Views/Garrafas/Edit.cshtml
+++ b/src/ExtraGasMVC/Views/Garrafas/Edit.cshtml
@@ -28,6 +28,7 @@
                 <div class="col-md-3">
                     <label asp-for="Codigo" class="form-label"></label> <span class="text-danger">*</span>
                     <input asp-for="Codigo" class="form-control" required />
+                    <span asp-validation-for="Codigo" class="text-danger small"></span>
                 </div>
                 <div class="col-md-2">
                     <label asp-for="CapacidadKg" class="form-label"></label> <span class="text-danger">*</span>
@@ -37,6 +38,7 @@
                         <option value="15">15 kg</option>
                         <option value="45">45 kg</option>
                     </select>
+                    <span asp-validation-for="CapacidadKg" class="text-danger small"></span>
                 </div>
                 <div class="col-md-3">
                     <label asp-for="EstadoGarrafaId" class="form-label"></label> <span class="text-danger">*</span>
@@ -47,10 +49,12 @@
                             <option value="@e.Id">@e.Nombre</option>
                         }
                     </select>
+                    <span asp-validation-for="EstadoGarrafaId" class="text-danger small"></span>
                 </div>
                 <div class="col-md-4">
                     <label asp-for="FechaCompra" class="form-label"></label> <span class="text-danger">*</span>
                     <input asp-for="FechaCompra" type="date" class="form-control" required />
+                    <span asp-validation-for="FechaCompra" class="text-danger small"></span>
                 </div>
                 <div class="col-md-6">
                     <label asp-for="ClienteId" class="form-label"></label>


### PR DESCRIPTION
## Resumen

Agrega validaciones de modelo en `CreateGarrafaDto` y `UpdateGarrafaDto` y renderiza los mensajes por campo en las vistas Create/Edit.

## Cambios

### `src/ExtraGasMVC/DTOs/GarrafaDto.cs`

- `using System.ComponentModel.DataAnnotations`.
- `CreateGarrafaDto` y `UpdateGarrafaDto` ahora declaran:
  - `Codigo` → `[Required]` + `[MaxLength(50)]`
  - `CapacidadKg` → `[Required]` + `[Range(10, 45)]`
  - `FechaCompra` → `[Required]`
  - `EstadoGarrafaId` → `[Required]` + `[Range(1, ulong.MaxValue)]`
- Mensajes de error en español consistentes con el resto del repo.
- `[Display(Name = "...")]` en los campos validados.

### `src/ExtraGasMVC/Views/Garrafas/Create.cshtml` y `Edit.cshtml`

- `<span asp-validation-for="..." class="text-danger small">` debajo de `Codigo`, `CapacidadKg`, `EstadoGarrafaId` y `FechaCompra` para que los mensajes de `ModelState` se rendericen junto a cada input.
- El `<div asp-validation-summary="ModelOnly">` ya existía en ambas vistas; no se duplica.

## Criterios de Aceptación (issue #57)

- [x] `[Required]` en `Codigo`, `CapacidadKg`, `FechaCompra`, `EstadoGarrafaId`
- [x] `[MaxLength(50)]` en `Codigo`
- [x] `[Range(10, 45)]` en `CapacidadKg`
- [x] Mensajes de error en español
- [x] Mensajes visibles en la UI (no solo en `ModelState`)

## Validación

- `dotnet build` sin errores ni warnings nuevos (solo se mantienen los warnings preexistentes de `AutoMapper` 12.0.1 y `Recepciones/Create.cshtml`).
- No se modificaron firmas públicas ni lógica de Controller/Service.

Refs #57