### PR TITLE
Post-PR #87: 4 follow-ups de install.sh y migraciones (#88)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,8 +66,13 @@ mysql -uroot                           # cliente root
 mysql -uroot extragas < db/migrations/<archivo>.sql  # migración puntual
 
 # BD — scripts
-./db/scripts/install.sh                # crear BD + migraciones + seed (idempotente)
-./db/scripts/reset.sh                  # drop + recreate (solo dev)
+./db/scripts/install.sh                       # crear BD + migraciones + seed (idempotente, skip-by-checksum)
+./db/scripts/setup_migrator_user.sh           # crear user extragas_migrator (idempotente, una vez como root)
+./db/scripts/reset.sh                         # drop + recreate (solo dev)
+
+# install.sh con migrator user (recomendado para homelab)
+MYSQL_USER=root MYSQL_MIGRATOR_PASS='xxx' ./db/scripts/setup_migrator_user.sh   # una vez
+MYSQL_MIGRATOR_USER=extragas_migrator MYSQL_MIGRATOR_PASS='xxx' ./db/scripts/install.sh
 
 # .NET
 dotnet restore                         # restore de paquetes
@@ -160,10 +165,10 @@ src/ExtraGasMVC/                    proyecto ASP.NET Core MVC (.NET 10.0)
 
 - El entorno actual apunta a un **homelab** (`192.168.0.216`) con MySQL 8.4.11, no a un server local. El cliente MySQL (`brew install mysql-client`) está en keg-only y requiere agregar `/opt/homebrew/opt/mysql-client/bin` al PATH.
 - Si `mysqladmin ping` (sin env vars) tira "Can't connect to local MySQL server through socket", es porque no pasaste `MYSQL_HOST` — el default es `localhost`. Exportá `MYSQL_HOST=tu_server` antes de correr el script.
-- El user `extragas` en el homelab requiere grants especiales para que `install.sh` corra: `GRANT SYSTEM_VARIABLES_ADMIN ON *.* TO 'extragas'@'192.168.0.%'` y `SET GLOBAL log_bin_trust_function_creators = 1` (binlog activo en MySQL 8.x con replicación).
+- El user `extragas` en el homelab es el user de la app. NO debe tener `SYSTEM_VARIABLES_ADMIN` (privilegio global) — para instalar/migrar se usa un user separado `extragas_migrator` con privilegios completos sobre `extragas.*` + `SYSTEM_VARIABLES_ADMIN`. Crear/rotar con `./db/scripts/setup_migrator_user.sh` (idempotente, requiere MYSQL_USER=root). El binlog de MySQL 8.x con replicación exige `SET GLOBAL log_bin_trust_function_creators = 1` para crear triggers — eso lo hace el migrator user (con SYSTEM_VARIABLES_ADMIN), no la app.
 - Si el cliente está en Apple Silicon y Homebrew no está, instalalo con `brew install mysql-client` (sin server).
 - El socket queda en `/tmp/mysql.sock` (no en `/var/mysql/`). Si una app cliente se queja, exportar `TMPDIR=/tmp`.
-- `install.sh` es **idempotente** sobre la estructura inicial (CREATE TABLE/VIEW/TRIGGER con IF NOT EXISTS) y sobre las migraciones incrementales que usan el patrón `information_schema` + `PREPARE`/`EXECUTE` o `INSERT IGNORE`. Si una migración nueva no es idempotente, falla en re-run con "Table/Column already exists" o "Duplicate key". Ver ADR #13 en `db/docs/DECISIONES.md` para el patrón correcto.
+- `install.sh` es **idempotente** sobre la estructura inicial (CREATE TABLE/VIEW/TRIGGER con IF NOT EXISTS), sobre las migraciones incrementales (patrón `information_schema` + `PREPARE`/`EXECUTE` o `INSERT IGNORE`), y mantiene además una tabla `schema_migrations` (filename PK + checksum SHA256) que skipea migraciones ya aplicadas y detecta drift (checksum cambió en archivo ya aplicado → abort con error explícito). Ver ADR #13 en `db/docs/DECISIONES.md`.
 - La migración de seed (`20260102_000009_seed_data.sql`) inlina las 24 provincias argentinas. El archivo `db/seed/provincias_argentina.sql` se conserva como referencia documental.
 - Los triggers usan `SIGNAL SQLSTATE` para validar; si la app recibe un error, traducirlo desde la capa de UI.
 - En passwords de BD, evitá caracteres que bash expanda (`$`, `*`, `!`, espacios). Si los necesitás, exportá con comillas simples: `MYSQL_PASS='Pa$$W0rd'`.

--- a/db/docs/DECISIONES.md
+++ b/db/docs/DECISIONES.md
@@ -199,25 +199,35 @@ Documento de decisiones (ADR-style) y supuestos del sistema **ExtraGas**.
 
 ## 13. Estrategia de idempotencia para migraciones incrementales
 
-**Decisión:** las migraciones incrementales (las posteriores a la creación inicial del schema) deben ser idempotentes — re-ejecutables sin fallar contra una BD que ya las tiene aplicadas.
+**Decisión:** las migraciones incrementales (las posteriores a la creación inicial del schema) deben ser idempotentes — re-ejecutables sin fallar contra una BD que ya las tiene aplicadas. La idempotencia se garantiza en **dos capas**:
 
-**Por qué:** `db/scripts/install.sh` declara ser idempotente. Las migraciones iniciales (CREATE TABLE, CREATE VIEW) usan `IF NOT EXISTS` y son naturalmente idempotentes. Las incrementales no lo son por defecto:
-- `ALTER TABLE ADD COLUMN` falla si la columna ya existe.
-- `ALTER TABLE DROP COLUMN` falla si la columna no existe.
-- `INSERT INTO lookup` falla con duplicate key.
+1. **Capa SQL (dentro de cada `.sql`)**: cada migración es auto-suficiente y no falla al re-ejecutarse.
+2. **Capa runner (`db/scripts/install.sh`)**: mantiene una tabla `schema_migrations` con `filename` (PK) + `checksum` (SHA256 del contenido). Si el archivo está registrado y su checksum no cambió, se skipea sin ejecutar.
 
-Esto bloquea re-correr el script después de un `DROP DATABASE` parcial, o si se quiere re-aplicar una migración puntual.
+**Por qué dos capas:**
+- La capa SQL protege contra re-ejecuciones accidentales (defensa en profundidad).
+- La capa runner evita ejecutar el archivo completo cuando no hace falta, y — más importante — **detecta drift**: si alguien edita una migración ya aplicada, el checksum no coincide y `install.sh` aborta con error explícito en lugar de re-ejecutar algo que no es lo que se aplicó originalmente.
 
-**Cómo se logra:**
+**Capa SQL — cómo se logra:**
 - **ADD/DROP COLUMN**: MySQL 8.x no soporta `IF [NOT] EXISTS` para columnas en `ALTER TABLE`. Se usa el patrón `information_schema` + `PREPARE`/`EXECUTE` para ejecutar condicionalmente.
 - **INSERT en lookup**: `INSERT IGNORE` (descarta solo el error de duplicate-key, no otros errores).
 - **CREATE/DROP VIEW, CREATE TRIGGER**: ya idempotentes con `IF NOT EXISTS` / `DROP IF EXISTS`.
 - **CREATE TABLE**: ya idempotente con `IF NOT EXISTS`.
 - **CREATE INDEX UNIQUE**: requiere `DROP INDEX` previo si el índice ya existe con el mismo nombre (ver migración 20260606_000001).
+- **Status SELECT final**: cuando el archivo imprime un "OK" al terminar, debe ser **condicional** sobre el estado real (ver migración `20260607_000001_drop_pedidos_entregado.sql` post-PR #88). Un SELECT incondicional contradice los mensajes del IF-guard y confunde al debug.
+
+**Capa runner — cómo funciona `install.sh`:**
+1. **Bootstrap defensivo**: `CREATE TABLE IF NOT EXISTS schema_migrations (...)` antes del loop. Cubre el caso de BD recién creada (todavía no se aplicó la migración que crea la tabla).
+2. **Para cada `.sql`**: calcula SHA256 del contenido, consulta `SELECT checksum FROM schema_migrations WHERE filename = ?`.
+   - **Fila no existe** → ejecuta el archivo y hace `INSERT INTO schema_migrations`.
+   - **Fila existe, checksum coincide** → skip con mensaje "already applied".
+   - **Fila existe, checksum distinto** → aborta con error explícito: `migration modified after application; restore the file or write a new migration`.
+3. Las migraciones existentes (las que ya tienen guards de `information_schema`) no se tocan — siguen siendo defensa en profundidad.
 
 **Implicancia:**
-- Las migraciones nuevas deben seguir este patrón. Code review debe verificar idempotencia antes de aceptar una migración nueva.
-- La solución definitiva (más robusta) sería una tabla `schema_migrations` con hashes de archivos aplicados y el script consultarla antes de ejecutar. No se implementa acá por costo/beneficio (un solo dev, homelab), pero queda como evolución futura si el proyecto pasa a multi-dev o CI/CD.
+- Las migraciones nuevas deben seguir el patrón de guards SQL. Code review debe verificar idempotencia antes de aceptar una migración nueva.
+- **No editar migraciones ya aplicadas.** Si se necesita cambiar comportamiento, escribir una migración nueva. Esta restricción la enforce el checksum check de `install.sh`.
+- La tabla `schema_migrations` vive en la BD `extragas`. No confundir con catálogos de dominio (estados, formas de pago, etc.).
 
 ---
 

--- a/db/migrations/20260607_000001_drop_pedidos_entregado.sql
+++ b/db/migrations/20260607_000001_drop_pedidos_entregado.sql
@@ -64,4 +64,15 @@ JOIN estados_pedido ep ON ep.id = p.estado_pedido_id
 JOIN canales_venta cv ON cv.id = p.canal_venta_id
 WHERE p.deleted_at IS NULL;
 
-SELECT 'Columna entregado eliminada y vista v_pedidos_resumen actualizada' AS status;
+-- -----------------------------------------------------------------------------
+-- Status final unificado: el SELECT original era engañoso porque se ejecutaba
+-- siempre (incluso en re-run donde la columna ya no existía). Ahora refleja
+-- el estado real: OK si el DROP ocurrió, noop si ya estaba eliminada.
+-- -----------------------------------------------------------------------------
+SET @sql = IF(@col_exists > 0,
+  'SELECT "OK: columna entregada eliminada; vista v_pedidos_resumen recreada" AS status',
+  'SELECT "noop: columna entregada ya estaba eliminada; vista v_pedidos_resumen recreada (idempotente)" AS status'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/db/migrations/20260607_000003_pedido_items_soft_delete_and_unique.sql
+++ b/db/migrations/20260607_000003_pedido_items_soft_delete_and_unique.sql
@@ -1,4 +1,4 @@
--- 20260607_000002_pedido_items_soft_delete_and_unique.sql
+-- 20260607_000003_pedido_items_soft_delete_and_unique.sql
 -- Adds soft-delete column to pedido_items and unique constraint for duplicate prevention.
 -- Issue #17: Soft-delete convention compliance.
 -- Issue #19: Race condition prevention via unique constraint.

--- a/db/migrations/20260824_000001_create_schema_migrations.sql
+++ b/db/migrations/20260824_000001_create_schema_migrations.sql
@@ -1,0 +1,28 @@
+-- =============================================================================
+-- 20260824_000001_create_schema_migrations.sql
+-- Crea la tabla `schema_migrations` para registrar cada archivo .sql aplicado,
+-- con su checksum SHA256.
+--
+-- Habilita idempotencia real en db/scripts/install.sh:
+--   - Si filename + checksum están registrados → skip (no ejecuta el archivo).
+--   - Si filename no está registrado → ejecutar y registrar.
+--   - Si filename está registrado con checksum distinto → ERROR (drift).
+--
+-- Esta tabla es esquema del proyecto, pero NO depende de ningún trigger ni
+-- del dominio: los INSERT los hace install.sh, no otra migración.
+-- Si install.sh corre contra una BD sin esta tabla, también la crea como
+-- bootstrap defensivo (CREATE TABLE IF NOT EXISTS antes del loop).
+-- =============================================================================
+
+USE extragas;
+
+CREATE TABLE IF NOT EXISTS `schema_migrations` (
+  `filename`    VARCHAR(255) NOT NULL,
+  `checksum`    CHAR(64)     NOT NULL,
+  `applied_at`  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`filename`),
+  KEY `idx_schema_migrations_applied_at` (`applied_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Registro de migraciones aplicadas (idempotencia real)';
+
+SELECT 'Tabla schema_migrations lista' AS status;

--- a/db/scripts/install.sh
+++ b/db/scripts/install.sh
@@ -6,17 +6,38 @@
 #   ./db/scripts/install.sh                # usa root sin password
 #   MYSQL_USER=miuser MYSQL_PASS=mipass ./db/scripts/install.sh
 #
-# Pre-requisito: MySQL corriendo (`brew services start mysql`)
+# Idempotencia:
+#   - Doble capa: cada migración .sql es idempotente por sí misma (guards de
+#     information_schema), y además install.sh mantiene una tabla
+#     `schema_migrations` con checksum SHA256 de cada archivo aplicado.
+#   - Si filename + checksum ya están registrados → skip (no se ejecuta el .sql).
+#   - Si filename no está registrado → ejecutar y registrar.
+#   - Si filename está registrado pero el checksum cambió → ERROR (drift
+#     detection): la migración fue editada después de aplicarse. Hay que
+#     restaurar el archivo o escribir una migración nueva.
 #
-# Idempotente: si la BD ya existe, conserva los datos y reaplica las
-# migraciones. Las migraciones estructurales usan IF NOT EXISTS / IF EXISTS /
-# CREATE OR REPLACE / INSERT IGNORE / DROP IF EXISTS, según corresponda.
-# Si una migración nueva no sigue este patrón, falla en re-run.
+# Migrator user opcional:
+#   MYSQL_MIGRATOR_USER=extragas_migrator MYSQL_MIGRATOR_PASS=xxx ./db/scripts/install.sh
+#   Si se configura, install.sh usa este user para todas las operaciones
+#   (incluyendo SET GLOBAL y CREATE TRIGGER). El user debe tener
+#   SYSTEM_VARIABLES_ADMIN + grants sobre extragas.*. Sin esta config,
+#   install.sh usa MYSQL_USER (que necesita esos privilegios por su cuenta).
+#   Para crear el migrator user, correr una vez como root:
+#     MYSQL_USER=root MYSQL_MIGRATOR_PASS=xxx ./db/scripts/setup_migrator_user.sh
+#
+# Pre-requisito: MySQL corriendo (`brew services start mysql`).
 # =============================================================================
 
 set -euo pipefail
 
 # --- Configuración -----------------------------------------------------------
+# Si solo se configura MYSQL_MIGRATOR_USER (sin MYSQL_USER), lo usamos también
+# para los pasos pre-loop (pre-check + CREATE DATABASE). Así, en un homelab
+# donde solo hay user de migraciones, no hace falta duplicar la config.
+if [ -z "${MYSQL_USER:-}" ] && [ -n "${MYSQL_MIGRATOR_USER:-}" ]; then
+  MYSQL_USER="${MYSQL_MIGRATOR_USER}"
+  MYSQL_PASS="${MYSQL_MIGRATOR_PASS:-}"
+fi
 MYSQL_USER="${MYSQL_USER:-root}"
 MYSQL_PASS="${MYSQL_PASS:-}"
 MYSQL_HOST="${MYSQL_HOST:-localhost}"
@@ -27,10 +48,31 @@ else
   MYSQL_CMD="${MYSQL_CMD}"  # sin password (instalación local de Homebrew)
 fi
 
+# User opcional para migraciones (con SYSTEM_VARIABLES_ADMIN). Si se configura,
+# install.sh lo usa para SET GLOBAL y CREATE TRIGGER en vez de MYSQL_USER.
+MYSQL_MIGRATOR_USER="${MYSQL_MIGRATOR_USER:-}"
+MYSQL_MIGRATOR_PASS="${MYSQL_MIGRATOR_PASS:-}"
+MYSQL_MIGRATOR_CMD=""
+if [ -n "${MYSQL_MIGRATOR_USER}" ]; then
+  MYSQL_MIGRATOR_CMD="mysql -u${MYSQL_MIGRATOR_USER} -h${MYSQL_HOST}"
+  if [ -n "${MYSQL_MIGRATOR_PASS}" ]; then
+    MYSQL_MIGRATOR_CMD="${MYSQL_MIGRATOR_CMD} -p${MYSQL_MIGRATOR_PASS}"
+  fi
+fi
+
 DB_NAME="extragas"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 MIGRATIONS_DIR="${PROJECT_ROOT}/db/migrations"
+
+# Helper: comando mysql efectivo (migrator si está configurado, si no MYSQL_USER).
+mysql_cmd() {
+  if [ -n "${MYSQL_MIGRATOR_CMD}" ]; then
+    echo "${MYSQL_MIGRATOR_CMD}"
+  else
+    echo "${MYSQL_CMD}"
+  fi
+}
 
 # --- Pre-checks --------------------------------------------------------------
 echo "==> Verificando conexión a MySQL..."
@@ -53,26 +95,83 @@ if [ "${EXIT_CODE}" -ne 0 ]; then
   exit 1
 fi
 ${MYSQL_CMD} -e "SELECT VERSION();" 2>/dev/null
+if [ -n "${MYSQL_MIGRATOR_USER}" ]; then
+  echo "    Migrator user: ${MYSQL_MIGRATOR_USER}@${MYSQL_HOST} (con SYSTEM_VARIABLES_ADMIN)"
+else
+  echo "    Modo: MYSQL_USER (${MYSQL_USER}) ejecuta también SET GLOBAL — debe tener SYSTEM_VARIABLES_ADMIN."
+fi
 
 # --- Crear BD ----------------------------------------------------------------
 echo "==> Creando base de datos ${DB_NAME} (si no existe)..."
 ${MYSQL_CMD} -e "CREATE DATABASE IF NOT EXISTS ${DB_NAME} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
 
-# --- Correr migraciones en orden ---------------------------------------------
+# --- Bootstrap defensivo: tabla schema_migrations ----------------------------
+# La migración 20260824_000001_create_schema_migrations.sql también la crea,
+# pero necesitamos que exista ANTES del loop para poder consultarla.
+EFFECTIVE_CMD=$(mysql_cmd)
+echo "==> Asegurando tabla schema_migrations (bootstrap defensivo)..."
+${EFFECTIVE_CMD} "${DB_NAME}" <<'EOF'
+CREATE TABLE IF NOT EXISTS `schema_migrations` (
+  `filename`    VARCHAR(255) NOT NULL,
+  `checksum`    CHAR(64)     NOT NULL,
+  `applied_at`  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`filename`),
+  KEY `idx_schema_migrations_applied_at` (`applied_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Registro de migraciones aplicadas (idempotencia real)';
+EOF
+
+# --- Detectar herramienta SHA256 --------------------------------------------
+if command -v sha256sum >/dev/null 2>&1; then
+  compute_sha256() { sha256sum "$1" | awk '{print $1}'; }
+elif command -v shasum >/dev/null 2>&1; then
+  compute_sha256() { shasum -a 256 "$1" | awk '{print $1}'; }
+else
+  echo "    ERROR: no se encontró sha256sum ni shasum — instalá coreutils (Linux) o usá macOS" >&2
+  exit 1
+fi
+
+# --- Correr migraciones con skip-by-checksum ---------------------------------
 echo "==> Aplicando migraciones desde ${MIGRATIONS_DIR}..."
 shopt -s nullglob
 for migration_file in "${MIGRATIONS_DIR}"/*.sql; do
   filename="$(basename "${migration_file}")"
-  echo "    -> ${filename}"
-  (cd "${PROJECT_ROOT}" && ${MYSQL_CMD} "${DB_NAME}" < "${migration_file}")
+  checksum=$(compute_sha256 "${migration_file}")
+
+  # Consultar schema_migrations (registrado o no).
+  # Usamos -N para output sin cabecera y || true para tolerar tabla vacía / error transitorio.
+  applied_checksum=$(${EFFECTIVE_CMD} "${DB_NAME}" -N -e \
+    "SELECT checksum FROM schema_migrations WHERE filename = '${filename}';" 2>/dev/null || true)
+
+  if [ -z "${applied_checksum}" ]; then
+    # No aplicada: ejecutar y registrar.
+    echo "    -> ${filename}"
+    (cd "${PROJECT_ROOT}" && ${EFFECTIVE_CMD} "${DB_NAME}" < "${migration_file}")
+    ${EFFECTIVE_CMD} "${DB_NAME}" -e \
+      "INSERT INTO schema_migrations (filename, checksum) VALUES ('${filename}', '${checksum}') \
+       ON DUPLICATE KEY UPDATE checksum=VALUES(checksum), applied_at=CURRENT_TIMESTAMP;" \
+      2>/dev/null
+  elif [ "${applied_checksum}" = "${checksum}" ]; then
+    # Aplicada con mismo checksum: skip.
+    echo "    -> ${filename} (already applied)"
+  else
+    # Drift: el archivo fue modificado después de aplicarse.
+    echo "    -> ${filename} ERROR: checksum drift detected" >&2
+    echo "       registrado: ${applied_checksum}" >&2
+    echo "       actual:     ${checksum}" >&2
+    echo "       La migración fue modificada después de aplicarse." >&2
+    echo "       Para continuar: restaurar el archivo original o escribir una migración nueva." >&2
+    exit 1
+  fi
 done
 shopt -u nullglob
 
 # --- Verificación final ------------------------------------------------------
 echo "==> Verificación final..."
-TABLE_COUNT=$(${MYSQL_CMD} "${DB_NAME}" -N -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='${DB_NAME}' AND table_type='BASE TABLE';" 2>/dev/null)
-VIEW_COUNT=$(${MYSQL_CMD} "${DB_NAME}" -N -e "SELECT COUNT(*) FROM information_schema.views WHERE table_schema='${DB_NAME}';" 2>/dev/null)
-TRIGGER_COUNT=$(${MYSQL_CMD} "${DB_NAME}" -N -e "SELECT COUNT(*) FROM information_schema.triggers WHERE trigger_schema='${DB_NAME}';" 2>/dev/null)
+TABLE_COUNT=$(${EFFECTIVE_CMD} "${DB_NAME}" -N -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='${DB_NAME}' AND table_type='BASE TABLE';" 2>/dev/null)
+VIEW_COUNT=$(${EFFECTIVE_CMD} "${DB_NAME}" -N -e "SELECT COUNT(*) FROM information_schema.views WHERE table_schema='${DB_NAME}';" 2>/dev/null)
+TRIGGER_COUNT=$(${EFFECTIVE_CMD} "${DB_NAME}" -N -e "SELECT COUNT(*) FROM information_schema.triggers WHERE trigger_schema='${DB_NAME}';" 2>/dev/null)
+APPLIED_MIGRATIONS=$(${EFFECTIVE_CMD} "${DB_NAME}" -N -e "SELECT COUNT(*) FROM schema_migrations;" 2>/dev/null)
 
 echo ""
 echo "================================================================"
@@ -81,6 +180,7 @@ echo "  BD:                ${DB_NAME}"
 echo "  Tablas:            ${TABLE_COUNT}"
 echo "  Vistas:            ${VIEW_COUNT}"
 echo "  Triggers:          ${TRIGGER_COUNT}"
+echo "  Migraciones:       ${APPLIED_MIGRATIONS} registradas"
 echo "================================================================"
 echo ""
 # Mostramos el comando sin el password (queda -p solo, así el shell lo pide).

--- a/db/scripts/setup_migrator_user.sh
+++ b/db/scripts/setup_migrator_user.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# =============================================================================
+# setup_migrator_user.sh — Crea (idempotente) el user `extragas_migrator` con
+# los grants necesarios para correr install.sh: SYSTEM_VARIABLES_ADMIN (para
+# SET GLOBAL) + permisos completos sobre `extragas.*` (para CREATE TRIGGER y
+# todo el resto del schema).
+#
+# Pensado para homelab/dev. Para producción, ajustar el host y rotar la
+# password fuera de este script.
+#
+# Uso:
+#   MYSQL_USER=root MYSQL_MIGRATOR_PASS='secretpass' ./db/scripts/setup_migrator_user.sh
+#
+# Pre-requisito: MySQL corriendo y MYSQL_USER con privilege CREATE USER.
+# Idempotente: se puede correr múltiples veces sin efecto colateral.
+# =============================================================================
+
+set -euo pipefail
+
+# --- Configuración -----------------------------------------------------------
+MYSQL_USER="${MYSQL_USER:-root}"
+MYSQL_PASS="${MYSQL_PASS:-}"
+MYSQL_HOST="${MYSQL_HOST:-localhost}"
+MIGRATOR_HOST="${MYSQL_MIGRATOR_HOST:-%}"   # '%' para homelab; ajustar para prod
+MIGRATOR_USER_NAME="${MYSQL_MIGRATOR_NAME:-extragas_migrator}"
+MYSQL_MIGRATOR_PASS="${MYSQL_MIGRATOR_PASS:-}"
+
+if [ -z "${MYSQL_MIGRATOR_PASS}" ]; then
+  echo "ERROR: MYSQL_MIGRATOR_PASS es requerido (la password del user a crear)." >&2
+  echo "       Ejemplo: MYSQL_MIGRATOR_PASS='unaPassDe16+Chars' ./db/scripts/setup_migrator_user.sh" >&2
+  exit 1
+fi
+
+if [ "${#MYSQL_MIGRATOR_PASS}" -lt 12 ]; then
+  echo "WARN: la password tiene ${#MYSQL_MIGRATOR_PASS} caracteres (recomendado >= 16)." >&2
+fi
+
+MYSQL_CMD="mysql -u${MYSQL_USER} -h${MYSQL_HOST}"
+if [ -n "${MYSQL_PASS}" ]; then
+  MYSQL_CMD="${MYSQL_CMD} -p${MYSQL_PASS}"
+fi
+
+# --- Pre-check ---------------------------------------------------------------
+echo "==> Verificando conexión a MySQL como ${MYSQL_USER}@${MYSQL_HOST}..."
+ERROR_OUTPUT=$(${MYSQL_CMD} -e "SELECT VERSION();" 2>&1 >/dev/null)
+if [ $? -ne 0 ]; then
+  echo "    ERROR: no se puede conectar. Detalle: ${ERROR_OUTPUT}" >&2
+  exit 1
+fi
+${MYSQL_CMD} -e "SELECT VERSION();" 2>/dev/null
+
+# --- Crear / actualizar user (idempotente) -----------------------------------
+echo "==> Creando/actualizando user ${MIGRATOR_USER_NAME}@${MIGRATOR_HOST}..."
+
+# MySQL 8.0+ no soporta CREATE USER IF NOT EXISTS. Usamos el patrón
+# information_schema + PREPARE/EXECUTE (consistente con las migraciones).
+${MYSQL_CMD} <<EOF
+SET @user_exists = (
+  SELECT COUNT(*) FROM mysql.user
+  WHERE user = '${MIGRATOR_USER_NAME}' AND host = '${MIGRATOR_HOST}'
+);
+SET @sql = IF(@user_exists = 0,
+  "CREATE USER '${MIGRATOR_USER_NAME}'@'${MIGRATOR_HOST}' IDENTIFIED BY '${MYSQL_MIGRATOR_PASS}'",
+  "SELECT '${MIGRATOR_USER_NAME}@${MIGRATOR_HOST} ya existe, no se recrea' AS status"
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Siempre reseteamos la password (idempotente): si el user existía, esto
+-- actualiza al valor de MYSQL_MIGRATOR_PASS. Útil para rotación.
+ALTER USER '${MIGRATOR_USER_NAME}'@'${MIGRATOR_HOST}' IDENTIFIED BY '${MYSQL_MIGRATOR_PASS}';
+EOF
+
+# --- Grants (idempotente: GRANT es idempotente en MySQL 8.x) ----------------
+echo "==> Aplicando grants..."
+${MYSQL_CMD} <<EOF
+-- SYSTEM_VARIABLES_ADMIN para SET GLOBAL (time_zone, log_bin_trust_function_creators, etc.)
+GRANT SYSTEM_VARIABLES_ADMIN ON *.* TO '${MIGRATOR_USER_NAME}'@'${MIGRATOR_HOST}';
+
+-- Grants completos sobre la BD del proyecto (necesarios para CREATE TRIGGER,
+-- CREATE VIEW, ALTER TABLE, etc.). NO usar ALL PRIVILEGES para que el GRANT
+-- quede explícito y revisable.
+GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, ALTER, INDEX, REFERENCES,
+      CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EXECUTE, TRIGGER,
+      CREATE TEMPORARY TABLES, LOCK TABLES, EVENT
+  ON \`extragas\`.* TO '${MIGRATOR_USER_NAME}'@'${MIGRATOR_HOST}';
+
+FLUSH PRIVILEGES;
+
+SELECT 'Grants aplicados correctamente' AS status;
+
+-- Verificación: mostrar grants del user
+SHOW GRANTS FOR '${MIGRATOR_USER_NAME}'@'${MIGRATOR_HOST}';
+EOF
+
+# --- Post-install: instrucciones ---------------------------------------------
+echo ""
+echo "================================================================"
+echo "  User ${MIGRATOR_USER_NAME}@${MIGRATOR_HOST} listo."
+echo ""
+echo "  Uso en install.sh:"
+echo "    MYSQL_USER=root ./db/scripts/install.sh \\"
+echo "      # modo root (todo el server, no recomendado en prod)"
+echo ""
+echo "    MYSQL_MIGRATOR_USER=${MIGRATOR_USER_NAME} \\"
+echo "    MYSQL_MIGRATOR_PASS='<esta-password>' \\"
+echo "    ./db/scripts/install.sh"
+echo ""
+echo "  Próximo paso (recomendado, manual como root):"
+echo "    REVOKE SYSTEM_VARIABLES_ADMIN ON *.* FROM 'extragas'@'%';"
+echo "    FLUSH PRIVILEGES;"
+echo "  (deja al user de la app con privilegios mínimos sobre extragas.*)."
+echo "================================================================"


### PR DESCRIPTION
## Resuelve #88 — Follow-ups post-PR #87

PR de cierre de los 4 puntos que quedaron fuera de scope del hardening de `install.sh` (PR #87). Cada tarea está en un commit atómico para revisión independiente.

### Tareas cubiertas

| # | Tarea | Commit | Estado |
|---|---|---|---|
| D | Renombrar migración con timestamp duplicado | `8c1cfc9` | ✅ |
| A | Mensaje engañoso en `drop_pedidos_entregado` | `44083ca` | ✅ |
| C | Tabla `schema_migrations` + ADR #13 evolucionado | `e52ba83` | ✅ |
| C | `install.sh` usa skip por checksum SHA256 | `31165c0` | ✅ |
| B | User `extragas_migrator` + script idempotente + `install.sh` con `MYSQL_MIGRATOR_USER` | `b81701d` | ✅ |

### Cambios principales

**Schema:**
- Nueva tabla `schema_migrations (filename PK, checksum CHAR(64), applied_at)` con índice en `applied_at`.
- Migración `20260824_000001_create_schema_migrations.sql` la crea (CREATE TABLE IF NOT EXISTS).
- `install.sh` calcula SHA256 de cada `.sql` (portable: `sha256sum` o `shasum`); si está registrado y coincide → skip; si cambió → abort con error.

**Scripts:**
- `install.sh` ahora tiene doble capa de idempotencia: la SQL de cada migración (defensa en profundidad) y la de schema_migrations (skip real + drift detection).
- Nuevo script `setup_migrator_user.sh` idempotente que crea/actualiza `extragas_migrator@%` con `SYSTEM_VARIABLES_ADMIN` + grants sobre `extragas.*`. Crea el user solo si no existe (information_schema + PREPARE/EXECUTE — `CREATE USER IF NOT EXISTS` no existe en MySQL 8.x).
- `install.sh` soporta `MYSQL_MIGRATOR_USER` / `MYSQL_MIGRATOR_PASS` para usar el user de migraciones. Si solo se configura el migrator user (sin `MYSQL_USER`), también lo usa para pre-checks y CREATE DATABASE.

**ADR #13 reescrito** en `db/docs/DECISIONES.md`: la estrategia de idempotencia ahora es explícitamente de dos capas, con énfasis en la detección de drift como beneficio principal.

**AGENTS.md** actualizado: el bloque de comandos clave menciona el migrator user; el gotcha sobre el user `extragas` refleja el nuevo flujo (privilegios mínimos, sin `SYSTEM_VARIABLES_ADMIN`).

### Validación contra homelab (192.168.0.216, MySQL 8.4.11)

Ejecutado y verificado:
- ✅ Primera corrida con `MYSQL_USER=root`: aplica 16 migraciones (15 existentes + la nueva `schema_migrations`).
- ✅ Segunda corrida: todas como `(already applied)` — skip real por checksum.
- ✅ Drift detection: agregar un caracter a una migración aplicada → abort con mensaje accionable.
- ✅ Reversión + re-run: vuelve a `(already applied)`.
- ✅ `setup_migrator_user.sh` corre 2 veces seguidas, idempotente.
- ✅ `install.sh` con `MYSQL_MIGRATOR_USER=extragas_migrator` (sin `MYSQL_USER`): corre completo, tabla final con 16 registradas.

### Cambios en homelab (efecto colateral)

- User `extragas_migrator@%` creado con `SYSTEM_VARIABLES_ADMIN` + ALL en `extragas.*`.
- `SYSTEM_VARIABLES_ADMIN` revocado al user `extragas@192.168.0.%` (privilegio creep innecesario para el user de la app).
- 16 filas en `schema_migrations` (las 15 migraciones existentes + la nueva).

### Acceptance criteria de la issue #88

- [x] **A**: re-run muestra un solo mensaje coherente (`noop:` o `OK:` según el caso real).
- [x] **B**: `extragas` ya no tiene `SYSTEM_VARIABLES_ADMIN` (privilegio global revocado); `install.sh` corre con el migrator user; queda documentado en AGENTS.md.
- [x] **C**: re-run skipea vía `schema_migrations`; drift explícito; IF NOT EXISTS defensivo en `install.sh`.
- [x] **D**: `20260607_000002_pedido_items_soft_delete_and_unique.sql` renombrada a `20260607_000003_*`.

### Notas

- El user de la app (`extragas`) actualmente no se está usando (appsettings.json apunta a root). Cuando se migre la app a usar `extragas`, va a operar normal porque sigue teniendo ALL sobre `extragas.*` — solo se removió el privilegio global.
- Para producción: rotar la password de `extragas_migrator` fuera del script y ajustar el host (`MYSQL_MIGRATOR_HOST`) según necesidad.
- Total diff: **+294 / −26** en 7 archivos. Bien por debajo del umbral de review.

Closes #88