### PR TITLE
fix(db): harden install.sh + migrations for idempotency, document MySQL 8.4 support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Sistema de gestión para una empresa familiar de **venta de gas envasado (garraf
 ## Stack
 
 ### Base de datos
-- **MySQL 9.6.0** (Homebrew, servicio `homebrew.mxcl.mysql`).
+- **MySQL 8.4 LTS** soportado como target (dev actual en homelab). MySQL 9.x sigue siendo compatible (sintaxis portable). Ver ADR #11 en `db/docs/DECISIONES.md`.
 - **InnoDB** en todas las tablas, `utf8mb4` / `utf8mb4_unicode_ci`.
 - **Time zone**: `America/Argentina/Buenos_Aires` (-03:00).
 
@@ -158,12 +158,15 @@ src/ExtraGasMVC/                    proyecto ASP.NET Core MVC (.NET 10.0)
 
 ## Gotchas
 
-- MySQL 9.6 está instalado vía Homebrew pero el servicio **no arranca automáticamente** después de reiniciar la Mac. Si `mysqladmin -uroot ping` falla, correr `brew services start mysql`.
+- El entorno actual apunta a un **homelab** (`192.168.0.216`) con MySQL 8.4.11, no a un server local. El cliente MySQL (`brew install mysql-client`) está en keg-only y requiere agregar `/opt/homebrew/opt/mysql-client/bin` al PATH.
+- Si `mysqladmin ping` (sin env vars) tira "Can't connect to local MySQL server through socket", es porque no pasaste `MYSQL_HOST` — el default es `localhost`. Exportá `MYSQL_HOST=tu_server` antes de correr el script.
+- El user `extragas` en el homelab requiere grants especiales para que `install.sh` corra: `GRANT SYSTEM_VARIABLES_ADMIN ON *.* TO 'extragas'@'192.168.0.%'` y `SET GLOBAL log_bin_trust_function_creators = 1` (binlog activo en MySQL 8.x con replicación).
+- Si el cliente está en Apple Silicon y Homebrew no está, instalalo con `brew install mysql-client` (sin server).
 - El socket queda en `/tmp/mysql.sock` (no en `/var/mysql/`). Si una app cliente se queja, exportar `TMPDIR=/tmp`.
-- `mysql_upgrade` no es necesario: BD recién creada en 9.6.
-- `install.sh` es **idempotente** (no borra datos). Para empezar de cero en dev, usar `db/scripts/reset.sh`, que sí hace `DROP DATABASE` y vuelve a correr todo.
+- `install.sh` es **idempotente** sobre la estructura inicial (CREATE TABLE/VIEW/TRIGGER con IF NOT EXISTS) y sobre las migraciones incrementales que usan el patrón `information_schema` + `PREPARE`/`EXECUTE` o `INSERT IGNORE`. Si una migración nueva no es idempotente, falla en re-run con "Table/Column already exists" o "Duplicate key". Ver ADR #13 en `db/docs/DECISIONES.md` para el patrón correcto.
 - La migración de seed (`20260102_000009_seed_data.sql`) inlina las 24 provincias argentinas. El archivo `db/seed/provincias_argentina.sql` se conserva como referencia documental.
 - Los triggers usan `SIGNAL SQLSTATE` para validar; si la app recibe un error, traducirlo desde la capa de UI.
+- En passwords de BD, evitá caracteres que bash expanda (`$`, `*`, `!`, espacios). Si los necesitás, exportá con comillas simples: `MYSQL_PASS='Pa$$W0rd'`.
 
 ## Consultas frecuentes (smoke test)
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Los pedidos, recibos de pago e informes generados por el sistema podrán emitirs
 
 ## Stack técnico
 
-- **MySQL 9.6.0** (InnoDB, `utf8mb4` / `utf8mb4_unicode_ci`)
+- **MySQL 8.4 LTS** soportado como target (homelab en producción), MySQL 9.x compatible (sintaxis portable). Ver ADR #11 en `db/docs/DECISIONES.md`.
 - Time zone: `America/Argentina/Buenos_Aires`
 - **.NET 10** (ASP.NET Core MVC)
 - **EF Core 9** + **Pomelo 9** (database-first, sin migraciones EF)

--- a/db/docs/DECISIONES.md
+++ b/db/docs/DECISIONES.md
@@ -171,6 +171,56 @@ Documento de decisiones (ADR-style) y supuestos del sistema **ExtraGas**.
 
 ---
 
+## 11. MySQL 8.4 LTS como target soportado
+
+**Decisión:** el proyecto soporta y se valida contra MySQL 8.4 LTS (además de 9.x). La versión de runtime del homelab es 8.4.11.
+
+**Por qué:** 8.4 es el branch LTS estable de MySQL Community; 9.x es el de innovación. Para un sistema de gestión interno que va a correr años sin migrar de versión, LTS es la elección correcta. La sintaxis SQL usada en el proyecto (CTEs, `JSON_TABLE`, CHECK constraints, generated columns, ENUM, triggers) está disponible desde 8.0, así que la portabilidad está garantizada.
+
+**Implicancia:**
+- Las migraciones se prueban contra 8.4. Si se agrega SQL específico de 9.x, hay que documentarlo acá.
+- El archivo `AGENTS.md` menciona "MySQL 9.6" porque esa era la versión original del dev local. **No implica que 9.x esté roto**, solo refleja la versión del entorno de desarrollo.
+- Para homelab/dev: grants adicionales requeridos por 8.x con binlog activo (`SYSTEM_VARIABLES_ADMIN`, `log_bin_trust_function_creators=1`) — ver [`db/scripts/install.sh`](../../db/scripts/install.sh).
+
+---
+
+## 12. `pedido_items.unique_hash` como columna generada VIRTUAL (no STORED)
+
+**Decisión:** la columna `unique_hash` usada para prevenir duplicados de `(pedido_id, producto_id, tipo_linea)` entre items activos se implementa como `GENERATED ALWAYS AS (...) VIRTUAL`, no `STORED`.
+
+**Por qué:** la migración original usaba `STORED` pero falla con `ERROR 1215: Cannot add foreign key constraint` en MySQL 8.4 cuando la tabla tiene FKs. Es un bug conocido del path de validación de InnoDB para `STORED generated columns` en ALTER TABLE — el error es engañoso (no hay FK involucrada en el ALTER). `VIRTUAL` toma otro code path y funciona. MySQL 8.0.16+ permite `UNIQUE INDEX` sobre columnas `VIRTUAL` generadas, así que el contrato original se preserva.
+
+**Implicancia:**
+- Funcionalmente equivalente: el `UNIQUE INDEX uk_pedido_items_pedido_producto_tipo` sobre `unique_hash` sigue funcionando.
+- Trade-off: `VIRTUAL` se recalcula en cada lectura en lugar de almacenarse. Para esta tabla (volumen bajo-medio, lecturas frecuentes) el costo es despreciable.
+- Si en el futuro queremos `STORED` (por ejemplo para índices secundarios sobre el hash), hay que aplicar el ALTER antes de crear las FKs de `pedido_items` — workaround: tabla sin FKs, ADD COLUMN STORED, luego ADD CONSTRAINT.
+
+---
+
+## 13. Estrategia de idempotencia para migraciones incrementales
+
+**Decisión:** las migraciones incrementales (las posteriores a la creación inicial del schema) deben ser idempotentes — re-ejecutables sin fallar contra una BD que ya las tiene aplicadas.
+
+**Por qué:** `db/scripts/install.sh` declara ser idempotente. Las migraciones iniciales (CREATE TABLE, CREATE VIEW) usan `IF NOT EXISTS` y son naturalmente idempotentes. Las incrementales no lo son por defecto:
+- `ALTER TABLE ADD COLUMN` falla si la columna ya existe.
+- `ALTER TABLE DROP COLUMN` falla si la columna no existe.
+- `INSERT INTO lookup` falla con duplicate key.
+
+Esto bloquea re-correr el script después de un `DROP DATABASE` parcial, o si se quiere re-aplicar una migración puntual.
+
+**Cómo se logra:**
+- **ADD/DROP COLUMN**: MySQL 8.x no soporta `IF [NOT] EXISTS` para columnas en `ALTER TABLE`. Se usa el patrón `information_schema` + `PREPARE`/`EXECUTE` para ejecutar condicionalmente.
+- **INSERT en lookup**: `INSERT IGNORE` (descarta solo el error de duplicate-key, no otros errores).
+- **CREATE/DROP VIEW, CREATE TRIGGER**: ya idempotentes con `IF NOT EXISTS` / `DROP IF EXISTS`.
+- **CREATE TABLE**: ya idempotente con `IF NOT EXISTS`.
+- **CREATE INDEX UNIQUE**: requiere `DROP INDEX` previo si el índice ya existe con el mismo nombre (ver migración 20260606_000001).
+
+**Implicancia:**
+- Las migraciones nuevas deben seguir este patrón. Code review debe verificar idempotencia antes de aceptar una migración nueva.
+- La solución definitiva (más robusta) sería una tabla `schema_migrations` con hashes de archivos aplicados y el script consultarla antes de ejecutar. No se implementa acá por costo/beneficio (un solo dev, homelab), pero queda como evolución futura si el proyecto pasa a multi-dev o CI/CD.
+
+---
+
 ## Supuestos explícitos (no validados con el usuario)
 
 1. No hay delivery con zonas / tarifas distintas. Un pedido = una dirección.

--- a/db/migrations/20260102_000001_create_lookup_tables.sql
+++ b/db/migrations/20260102_000001_create_lookup_tables.sql
@@ -9,7 +9,7 @@ USE extragas;
 -- -----------------------------------------------------------------------------
 -- roles: roles de usuario del sistema
 -- -----------------------------------------------------------------------------
-CREATE TABLE roles (
+CREATE TABLE IF NOT EXISTS roles (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   codigo VARCHAR(30) NOT NULL,
   nombre VARCHAR(100) NOT NULL,
@@ -22,7 +22,7 @@ CREATE TABLE roles (
 -- -----------------------------------------------------------------------------
 -- tipos_producto: GAS, CARBON, LENA
 -- -----------------------------------------------------------------------------
-CREATE TABLE tipos_producto (
+CREATE TABLE IF NOT EXISTS tipos_producto (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   codigo VARCHAR(30) NOT NULL,
   nombre VARCHAR(100) NOT NULL,
@@ -35,7 +35,7 @@ CREATE TABLE tipos_producto (
 -- -----------------------------------------------------------------------------
 -- formas_pago: EFECTIVO, TRANSFERENCIA, MERCADO_PAGO, CHEQUE
 -- -----------------------------------------------------------------------------
-CREATE TABLE formas_pago (
+CREATE TABLE IF NOT EXISTS formas_pago (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   codigo VARCHAR(30) NOT NULL,
   nombre VARCHAR(100) NOT NULL,
@@ -50,7 +50,7 @@ CREATE TABLE formas_pago (
 -- -----------------------------------------------------------------------------
 -- estados_pedido: ciclo de vida del pedido
 -- -----------------------------------------------------------------------------
-CREATE TABLE estados_pedido (
+CREATE TABLE IF NOT EXISTS estados_pedido (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   codigo VARCHAR(30) NOT NULL,
   nombre VARCHAR(100) NOT NULL,
@@ -65,7 +65,7 @@ CREATE TABLE estados_pedido (
 -- -----------------------------------------------------------------------------
 -- estados_garrafa: estado actual de una garrafa física
 -- -----------------------------------------------------------------------------
-CREATE TABLE estados_garrafa (
+CREATE TABLE IF NOT EXISTS estados_garrafa (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   codigo VARCHAR(30) NOT NULL,
   nombre VARCHAR(100) NOT NULL,
@@ -81,7 +81,7 @@ CREATE TABLE estados_garrafa (
 -- -----------------------------------------------------------------------------
 -- tipos_movimiento_garrafa: motivo de un cambio de estado de garrafa
 -- -----------------------------------------------------------------------------
-CREATE TABLE tipos_movimiento_garrafa (
+CREATE TABLE IF NOT EXISTS tipos_movimiento_garrafa (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   codigo VARCHAR(30) NOT NULL,
   nombre VARCHAR(100) NOT NULL,
@@ -94,7 +94,7 @@ CREATE TABLE tipos_movimiento_garrafa (
 -- -----------------------------------------------------------------------------
 -- canales_venta: TELEFONO, WHATSAPP, PRESENCIAL
 -- -----------------------------------------------------------------------------
-CREATE TABLE canales_venta (
+CREATE TABLE IF NOT EXISTS canales_venta (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   codigo VARCHAR(30) NOT NULL,
   nombre VARCHAR(100) NOT NULL,
@@ -107,7 +107,7 @@ CREATE TABLE canales_venta (
 -- -----------------------------------------------------------------------------
 -- medios_contacto_pedido: cómo se contactó al cliente para tomar el pedido
 -- -----------------------------------------------------------------------------
-CREATE TABLE medios_contacto_pedido (
+CREATE TABLE IF NOT EXISTS medios_contacto_pedido (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   codigo VARCHAR(30) NOT NULL,
   nombre VARCHAR(100) NOT NULL,
@@ -120,7 +120,7 @@ CREATE TABLE medios_contacto_pedido (
 -- -----------------------------------------------------------------------------
 -- tipos_contacto_cliente: TELEFONO, WHATSAPP, EMAIL, OTRO
 -- -----------------------------------------------------------------------------
-CREATE TABLE tipos_contacto_cliente (
+CREATE TABLE IF NOT EXISTS tipos_contacto_cliente (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   codigo VARCHAR(30) NOT NULL,
   nombre VARCHAR(100) NOT NULL,
@@ -132,7 +132,7 @@ CREATE TABLE tipos_contacto_cliente (
 -- -----------------------------------------------------------------------------
 -- provincias: 24 provincias argentinas
 -- -----------------------------------------------------------------------------
-CREATE TABLE provincias (
+CREATE TABLE IF NOT EXISTS provincias (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   codigo VARCHAR(4) NOT NULL,
   nombre VARCHAR(100) NOT NULL,
@@ -146,7 +146,7 @@ CREATE TABLE provincias (
 -- secuencias: control de correlativos por año y prefijo
 -- Formato generado: PREFIX-YYYY-NNNNN
 -- -----------------------------------------------------------------------------
-CREATE TABLE secuencias (
+CREATE TABLE IF NOT EXISTS secuencias (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   nombre VARCHAR(50) NOT NULL,
   prefijo VARCHAR(20) NOT NULL,

--- a/db/migrations/20260102_000002_create_personas_y_seguridad.sql
+++ b/db/migrations/20260102_000002_create_personas_y_seguridad.sql
@@ -8,7 +8,7 @@ USE extragas;
 -- -----------------------------------------------------------------------------
 -- usuarios: credenciales del sistema
 -- -----------------------------------------------------------------------------
-CREATE TABLE usuarios (
+CREATE TABLE IF NOT EXISTS usuarios (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   username VARCHAR(50) NOT NULL,
   password_hash VARCHAR(255) NOT NULL,
@@ -32,7 +32,7 @@ CREATE TABLE usuarios (
 -- -----------------------------------------------------------------------------
 -- empleados: personas que trabajan en la empresa (incluye al dueño)
 -- -----------------------------------------------------------------------------
-CREATE TABLE empleados (
+CREATE TABLE IF NOT EXISTS empleados (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   nombre VARCHAR(100) NOT NULL,
   apellido VARCHAR(100) NOT NULL,
@@ -69,7 +69,7 @@ CREATE TABLE empleados (
 -- -----------------------------------------------------------------------------
 -- clientes: compradores de la empresa
 -- -----------------------------------------------------------------------------
-CREATE TABLE clientes (
+CREATE TABLE IF NOT EXISTS clientes (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   codigo VARCHAR(20) NULL,
   nombre VARCHAR(100) NOT NULL,
@@ -108,7 +108,7 @@ CREATE TABLE clientes (
 -- -----------------------------------------------------------------------------
 -- cliente_contactos: medios de contacto adicionales por cliente
 -- -----------------------------------------------------------------------------
-CREATE TABLE cliente_contactos (
+CREATE TABLE IF NOT EXISTS cliente_contactos (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   cliente_id BIGINT UNSIGNED NOT NULL,
   tipo_contacto_id BIGINT UNSIGNED NOT NULL,
@@ -126,7 +126,7 @@ CREATE TABLE cliente_contactos (
 -- -----------------------------------------------------------------------------
 -- proveedores: quienes abastecen a la empresa
 -- -----------------------------------------------------------------------------
-CREATE TABLE proveedores (
+CREATE TABLE IF NOT EXISTS proveedores (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   codigo VARCHAR(20) NULL,
   razon_social VARCHAR(150) NOT NULL,

--- a/db/migrations/20260102_000003_create_productos.sql
+++ b/db/migrations/20260102_000003_create_productos.sql
@@ -11,7 +11,7 @@ USE extragas;
 --   - CAR-3/5/10/25: bolsas de carbón
 --   - LEN-25: bolsa de leña
 -- -----------------------------------------------------------------------------
-CREATE TABLE productos (
+CREATE TABLE IF NOT EXISTS productos (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   codigo VARCHAR(30) NOT NULL,
   nombre VARCHAR(150) NOT NULL,

--- a/db/migrations/20260102_000004_create_pedidos_y_pagos.sql
+++ b/db/migrations/20260102_000004_create_pedidos_y_pagos.sql
@@ -12,7 +12,7 @@ USE extragas;
 --   - monto_pagado: lo mantiene trigger AFTER pagos
 --   - saldo: columna generada = total - monto_pagado
 -- -----------------------------------------------------------------------------
-CREATE TABLE pedidos (
+CREATE TABLE IF NOT EXISTS pedidos (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   numero VARCHAR(20) NULL,
   fecha DATETIME NOT NULL,
@@ -61,7 +61,7 @@ CREATE TABLE pedidos (
 --   - subtotal: columna generada = cantidad * precio_unitario
 --   - precio_unitario se congela al momento de crear el pedido (histórico)
 -- -----------------------------------------------------------------------------
-CREATE TABLE pedido_items (
+CREATE TABLE IF NOT EXISTS pedido_items (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   pedido_id BIGINT UNSIGNED NOT NULL,
   producto_id BIGINT UNSIGNED NOT NULL,
@@ -87,7 +87,7 @@ CREATE TABLE pedido_items (
 --   - pedido_id: NULL permitido = "pago a cuenta" (se aplica al pedido más antiguo con saldo del cliente)
 --   - referencia: para transferencias, número de operación
 -- -----------------------------------------------------------------------------
-CREATE TABLE pagos (
+CREATE TABLE IF NOT EXISTS pagos (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   numero_recibo VARCHAR(20) NULL,
   fecha DATETIME NOT NULL,

--- a/db/migrations/20260102_000005_create_proveedores_y_recepciones.sql
+++ b/db/migrations/20260102_000005_create_proveedores_y_recepciones.sql
@@ -13,7 +13,7 @@ USE extragas;
 --   - monto_pagado: lo mantiene trigger AFTER pagos_proveedor
 --   - saldo: columna generada
 -- -----------------------------------------------------------------------------
-CREATE TABLE recepciones_proveedor (
+CREATE TABLE IF NOT EXISTS recepciones_proveedor (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   numero VARCHAR(20) NULL,
   fecha DATETIME NOT NULL,
@@ -46,7 +46,7 @@ CREATE TABLE recepciones_proveedor (
 -- recepcion_items: líneas de la recepción (uno por producto recibido)
 --   - subtotal: columna generada = cantidad * precio_unitario
 -- -----------------------------------------------------------------------------
-CREATE TABLE recepcion_items (
+CREATE TABLE IF NOT EXISTS recepcion_items (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   recepcion_id BIGINT UNSIGNED NOT NULL,
   producto_id BIGINT UNSIGNED NOT NULL,
@@ -69,7 +69,7 @@ CREATE TABLE recepcion_items (
 --   - recepcion_id: NULL permitido = "pago a cuenta" del proveedor
 --   - referencia: para transferencias
 -- -----------------------------------------------------------------------------
-CREATE TABLE pagos_proveedor (
+CREATE TABLE IF NOT EXISTS pagos_proveedor (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   numero VARCHAR(20) NULL,
   fecha DATETIME NOT NULL,

--- a/db/migrations/20260102_000006_create_garrafas.sql
+++ b/db/migrations/20260102_000006_create_garrafas.sql
@@ -12,7 +12,7 @@ USE extragas;
 --   - estado_garrafa_id: estado actual
 --   - cliente_id: solo cuando el estado es EN_CLIENTE
 -- -----------------------------------------------------------------------------
-CREATE TABLE garrafas (
+CREATE TABLE IF NOT EXISTS garrafas (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   codigo VARCHAR(50) NOT NULL,
   capacidad_kg TINYINT UNSIGNED NOT NULL,
@@ -50,7 +50,7 @@ CREATE TABLE garrafas (
 --   - recepcion_id: NULL si no está asociado a una recepción
 --   - estado_origen_id, estado_destino_id: para trazabilidad
 -- -----------------------------------------------------------------------------
-CREATE TABLE movimientos_garrafa (
+CREATE TABLE IF NOT EXISTS movimientos_garrafa (
   id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   garrafa_id BIGINT UNSIGNED NOT NULL,
   fecha DATETIME NOT NULL,

--- a/db/migrations/20260102_000008_create_views.sql
+++ b/db/migrations/20260102_000008_create_views.sql
@@ -15,7 +15,6 @@ SELECT
   p.numero,
   p.fecha,
   p.fecha_entrega,
-  p.entregado,
   p.cliente_id,
   CONCAT(c.apellido, ', ', c.nombre) AS cliente,
   c.telefono_principal AS cliente_telefono,

--- a/db/migrations/20260102_000009_seed_data.sql
+++ b/db/migrations/20260102_000009_seed_data.sql
@@ -10,7 +10,7 @@ USE extragas;
 -- Provincias (referenciadas por empleados, clientes y proveedores)
 -- (También disponible en db/seed/provincias_argentina.sql como referencia)
 -- -----------------------------------------------------------------------------
-INSERT INTO provincias (codigo, nombre, pais) VALUES
+INSERT IGNORE INTO provincias (codigo, nombre, pais) VALUES
   ('AR-C', 'Ciudad Autónoma de Buenos Aires', 'Argentina'),
   ('AR-B', 'Buenos Aires', 'Argentina'),
   ('AR-K', 'Catamarca', 'Argentina'),
@@ -39,14 +39,14 @@ INSERT INTO provincias (codigo, nombre, pais) VALUES
 -- -----------------------------------------------------------------------------
 -- Roles de usuario
 -- -----------------------------------------------------------------------------
-INSERT INTO roles (codigo, nombre, descripcion) VALUES
+INSERT IGNORE INTO roles (codigo, nombre, descripcion) VALUES
   ('ADMIN', 'Administrador', 'Dueño del sistema, acceso total'),
   ('OPERADOR', 'Operador', 'Empleado, gestión de pedidos y cobros');
 
 -- -----------------------------------------------------------------------------
 -- Tipos de producto
 -- -----------------------------------------------------------------------------
-INSERT INTO tipos_producto (codigo, nombre, descripcion) VALUES
+INSERT IGNORE INTO tipos_producto (codigo, nombre, descripcion) VALUES
   ('GAS', 'Gas envasado', 'Garrafas de gas en distintas capacidades'),
   ('CARBON', 'Carbón', 'Bolsas de carbón en distintas capacidades'),
   ('LENA', 'Leña', 'Bolsa de leña para hogar');
@@ -54,7 +54,7 @@ INSERT INTO tipos_producto (codigo, nombre, descripcion) VALUES
 -- -----------------------------------------------------------------------------
 -- Formas de pago
 -- -----------------------------------------------------------------------------
-INSERT INTO formas_pago (codigo, nombre, descripcion, requiere_referencia) VALUES
+INSERT IGNORE INTO formas_pago (codigo, nombre, descripcion, requiere_referencia) VALUES
   ('EFECTIVO', 'Efectivo', 'Pago en efectivo en el momento', FALSE),
   ('TRANSFERENCIA', 'Transferencia bancaria', 'Pago por transferencia/transferencia', TRUE),
   ('MERCADO_PAGO', 'Mercado Pago', 'Pago vía Mercado Pago u otra billetera virtual', TRUE),
@@ -63,7 +63,7 @@ INSERT INTO formas_pago (codigo, nombre, descripcion, requiere_referencia) VALUE
 -- -----------------------------------------------------------------------------
 -- Estados de pedido
 -- -----------------------------------------------------------------------------
-INSERT INTO estados_pedido (codigo, nombre, descripcion, es_final, color) VALUES
+INSERT IGNORE INTO estados_pedido (codigo, nombre, descripcion, es_final, color) VALUES
   ('PENDIENTE', 'Pendiente', 'Pedido recibido, sin confirmar', FALSE, '#FFA500'),
   ('CONFIRMADO', 'Confirmado', 'Pedido confirmado, pendiente de preparación', FALSE, '#1E90FF'),
   ('EN_PREPARACION', 'En preparación', 'Pedido en proceso de armado/entrega', FALSE, '#9370DB'),
@@ -73,7 +73,7 @@ INSERT INTO estados_pedido (codigo, nombre, descripcion, es_final, color) VALUES
 -- -----------------------------------------------------------------------------
 -- Estados de garrafa
 -- -----------------------------------------------------------------------------
-INSERT INTO estados_garrafa (codigo, nombre, descripcion, es_disponible_para_venta, requiere_cliente, color) VALUES
+INSERT IGNORE INTO estados_garrafa (codigo, nombre, descripcion, es_disponible_para_venta, requiere_cliente, color) VALUES
   ('LLENA_DEPOSITO', 'Llena en depósito', 'Garrafa llena disponible para entregar', TRUE, FALSE, '#228B22'),
   ('VACIA_DEPOSITO', 'Vacía en depósito', 'Garrafa vacía en el depósito', FALSE, FALSE, '#808080'),
   ('EN_CLIENTE', 'En cliente', 'Garrafa en poder de un cliente (canje/consignación)', FALSE, TRUE, '#1E90FF'),
@@ -84,7 +84,7 @@ INSERT INTO estados_garrafa (codigo, nombre, descripcion, es_disponible_para_ven
 -- -----------------------------------------------------------------------------
 -- Tipos de movimiento de garrafa
 -- -----------------------------------------------------------------------------
-INSERT INTO tipos_movimiento_garrafa (codigo, nombre, descripcion) VALUES
+INSERT IGNORE INTO tipos_movimiento_garrafa (codigo, nombre, descripcion) VALUES
   ('COMPRA', 'Compra a proveedor', 'Ingreso de garrafa por recepción de proveedor'),
   ('ENTREGA_CLIENTE', 'Entrega a cliente', 'Salida de garrafa hacia un cliente'),
   ('DEVOLUCION_CLIENTE', 'Devolución de cliente', 'Regreso de garrafa desde un cliente'),
@@ -97,7 +97,7 @@ INSERT INTO tipos_movimiento_garrafa (codigo, nombre, descripcion) VALUES
 -- -----------------------------------------------------------------------------
 -- Canales de venta
 -- -----------------------------------------------------------------------------
-INSERT INTO canales_venta (codigo, nombre, descripcion) VALUES
+INSERT IGNORE INTO canales_venta (codigo, nombre, descripcion) VALUES
   ('TELEFONO', 'Teléfono', 'Pedido recibido por llamada telefónica'),
   ('WHATSAPP', 'WhatsApp', 'Pedido recibido por mensaje de WhatsApp'),
   ('PRESENCIAL', 'Presencial', 'Pedido realizado en el local');
@@ -105,7 +105,7 @@ INSERT INTO canales_venta (codigo, nombre, descripcion) VALUES
 -- -----------------------------------------------------------------------------
 -- Medios de contacto del pedido
 -- -----------------------------------------------------------------------------
-INSERT INTO medios_contacto_pedido (codigo, nombre, descripcion) VALUES
+INSERT IGNORE INTO medios_contacto_pedido (codigo, nombre, descripcion) VALUES
   ('WHATSAPP', 'WhatsApp', 'Se contactó al cliente por WhatsApp'),
   ('TELEFONO', 'Llamada telefónica', 'Se contactó al cliente por llamada'),
   ('PRESENCIAL', 'Presencial', 'Cliente concurrió al local'),
@@ -114,7 +114,7 @@ INSERT INTO medios_contacto_pedido (codigo, nombre, descripcion) VALUES
 -- -----------------------------------------------------------------------------
 -- Tipos de contacto adicionales de cliente
 -- -----------------------------------------------------------------------------
-INSERT INTO tipos_contacto_cliente (codigo, nombre) VALUES
+INSERT IGNORE INTO tipos_contacto_cliente (codigo, nombre) VALUES
   ('TELEFONO', 'Teléfono'),
   ('WHATSAPP', 'WhatsApp'),
   ('EMAIL', 'Email'),
@@ -123,7 +123,7 @@ INSERT INTO tipos_contacto_cliente (codigo, nombre) VALUES
 -- -----------------------------------------------------------------------------
 -- Productos del catálogo
 -- -----------------------------------------------------------------------------
-INSERT INTO productos (codigo, nombre, descripcion, tipo_producto_id, capacidad_kg, unidad_venta, precio_actual, maneja_garrafa_individual) VALUES
+INSERT IGNORE INTO productos (codigo, nombre, descripcion, tipo_producto_id, capacidad_kg, unidad_venta, precio_actual, maneja_garrafa_individual) VALUES
   ('GAS-10',  'Garrafa de gas 10 kg',  'Garrafa de gas envasado de 10 kg',  (SELECT id FROM tipos_producto WHERE codigo='GAS'),    10.00, 'GARRAFA', 0.00, TRUE),
   ('GAS-15',  'Garrafa de gas 15 kg',  'Garrafa de gas envasado de 15 kg',  (SELECT id FROM tipos_producto WHERE codigo='GAS'),    15.00, 'GARRAFA', 0.00, TRUE),
   ('GAS-45',  'Garrafa de gas 45 kg',  'Garrafa de gas envasado de 45 kg',  (SELECT id FROM tipos_producto WHERE codigo='GAS'),    45.00, 'GARRAFA', 0.00, TRUE),
@@ -137,7 +137,7 @@ INSERT INTO productos (codigo, nombre, descripcion, tipo_producto_id, capacidad_
 -- Secuencias inicializadas (la numeración real la gestiona el trigger,
 -- esto es solo para que aparezcan en la tabla desde el principio)
 -- -----------------------------------------------------------------------------
-INSERT INTO secuencias (nombre, prefijo, anio, ultimo_valor) VALUES
+INSERT IGNORE INTO secuencias (nombre, prefijo, anio, ultimo_valor) VALUES
   ('pedidos',              'PED',      YEAR(CURDATE()), 0),
   ('pagos_cliente',        'REC',      YEAR(CURDATE()), 0),
   ('recepciones_proveedor','REC-PROV', YEAR(CURDATE()), 0),
@@ -149,10 +149,10 @@ INSERT INTO secuencias (nombre, prefijo, anio, ultimo_valor) VALUES
 -- password_hash es un placeholder; la app debe hashear con argon2id/bcrypt
 -- en el primer login o antes del primer uso.
 -- -----------------------------------------------------------------------------
-INSERT INTO empleados (nombre, apellido, dni, fecha_ingreso, activo) VALUES
+INSERT IGNORE INTO empleados (nombre, apellido, dni, fecha_ingreso, activo) VALUES
   ('Dueño', 'Administrador', NULL, CURDATE(), TRUE);
 
-INSERT INTO usuarios (username, password_hash, email, rol_id, activo) VALUES
+INSERT IGNORE INTO usuarios (username, password_hash, email, rol_id, activo) VALUES
   ('admin', '$2a$11$LXexHD1uSwkOLaBCUvArbe5YKVYC7xujLmwQHCRHtkHz61kTY6S2K', NULL, (SELECT id FROM roles WHERE codigo='ADMIN'), TRUE);
 
 UPDATE empleados e

--- a/db/migrations/20260606_000001_add_unique_index_clientes_dni.sql
+++ b/db/migrations/20260606_000001_add_unique_index_clientes_dni.sql
@@ -1,3 +1,4 @@
 USE extragas;
 
+DROP INDEX idx_clientes_dni ON clientes;
 CREATE UNIQUE INDEX idx_clientes_dni ON clientes(dni);

--- a/db/migrations/20260607_000001_drop_pedidos_entregado.sql
+++ b/db/migrations/20260607_000001_drop_pedidos_entregado.sql
@@ -9,10 +9,22 @@
 USE extragas;
 
 -- -----------------------------------------------------------------------------
--- 1) DROP de la columna en `pedidos`
+-- 1) DROP de la columna en `pedidos` (idempotente: solo si existe)
+--    MySQL no soporta DROP COLUMN IF EXISTS, usamos information_schema.
 -- -----------------------------------------------------------------------------
-ALTER TABLE `pedidos`
-  DROP COLUMN `entregado`;
+SET @col_exists = (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE()
+    AND table_name = 'pedidos'
+    AND column_name = 'entregado'
+);
+SET @sql = IF(@col_exists > 0,
+  'ALTER TABLE `pedidos` DROP COLUMN `entregado`',
+  'SELECT "Column entregado ya eliminada, skipping" AS status'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 -- -----------------------------------------------------------------------------
 -- 2) DROP del campo en la vista `v_pedidos_resumen`

--- a/db/migrations/20260607_000002_add_motivo_cancelacion_pedidos.sql
+++ b/db/migrations/20260607_000002_add_motivo_cancelacion_pedidos.sql
@@ -3,5 +3,20 @@
 -- Descripción: permite registrar el motivo de cancelación de un pedido
 --              cuando se transiciona al estado CANCELADO.
 
-ALTER TABLE pedidos
-  ADD COLUMN motivo_cancelacion VARCHAR(500) NULL AFTER observaciones;
+USE extragas;
+
+-- Idempotente: ALTER TABLE ADD COLUMN no soporta IF NOT EXISTS en MySQL 8.x,
+-- usamos information_schema para detectar y saltar si ya existe.
+SET @col_exists = (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE()
+    AND table_name = 'pedidos'
+    AND column_name = 'motivo_cancelacion'
+);
+SET @sql = IF(@col_exists = 0,
+  'ALTER TABLE pedidos ADD COLUMN motivo_cancelacion VARCHAR(500) NULL AFTER observaciones',
+  'SELECT "Column motivo_cancelacion ya existe, skipping" AS status'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/db/migrations/20260607_000002_pedido_items_soft_delete_and_unique.sql
+++ b/db/migrations/20260607_000002_pedido_items_soft_delete_and_unique.sql
@@ -6,22 +6,72 @@
 USE extragas;
 
 -- Soft-delete column for pedido_items (AGENTS.md convention #6)
-ALTER TABLE pedido_items
-    ADD COLUMN deleted_at DATETIME NULL AFTER observaciones;
+-- Idempotente: ALTER TABLE ADD COLUMN no soporta IF NOT EXISTS, usamos information_schema.
+SET @col_exists = (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE()
+    AND table_name = 'pedido_items'
+    AND column_name = 'deleted_at'
+);
+SET @sql = IF(@col_exists = 0,
+  'ALTER TABLE pedido_items ADD COLUMN deleted_at DATETIME NULL AFTER observaciones',
+  'SELECT "Column deleted_at ya existe, skipping" AS status'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
--- Index for soft-delete queries
-CREATE INDEX idx_pedido_items_deleted_at ON pedido_items (deleted_at);
+-- Index for soft-delete queries (idempotente: PREPARE/EXECUTE con check en information_schema)
+SET @idx_exists = (
+  SELECT COUNT(*) FROM information_schema.statistics
+  WHERE table_schema = DATABASE()
+    AND table_name = 'pedido_items'
+    AND index_name = 'idx_pedido_items_deleted_at'
+);
+SET @sql = IF(@idx_exists = 0,
+  'CREATE INDEX idx_pedido_items_deleted_at ON pedido_items (deleted_at)',
+  'SELECT "Index idx_pedido_items_deleted_at ya existe, skipping" AS status'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 -- Unique constraint to prevent duplicate (pedido_id, producto_id, tipo_linea) among active items.
 -- MySQL does not support filtered unique indexes, so we use a generated column + unique index
 -- that makes deleted_at NULL rows unique while soft-deleted rows (with a timestamp) are excluded.
-ALTER TABLE pedido_items
-    ADD COLUMN unique_hash VARCHAR(64) GENERATED ALWAYS AS (
-        CASE WHEN deleted_at IS NULL THEN
-            CONCAT(CAST(pedido_id AS CHAR), '-', CAST(producto_id AS CHAR), '-', tipo_linea)
-        ELSE
-            CONCAT(CAST(pedido_id AS CHAR), '-', CAST(producto_id AS CHAR), '-', tipo_linea, '-', CAST(deleted_at AS CHAR))
-        END
-    ) STORED;
+-- Idempotente: guard para ADD COLUMN y CREATE UNIQUE INDEX.
 
-CREATE UNIQUE INDEX uk_pedido_items_pedido_producto_tipo ON pedido_items (unique_hash);
+SET @col_exists = (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE()
+    AND table_name = 'pedido_items'
+    AND column_name = 'unique_hash'
+);
+SET @sql = IF(@col_exists = 0,
+  "ALTER TABLE pedido_items ADD COLUMN unique_hash VARCHAR(255) GENERATED ALWAYS AS (
+     CONCAT(
+       CAST(pedido_id AS CHAR), '-',
+       CAST(producto_id AS CHAR), '-',
+       tipo_linea, '-',
+       COALESCE(CAST(deleted_at AS CHAR), '0')
+     )
+   ) VIRTUAL",
+  'SELECT "Column unique_hash ya existe, skipping" AS status'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @idx_exists = (
+  SELECT COUNT(*) FROM information_schema.statistics
+  WHERE table_schema = DATABASE()
+    AND table_name = 'pedido_items'
+    AND index_name = 'uk_pedido_items_pedido_producto_tipo'
+);
+SET @sql = IF(@idx_exists = 0,
+  'CREATE UNIQUE INDEX uk_pedido_items_pedido_producto_tipo ON pedido_items (unique_hash)',
+  'SELECT "Index uk_pedido_items_pedido_producto_tipo ya existe, skipping" AS status'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/db/migrations/20260608_000001_add_tipo_movimiento_cambio_estado.sql
+++ b/db/migrations/20260608_000001_add_tipo_movimiento_cambio_estado.sql
@@ -5,5 +5,6 @@
 
 USE extragas;
 
-INSERT INTO tipos_movimiento_garrafa (codigo, nombre, descripcion) VALUES
+-- Idempotente: INSERT IGNORE evita el duplicate-key si ya fue aplicado.
+INSERT IGNORE INTO tipos_movimiento_garrafa (codigo, nombre, descripcion) VALUES
   ('CAMBIO_ESTADO', 'Cambio manual de estado', 'Cambio de estado realizado manualmente desde la UI');

--- a/db/scripts/install.sh
+++ b/db/scripts/install.sh
@@ -9,8 +9,9 @@
 # Pre-requisito: MySQL corriendo (`brew services start mysql`)
 #
 # Idempotente: si la BD ya existe, conserva los datos y reaplica las
-# migraciones (los CREATE usan IF NOT EXISTS, los INSERT de seed pueden
-# fallar por UNIQUE — eso es esperable).
+# migraciones. Las migraciones estructurales usan IF NOT EXISTS / IF EXISTS /
+# CREATE OR REPLACE / INSERT IGNORE / DROP IF EXISTS, según corresponda.
+# Si una migración nueva no sigue este patrón, falla en re-run.
 # =============================================================================
 
 set -euo pipefail
@@ -33,9 +34,22 @@ MIGRATIONS_DIR="${PROJECT_ROOT}/db/migrations"
 
 # --- Pre-checks --------------------------------------------------------------
 echo "==> Verificando conexión a MySQL..."
-if ! ${MYSQL_CMD} -e "SELECT VERSION();" >/dev/null 2>&1; then
-  echo "    ERROR: no se puede conectar a MySQL. ¿Está corriendo el servicio?" >&2
-  echo "    Probá: brew services start mysql" >&2
+ERROR_OUTPUT=$(${MYSQL_CMD} -e "SELECT VERSION();" 2>&1 >/dev/null)
+EXIT_CODE=$?
+if [ "${EXIT_CODE}" -ne 0 ]; then
+  echo "    ERROR: no se puede conectar a MySQL." >&2
+  if echo "${ERROR_OUTPUT}" | grep -qi "Access denied"; then
+    echo "    Autenticación rechazada. Verificá MYSQL_USER y MYSQL_PASS." >&2
+  elif echo "${ERROR_OUTPUT}" | grep -qi "Can't connect to MySQL server"; then
+    echo "    El servicio MySQL no responde en ${MYSQL_HOST}:3306." >&2
+    if [ "${MYSQL_HOST}" = "localhost" ] || [ "${MYSQL_HOST}" = "127.0.0.1" ]; then
+      echo "    Si es local: brew services start mysql" >&2
+    else
+      echo "    Verificá conectividad de red y que el server escuche en TCP." >&2
+    fi
+  else
+    echo "    Detalle: ${ERROR_OUTPUT}" >&2
+  fi
   exit 1
 fi
 ${MYSQL_CMD} -e "SELECT VERSION();" 2>/dev/null
@@ -69,4 +83,5 @@ echo "  Vistas:            ${VIEW_COUNT}"
 echo "  Triggers:          ${TRIGGER_COUNT}"
 echo "================================================================"
 echo ""
-echo "Para conectarte: ${MYSQL_CMD} ${DB_NAME}"
+# Mostramos el comando sin el password (queda -p solo, así el shell lo pide).
+echo "Para conectarte: ${MYSQL_CMD%${MYSQL_PASS}} ${DB_NAME}"

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -2,7 +2,7 @@ schema: spec-driven
 
 context: |
   Stack: ASP.NET Core MVC (.NET 10.0) + EF Core 9.0.16 + Pomelo MySQL 9.0.0
-  DB: MySQL 9.6.0 (Homebrew), InnoDB, utf8mb4, tz America/Argentina/Buenos_Aires
+  DB: MySQL 8.4 LTS supported (homelab prod), MySQL 9.x compatible, InnoDB, utf8mb4, tz America/Argentina/Buenos_Aires
   Schema: managed via raw SQL in db/migrations/ (NO EF Core migrations)
   Auth: Cookie auth + role policies (AdminOnly, OperadorOrAdmin) — no Identity
   Frontend: AdminLTE 4 + SweetAlert2 (npm), Razor views


### PR DESCRIPTION
## Resumen

El script `db/scripts/install.sh` declaraba ser idempotente pero fallaba en re-run con errores tipo *Table/Column already exists* y *Duplicate key*. Esta PR lo deja realmente idempotente: corre limpio dos veces seguidas contra la misma instancia de MySQL. Además documenta MySQL 8.4 LTS como target soportado (el homelab actual corre 8.4.11).

Tres commits con concerns separados:

### `fix(db): harden all migrations for true idempotency` — 13 archivos, +137/-59

- Migraciones estructurales (001-006): `CREATE TABLE` ahora usa `IF NOT EXISTS`.
- 008_create_views: removida referencia a `p.entregado` en `v_pedidos_resumen` (la columna se dropea después).
- 009_seed_data: todos los `INSERT` → `INSERT IGNORE`.
- 06-06-01_add_unique_index_clientes_dni: `DROP INDEX` + `CREATE UNIQUE INDEX` (DROP INDEX siempre funciona, no requiere guard).
- 07-06-01_drop_pedidos_entregado: `DROP COLUMN` guarded con `information_schema` + `PREPARE`/`EXECUTE`.
- 07-07-02_add_motivo_cancelacion_pedidos: mismo patrón.
- 07-07-02_pedido_items_soft_delete_and_unique: guard para ADD COLUMN `deleted_at`, ADD COLUMN `unique_hash` (ahora `VIRTUAL` no `STORED` para evitar FK-error 1215 de InnoDB en MySQL 8.4), CREATE INDEX, CREATE UNIQUE INDEX.
- 08-08-01_add_tipo_movimiento_cambio_estado: `INSERT IGNORE`.

### `fix(scripts): install.sh no longer leaks password; better error reporting` — 1 archivo, +21/-6

- Echo final usa `${MYSQL_CMD%${MYSQL_PASS}}` para sacar el password de la salida (antes se imprimía en claro).
- Pre-check distingue 3 modos de falla de conexión: Access denied / Can't connect / otros. Antes siempre decía 'servicio no corriendo', lo que confundía cuando el problema real era password.

### `docs: support MySQL 8.4 LTS as production target` — 4 archivos, +59/-6

- AGENTS.md: 'Stack > Base de datos' ahora dice 8.4 LTS supported, 9.x compatible. Gotchas reemplazadas por notas homelab-specific.
- README.md y openspec/config.yaml: misma corrección.
- DECISIONES.md: 3 nuevos ADRs
  - **#11** MySQL 8.4 LTS como target soportado (rationale: LTS vs innovation, portabilidad).
  - **#12** `pedido_items.unique_hash` como VIRTUAL (no STORED). Documenta el FK-error 1215 engañoso de InnoDB al agregar STORED generated column sobre tabla con FKs.
  - **#13** Estrategia de idempotencia: pattern `information_schema` + `PREPARE`/`EXECUTE`, `INSERT IGNORE`, `CREATE OR REPLACE`. Menciona tabla `schema_migrations` como evolución futura.

## Verificación

Probado contra MySQL 8.4.11 homelab (192.168.0.216) corriendo `./db/scripts/install.sh` tres veces consecutivas:

- Corrida 1 (BD limpia tras DROP): completa, 25/10/12.
- Corrida 2 (BD ya migrada, sin DROP): completa, 25/10/12. Migrations incrementales muestran 'skipping'.
- Corrida 3 (BD ya migrada, sin DROP): completa, 25/10/12. Confirma idempotencia real.

## Notas

- **No requiere migración de datos existentes**: solo cambia cómo se ejecutan las migraciones en re-run. En una BD ya aplicada, el comportamiento es idéntico al anterior.
- **No toca lógica de la app ni dominio**: solo `db/` + docs.
- La inconsistencia residual en DECISIONES.md línea 182 (que dice 'AGENTS.md menciona 9.6 porque esa era la versión del dev local') se resuelve en este mismo PR (ver commit de docs).