### PR TITLE
feat(auth): mejoras de lockout, auditoria, politica y recuperacion (#90)

### DIFF
--- a/ExtraGasMVC.sln
+++ b/ExtraGasMVC.sln
@@ -7,6 +7,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExtraGasMVC", "src\ExtraGasMVC\ExtraGasMVC.csproj", "{18461402-B97C-421A-A0E4-66AB48BA6231}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExtraGasMVC.Tests", "tests\ExtraGasMVC.Tests\ExtraGasMVC.Tests.csproj", "{0989FD0B-8228-4F3C-9E99-ED9180D1DAA8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,11 +33,24 @@ Global
 		{18461402-B97C-421A-A0E4-66AB48BA6231}.Release|x64.Build.0 = Release|Any CPU
 		{18461402-B97C-421A-A0E4-66AB48BA6231}.Release|x86.ActiveCfg = Release|Any CPU
 		{18461402-B97C-421A-A0E4-66AB48BA6231}.Release|x86.Build.0 = Release|Any CPU
+		{0989FD0B-8228-4F3C-9E99-ED9180D1DAA8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0989FD0B-8228-4F3C-9E99-ED9180D1DAA8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0989FD0B-8228-4F3C-9E99-ED9180D1DAA8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0989FD0B-8228-4F3C-9E99-ED9180D1DAA8}.Debug|x64.Build.0 = Debug|Any CPU
+		{0989FD0B-8228-4F3C-9E99-ED9180D1DAA8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0989FD0B-8228-4F3C-9E99-ED9180D1DAA8}.Debug|x86.Build.0 = Debug|Any CPU
+		{0989FD0B-8228-4F3C-9E99-ED9180D1DAA8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0989FD0B-8228-4F3C-9E99-ED9180D1DAA8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0989FD0B-8228-4F3C-9E99-ED9180D1DAA8}.Release|x64.ActiveCfg = Release|Any CPU
+		{0989FD0B-8228-4F3C-9E99-ED9180D1DAA8}.Release|x64.Build.0 = Release|Any CPU
+		{0989FD0B-8228-4F3C-9E99-ED9180D1DAA8}.Release|x86.ActiveCfg = Release|Any CPU
+		{0989FD0B-8228-4F3C-9E99-ED9180D1DAA8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{18461402-B97C-421A-A0E4-66AB48BA6231} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{0989FD0B-8228-4F3C-9E99-ED9180D1DAA8} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/db/docs/DECISIONES.md
+++ b/db/docs/DECISIONES.md
@@ -231,6 +231,35 @@ Documento de decisiones (ADR-style) y supuestos del sistema **ExtraGas**.
 
 ---
 
+## 14. Autenticacion propia (sin ASP.NET Core Identity) — lockout, politica configurable, auditoria y recuperacion admin-assisted
+
+**Contexto:** el sistema necesitaba endurecer la autenticacion (lockout por intentos fallidos, politica de password configurable, auditoria de logins, recuperacion admin-assisted) pero sin migrar a ASP.NET Core Identity por costo de adopcion y dependencia externa.
+
+**Decisiones tomadas:**
+
+1. **Mensaje generico anti-user-enumeration**: el login devuelve el mismo texto ("Usuario o contrasena invalidos") para `UserNotFound`, `UserDeleted` e `InvalidPassword`. Solo `LockedOut` y `UserInactive` se diferencian porque el usuario legitimo necesita saber por que no entra. Esto evita que un atacante use el endpoint para enumerar usernames validos.
+
+2. **Lockout sin re-hashear**: cuando una cuenta esta bloqueada (`bloqueado_hasta > NOW()`), `ValidateAndLoadForAuthAsync` rechaza antes de invocar `BCrypt.Verify`. Esto previene timing-attack: no se puede deducir si la password era correcta a partir del tiempo de respuesta.
+
+3. **`LoginResult` + `LoginFailureReason` como contrato**: el servicio no devuelve `UsuarioDto? null` sino un record `LoginResult(User, FailureReason, AttemptedUserId)`. Esto permite propagar el motivo de fallo a la UI (para mensajes especificos) y a la auditoria (para `motivo_fallo`). `AttemptedUserId` lleva el id del usuario conocido aun cuando el login fallo por inactivo/eliminado/lockout/password — clave para vincular los intentos fallidos al usuario real en `auditoria_logins`.
+
+4. **Auditoria desacoplada del login**: `RecordAsync` se invoca dentro de un `try/catch` que loguea con `ILogger` y no propaga. Si la tabla `auditoria_logins` tiene un problema (constraint, deadlock), el login sigue funcionando. La trazabilidad se prefiere sobre garantia absoluta de persistencia; un follow-up podria migrar a outbox.
+
+5. **PasswordPolicy + AuthLockout via `IOptions<>`**: ambas opciones se bindean al arranque. Cambios requieren reinicio. Out-of-scope la migracion a `IOptionsMonitor<>`.
+
+6. **`TemporaryPasswordGenerator` criptografico**: usa `RandomNumberGenerator.GetInt32` (no `Random`), garantiza lower/upper/digit/symbol en las primeras 4 posiciones y aplica Fisher-Yates al final. Resultado: passwords no predecibles que cumplen la policy por construccion.
+
+7. **ForwardedHeaders opcional**: detras de un reverse proxy, `HttpContext.Connection.RemoteIpAddress` ya viene reescrito por el middleware `UseForwardedHeaders` cuando hay `KnownProxies`/`KnownNetworks` configurados. Sin config, ASP.NET falla a "closed" (no reescribe), evitando IP spoofing. Configurar `ForwardedHeaders` en appsettings por entorno.
+
+8. **TempData una-vez para password temporal**: el POST de `ResetPassword` asigna `TempData["TemporaryPassword"]` y redirige a `Edit`. El GET de `Edit` usa `TempData.Peek` + `TempData.Remove` para asegurar que la password se muestre exactamente una vez (no reaparece en refresh). El modelo de cookie-based TempData del ASP.NET Core hace esto seguro: el `Remove` actualiza la cookie, el siguiente request no la ve.
+
+**Implicancia:**
+- No introducir ASP.NET Core Identity sin antes evaluar estas primitivas — la mayoria del valor de Identity (lockout, policy, hash) ya esta cubierta por esta capa.
+- Los archivos `Configuration/AuthLockoutOptions.cs` y `Configuration/PasswordPolicyOptions.cs` son la unica fuente de verdad para esos tunables. Cambiar defaults requiere migracion conceptual, no de datos.
+- Tests automatizados de `PasswordPolicyService.Validate`, `UsuarioService.HandleFailedAttemptAsync` y `TemporaryPasswordGenerator.Generate` quedan pendientes como deuda explicita.
+
+---
+
 ## Supuestos explícitos (no validados con el usuario)
 
 1. No hay delivery con zonas / tarifas distintas. Un pedido = una dirección.

--- a/db/migrations/20260828_000001_add_usuarios_lockout.sql
+++ b/db/migrations/20260828_000001_add_usuarios_lockout.sql
@@ -1,0 +1,47 @@
+-- =============================================================================
+-- 20260828_000001_add_usuarios_lockout.sql
+-- Adds lockout columns to `usuarios` for failed-login protection.
+-- Issue #90 (mejora #1): lockout por intentos fallidos.
+--
+-- - intentos_fallidos: SMALLINT UNSIGNED, contador de intentos fallidos
+--   consecutivos desde el último login exitoso (o desde el reset).
+-- - bloqueado_hasta: DATETIME NULL, fecha hasta la cual el usuario está
+--   bloqueado. NULL = no bloqueado.
+--
+-- Idempotente: ALTER TABLE ADD COLUMN no soporta IF NOT EXISTS, usamos
+-- information_schema + PREPARE/EXECUTE (mismo patrón que otras migraciones).
+-- =============================================================================
+
+USE extragas;
+
+-- Columna intentos_fallidos
+SET @col_exists = (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE()
+    AND table_name = 'usuarios'
+    AND column_name = 'intentos_fallidos'
+);
+SET @sql = IF(@col_exists = 0,
+  'ALTER TABLE usuarios ADD COLUMN intentos_fallidos SMALLINT UNSIGNED NOT NULL DEFAULT 0 AFTER ultimo_login',
+  'SELECT "Column intentos_fallidos ya existe, skipping" AS status'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Columna bloqueado_hasta
+SET @col_exists = (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE()
+    AND table_name = 'usuarios'
+    AND column_name = 'bloqueado_hasta'
+);
+SET @sql = IF(@col_exists = 0,
+  'ALTER TABLE usuarios ADD COLUMN bloqueado_hasta DATETIME NULL AFTER intentos_fallidos',
+  'SELECT "Column bloqueado_hasta ya existe, skipping" AS status'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT 'Lockout columns agregadas a usuarios' AS status;

--- a/db/migrations/20260828_000002_create_auditoria_logins.sql
+++ b/db/migrations/20260828_000002_create_auditoria_logins.sql
@@ -1,0 +1,39 @@
+-- =============================================================================
+-- 20260828_000002_create_auditoria_logins.sql
+-- Creates auditoria_logins table to log every login attempt (successful or not).
+-- Issue #90 (mejora #4): auditoria de intentos de login.
+--
+-- Permite detectar ataques de fuerza bruta y auditar accesos historicos.
+-- Se registra TODO intento, exista el usuario o no, con username_intentado
+-- para mantener trazabilidad incluso de intentos a usuarios inexistentes.
+--
+-- - motivo_fallo: codigo de LoginFailureReason (None, UserNotFound, UserInactive,
+--   UserDeleted, InvalidPassword, LockedOut). NULL cuando exito = TRUE.
+-- - FK a usuarios con ON DELETE SET NULL: si se elimina un usuario se mantiene
+--   la fila de auditoria (no se pierde evidencia historica).
+-- - ip_origen VARCHAR(45): alcance para IPv4 + IPv6 (max 45 chars).
+-- - Idempotente: la tabla se crea solo si no existe.
+-- =============================================================================
+
+USE extragas;
+
+CREATE TABLE IF NOT EXISTS `auditoria_logins` (
+  `id`                 BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `username_intentado` VARCHAR(50)     NOT NULL,
+  `usuario_id`         BIGINT UNSIGNED NULL,
+  `exito`              TINYINT(1)      NOT NULL,
+  `motivo_fallo`       VARCHAR(20)     NULL,
+  `ip_origen`          VARCHAR(45)     NULL,
+  `user_agent`         VARCHAR(255)    NULL,
+  `created_at`         DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_auditoria_logins_created_at` (`created_at`),
+  KEY `idx_auditoria_logins_usuario_id` (`usuario_id`),
+  KEY `idx_auditoria_logins_ip_origen` (`ip_origen`),
+  CONSTRAINT `fk_auditoria_logins_usuario`
+    FOREIGN KEY (`usuario_id`) REFERENCES `usuarios` (`id`)
+    ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Registro de intentos de login (exitosos y fallidos)';
+
+SELECT 'Tabla auditoria_logins lista' AS status;

--- a/db/migrations/20260828_000003_add_debe_cambiar_password.sql
+++ b/db/migrations/20260828_000003_add_debe_cambiar_password.sql
@@ -1,0 +1,30 @@
+-- =============================================================================
+-- 20260828_000003_add_debe_cambiar_password.sql
+-- Adds debe_cambiar_password flag to usuarios for forced password change.
+-- Issue #90 (mejora #2): recuperacion de contrasena admin-assisted.
+--
+-- Cuando un admin resetea la password de un usuario, se genera una password
+-- temporal y se marca este flag en TRUE. En el siguiente login, el usuario
+-- es redirigido a la pantalla de cambio obligatorio hasta que setee su
+-- propia contrasena (luego el flag vuelve a FALSE).
+--
+-- Idempotente: ALTER TABLE ADD COLUMN con guard en information_schema.
+-- =============================================================================
+
+USE extragas;
+
+SET @col_exists = (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE()
+    AND table_name = 'usuarios'
+    AND column_name = 'debe_cambiar_password'
+);
+SET @sql = IF(@col_exists = 0,
+  'ALTER TABLE usuarios ADD COLUMN debe_cambiar_password TINYINT(1) NOT NULL DEFAULT 0 AFTER bloqueado_hasta',
+  'SELECT "Column debe_cambiar_password ya existe, skipping" AS status'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT 'Column debe_cambiar_password agregada' AS status;

--- a/src/ExtraGasMVC/Configuration/AuthLockoutOptions.cs
+++ b/src/ExtraGasMVC/Configuration/AuthLockoutOptions.cs
@@ -3,6 +3,10 @@ namespace ExtraGasMVC.Configuration;
 /// <summary>
 /// Opciones de lockout por intentos fallidos de login.
 /// Bound desde la sección "Auth:Lockout" de appsettings.
+///
+/// IMPORTANTE: el binding se hace en el arranque del proceso con IOptions&lt;&gt;.
+/// Cambios en appsettings.json requieren reinicio de la aplicacion.
+/// Si se necesita hot-reload, migrar a IOptionsMonitor&lt;&gt;.
 /// </summary>
 public class AuthLockoutOptions
 {
@@ -10,7 +14,7 @@ public class AuthLockoutOptions
 
     /// <summary>
     /// Cantidad máxima de intentos fallidos consecutivos antes de bloquear.
-    /// 0 o negativo desactiva el lockout.
+    /// 0 o negativo desactiva el lockout (util para tests o para apagarlo en dev).
     /// </summary>
     public int MaxFailedAttempts { get; set; } = 5;
 

--- a/src/ExtraGasMVC/Configuration/AuthLockoutOptions.cs
+++ b/src/ExtraGasMVC/Configuration/AuthLockoutOptions.cs
@@ -1,0 +1,21 @@
+namespace ExtraGasMVC.Configuration;
+
+/// <summary>
+/// Opciones de lockout por intentos fallidos de login.
+/// Bound desde la sección "Auth:Lockout" de appsettings.
+/// </summary>
+public class AuthLockoutOptions
+{
+    public const string SectionName = "Auth:Lockout";
+
+    /// <summary>
+    /// Cantidad máxima de intentos fallidos consecutivos antes de bloquear.
+    /// 0 o negativo desactiva el lockout.
+    /// </summary>
+    public int MaxFailedAttempts { get; set; } = 5;
+
+    /// <summary>
+    /// Duración del bloqueo en minutos tras alcanzar el umbral.
+    /// </summary>
+    public int LockoutMinutes { get; set; } = 15;
+}

--- a/src/ExtraGasMVC/Configuration/PasswordPolicyOptions.cs
+++ b/src/ExtraGasMVC/Configuration/PasswordPolicyOptions.cs
@@ -1,7 +1,11 @@
 namespace ExtraGasMVC.Configuration;
 
 /// <summary>
-/// Política configurable de contraseñas. Bound desde "Auth:PasswordPolicy".
+/// Política configurable de contraseñas. Bound desde "Auth:PasswordPolicy" de appsettings.
+///
+/// IMPORTANTE: el binding se hace en el arranque del proceso con IOptions&lt;&gt;.
+/// Cambios en appsettings.json requieren reinicio de la aplicacion.
+/// Si se necesita hot-reload, migrar a IOptionsMonitor&lt;&gt;.
 /// </summary>
 public class PasswordPolicyOptions
 {

--- a/src/ExtraGasMVC/Configuration/PasswordPolicyOptions.cs
+++ b/src/ExtraGasMVC/Configuration/PasswordPolicyOptions.cs
@@ -1,0 +1,40 @@
+namespace ExtraGasMVC.Configuration;
+
+/// <summary>
+/// Política configurable de contraseñas. Bound desde "Auth:PasswordPolicy".
+/// </summary>
+public class PasswordPolicyOptions
+{
+    public const string SectionName = "Auth:PasswordPolicy";
+
+    /// <summary>
+    /// Longitud mínima de la contraseña. 0 o negativo desactiva la regla.
+    /// </summary>
+    public int MinLength { get; set; } = 8;
+
+    /// <summary>
+    /// Requiere al menos una letra mayúscula (A-Z).
+    /// </summary>
+    public bool RequireUppercase { get; set; } = true;
+
+    /// <summary>
+    /// Requiere al menos una letra minúscula (a-z).
+    /// </summary>
+    public bool RequireLowercase { get; set; } = true;
+
+    /// <summary>
+    /// Requiere al menos un dígito (0-9).
+    /// </summary>
+    public bool RequireDigit { get; set; } = true;
+
+    /// <summary>
+    /// Requiere al menos un símbolo no alfanumérico.
+    /// </summary>
+    public bool RequireSpecialChar { get; set; } = false;
+
+    /// <summary>
+    /// Cantidad máxima de caracteres consecutivos repetidos permitidos.
+    /// 0 o negativo desactiva la regla. Default 4 evita "aaaa".
+    /// </summary>
+    public int MaxConsecutiveChars { get; set; } = 4;
+}

--- a/src/ExtraGasMVC/Controllers/AccountController.cs
+++ b/src/ExtraGasMVC/Controllers/AccountController.cs
@@ -14,15 +14,18 @@ public class AccountController : BaseController
     private readonly IUsuarioService _usuarioService;
     private readonly IAuditoriaLoginService _auditoriaService;
     private readonly IPasswordPolicyService _passwordPolicy;
+    private readonly ILogger<AccountController> _logger;
 
     public AccountController(
         IUsuarioService usuarioService,
         IAuditoriaLoginService auditoriaService,
-        IPasswordPolicyService passwordPolicy)
+        IPasswordPolicyService passwordPolicy,
+        ILogger<AccountController> logger)
     {
         _usuarioService = usuarioService;
         _auditoriaService = auditoriaService;
         _passwordPolicy = passwordPolicy;
+        _logger = logger;
     }
 
     [HttpGet]
@@ -52,14 +55,26 @@ public class AccountController : BaseController
         // Registrar el intento en auditoria (siempre, exista o no el usuario).
         // usuarioId lleva el id del usuario conocido incluso si el login fallo por
         // inactivo/eliminado/lockout/password (ver LoginResult.AttemptedUserId).
-        await _auditoriaService.RecordAsync(
-            usernameIntentado: usuario,
-            usuarioId: loginResult.AttemptedUserId,
-            exito: loginResult.Success,
-            motivoFallo: loginResult.FailureReason,
-            ipOrigen: GetClientIp(),
-            userAgent: GetUserAgent(),
-            ct: default);
+        // La auditoria esta desacoplada del flujo de login: si la insercion falla,
+        // se registra el error y se continua; no debe bloquear la autenticacion.
+        try
+        {
+            await _auditoriaService.RecordAsync(
+                usernameIntentado: usuario,
+                usuarioId: loginResult.AttemptedUserId,
+                exito: loginResult.Success,
+                motivoFallo: loginResult.FailureReason,
+                ipOrigen: GetClientIp(),
+                userAgent: GetUserAgent(),
+                ct: default);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Fallo registrando intento de login para '{Username}' (exito={Success}, motivo={Reason}). " +
+                "El login continua normalmente.",
+                usuario, loginResult.Success, loginResult.FailureReason);
+        }
 
         if (!loginResult.Success)
         {

--- a/src/ExtraGasMVC/Controllers/AccountController.cs
+++ b/src/ExtraGasMVC/Controllers/AccountController.cs
@@ -12,10 +12,12 @@ namespace ExtraGasMVC.Controllers;
 public class AccountController : Controller
 {
     private readonly IUsuarioService _usuarioService;
+    private readonly IAuditoriaLoginService _auditoriaService;
 
-    public AccountController(IUsuarioService usuarioService)
+    public AccountController(IUsuarioService usuarioService, IAuditoriaLoginService auditoriaService)
     {
         _usuarioService = usuarioService;
+        _auditoriaService = auditoriaService;
     }
 
     [HttpGet]
@@ -39,6 +41,17 @@ public class AccountController : Controller
         }
 
         var loginResult = await _usuarioService.ValidateAndLoadForAuthAsync(usuario, password);
+
+        // Registrar el intento en auditoria (siempre, exista o no el usuario).
+        await _auditoriaService.RecordAsync(
+            usernameIntentado: usuario,
+            usuarioId: loginResult.User?.Id,
+            exito: loginResult.Success,
+            motivoFallo: loginResult.FailureReason,
+            ipOrigen: GetClientIp(),
+            userAgent: GetUserAgent(),
+            ct: default);
+
         if (!loginResult.Success)
         {
             ModelState.AddModelError(string.Empty, MapLoginFailureToMessage(loginResult.FailureReason));
@@ -82,6 +95,19 @@ public class AccountController : Controller
         // si el usuario existe.
         _ => "Usuario o contrasena invalidos."
     };
+
+    private string? GetClientIp()
+    {
+        // Connection.RemoteIpAddress puede ser null detras de ciertos proxies;
+        // en produccion se suele complementar con X-Forwarded-For.
+        return HttpContext.Connection.RemoteIpAddress?.ToString();
+    }
+
+    private string? GetUserAgent()
+    {
+        var ua = HttpContext.Request.Headers.UserAgent.ToString();
+        return string.IsNullOrWhiteSpace(ua) ? null : (ua.Length > 255 ? ua[..255] : ua);
+    }
 
     [HttpPost]
     [ValidateAntiForgeryToken]

--- a/src/ExtraGasMVC/Controllers/AccountController.cs
+++ b/src/ExtraGasMVC/Controllers/AccountController.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using ExtraGasMVC.Services;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -37,13 +38,14 @@ public class AccountController : Controller
             return View();
         }
 
-        var userDto = await _usuarioService.ValidateAndLoadForAuthAsync(usuario, password);
-        if (userDto is null)
+        var loginResult = await _usuarioService.ValidateAndLoadForAuthAsync(usuario, password);
+        if (!loginResult.Success)
         {
-            ModelState.AddModelError(string.Empty, "Usuario o contrasena invalidos.");
+            ModelState.AddModelError(string.Empty, MapLoginFailureToMessage(loginResult.FailureReason));
             return View();
         }
 
+        var userDto = loginResult.User!;
         var claims = new List<Claim>
         {
             new(ClaimTypes.NameIdentifier, userDto.Id.ToString()),
@@ -69,6 +71,17 @@ public class AccountController : Controller
 
         return RedirectToAction("Index", "Home");
     }
+
+    private static string MapLoginFailureToMessage(LoginFailureReason reason) => reason switch
+    {
+        LoginFailureReason.LockedOut =>
+            "Cuenta bloqueada temporalmente por demasiados intentos fallidos. Intenta nuevamente en unos minutos.",
+        LoginFailureReason.UserInactive =>
+            "El usuario esta inactivo. Contacta a un administrador.",
+        // UserNotFound, UserDeleted, InvalidPassword: mensaje generico para no delatar
+        // si el usuario existe.
+        _ => "Usuario o contrasena invalidos."
+    };
 
     [HttpPost]
     [ValidateAntiForgeryToken]

--- a/src/ExtraGasMVC/Controllers/AccountController.cs
+++ b/src/ExtraGasMVC/Controllers/AccountController.cs
@@ -157,8 +157,12 @@ public class AccountController : BaseController
 
     private string? GetClientIp()
     {
-        // Connection.RemoteIpAddress puede ser null detras de ciertos proxies;
-        // en produccion se suele complementar con X-Forwarded-For.
+        // Si el middleware UseForwardedHeaders esta configurado con KnownProxies
+        // o KnownNetworks, HttpContext.Connection.RemoteIpAddress ya viene
+        // reescrito con el primer IP de X-Forwarded-For de confianza. Sin esa
+        // config, devolvemos la IP de la conexion directa. Configurar
+        // ForwardedHeaders:KnownProxies/KnownNetworks en appsettings para
+        // entornos detras de reverse proxy (Caddy, nginx, IIS).
         return HttpContext.Connection.RemoteIpAddress?.ToString();
     }
 

--- a/src/ExtraGasMVC/Controllers/AccountController.cs
+++ b/src/ExtraGasMVC/Controllers/AccountController.cs
@@ -75,10 +75,14 @@ public class AccountController : BaseController
         }
         catch (Exception ex)
         {
+            var sanitizedUsuario = (usuario ?? string.Empty)
+                .Replace("\r", string.Empty)
+                .Replace("\n", string.Empty);
+
             _logger.LogError(ex,
                 "Fallo registrando intento de login para '{Username}' (exito={Success}, motivo={Reason}). " +
                 "El login continua normalmente.",
-                usuario, loginResult.Success, loginResult.FailureReason);
+                sanitizedUsuario, loginResult.Success, loginResult.FailureReason);
         }
 
         if (!loginResult.Success)

--- a/src/ExtraGasMVC/Controllers/AccountController.cs
+++ b/src/ExtraGasMVC/Controllers/AccountController.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using ExtraGasMVC.DTOs;
 using ExtraGasMVC.Services;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.AspNetCore.Authentication;
@@ -8,19 +9,24 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace ExtraGasMVC.Controllers;
 
-[AllowAnonymous]
-public class AccountController : Controller
+public class AccountController : BaseController
 {
     private readonly IUsuarioService _usuarioService;
     private readonly IAuditoriaLoginService _auditoriaService;
+    private readonly IPasswordPolicyService _passwordPolicy;
 
-    public AccountController(IUsuarioService usuarioService, IAuditoriaLoginService auditoriaService)
+    public AccountController(
+        IUsuarioService usuarioService,
+        IAuditoriaLoginService auditoriaService,
+        IPasswordPolicyService passwordPolicy)
     {
         _usuarioService = usuarioService;
         _auditoriaService = auditoriaService;
+        _passwordPolicy = passwordPolicy;
     }
 
     [HttpGet]
+    [AllowAnonymous]
     public IActionResult Login(string? returnUrl = null)
     {
         if (User.Identity?.IsAuthenticated == true)
@@ -32,6 +38,7 @@ public class AccountController : Controller
 
     [HttpPost]
     [ValidateAntiForgeryToken]
+    [AllowAnonymous]
     public async Task<IActionResult> Login(string usuario, string password, string? returnUrl = null)
     {
         if (string.IsNullOrWhiteSpace(usuario) || string.IsNullOrWhiteSpace(password))
@@ -79,10 +86,60 @@ public class AccountController : Controller
 
         TempData["Success"] = "Sesion iniciada.";
 
+        // Forzar cambio de password si fue marcado por un reset admin-assisted.
+        if (userDto.DebeCambiarPassword)
+        {
+            TempData["Warning"] = "Tu password fue reseteada por un administrador. Debes cambiarla antes de continuar.";
+            return RedirectToAction(nameof(ChangePassword));
+        }
+
         if (!string.IsNullOrEmpty(returnUrl) && Url.IsLocalUrl(returnUrl))
             return Redirect(returnUrl);
 
         return RedirectToAction("Index", "Home");
+    }
+
+    [HttpGet]
+    [Authorize]
+    public IActionResult ChangePassword()
+    {
+        return View(new AccountChangePasswordDto());
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    [Authorize]
+    public async Task<IActionResult> ChangePassword(AccountChangePasswordDto dto, CancellationToken ct = default)
+    {
+        if (!ModelState.IsValid)
+            return View(dto);
+
+        var policyResult = _passwordPolicy.Validate(dto.NewPassword);
+        if (!policyResult.IsValid)
+        {
+            foreach (var err in policyResult.Errors)
+                ModelState.AddModelError(nameof(dto.NewPassword), err);
+            return View(dto);
+        }
+
+        var userId = GetCurrentUserId();
+        if (userId is null)
+            return RedirectToAction(nameof(Logout));
+
+        try
+        {
+            await _usuarioService.ChangePasswordWithoutCurrentAsync(userId.Value, dto.NewPassword, ct);
+            TempData["Success"] = "Contrasena actualizada correctamente.";
+
+            // Re-issue el cookie claim para que el flag refreshed no quede inconsistente.
+            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+            return RedirectToAction(nameof(Login));
+        }
+        catch (Exception ex)
+        {
+            ModelState.AddModelError(string.Empty, $"No se pudo actualizar la contrasena: {ex.Message}");
+            return View(dto);
+        }
     }
 
     private static string MapLoginFailureToMessage(LoginFailureReason reason) => reason switch
@@ -111,6 +168,7 @@ public class AccountController : Controller
 
     [HttpPost]
     [ValidateAntiForgeryToken]
+    [AllowAnonymous]
     public async Task<IActionResult> Logout()
     {
         await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
@@ -118,5 +176,6 @@ public class AccountController : Controller
     }
 
     [HttpGet]
+    [AllowAnonymous]
     public IActionResult AccessDenied() => View();
 }

--- a/src/ExtraGasMVC/Controllers/AccountController.cs
+++ b/src/ExtraGasMVC/Controllers/AccountController.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using ExtraGasMVC.Configuration;
 using ExtraGasMVC.DTOs;
 using ExtraGasMVC.Services;
 using ExtraGasMVC.Services.Interfaces;
@@ -6,6 +7,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace ExtraGasMVC.Controllers;
 
@@ -15,17 +17,20 @@ public class AccountController : BaseController
     private readonly IAuditoriaLoginService _auditoriaService;
     private readonly IPasswordPolicyService _passwordPolicy;
     private readonly ILogger<AccountController> _logger;
+    private readonly PasswordPolicyOptions _passwordOptions;
 
     public AccountController(
         IUsuarioService usuarioService,
         IAuditoriaLoginService auditoriaService,
         IPasswordPolicyService passwordPolicy,
-        ILogger<AccountController> logger)
+        ILogger<AccountController> logger,
+        IOptions<PasswordPolicyOptions> passwordOptions)
     {
         _usuarioService = usuarioService;
         _auditoriaService = auditoriaService;
         _passwordPolicy = passwordPolicy;
         _logger = logger;
+        _passwordOptions = passwordOptions.Value;
     }
 
     [HttpGet]
@@ -120,6 +125,7 @@ public class AccountController : BaseController
     [Authorize]
     public IActionResult ChangePassword()
     {
+        ViewBag.PasswordPolicy = _passwordOptions;
         return View(new AccountChangePasswordDto());
     }
 

--- a/src/ExtraGasMVC/Controllers/AccountController.cs
+++ b/src/ExtraGasMVC/Controllers/AccountController.cs
@@ -50,9 +50,11 @@ public class AccountController : BaseController
         var loginResult = await _usuarioService.ValidateAndLoadForAuthAsync(usuario, password);
 
         // Registrar el intento en auditoria (siempre, exista o no el usuario).
+        // usuarioId lleva el id del usuario conocido incluso si el login fallo por
+        // inactivo/eliminado/lockout/password (ver LoginResult.AttemptedUserId).
         await _auditoriaService.RecordAsync(
             usernameIntentado: usuario,
-            usuarioId: loginResult.User?.Id,
+            usuarioId: loginResult.AttemptedUserId,
             exito: loginResult.Success,
             motivoFallo: loginResult.FailureReason,
             ipOrigen: GetClientIp(),

--- a/src/ExtraGasMVC/Controllers/AuditoriaLoginsController.cs
+++ b/src/ExtraGasMVC/Controllers/AuditoriaLoginsController.cs
@@ -1,4 +1,5 @@
 using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Models.ViewModels;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -25,13 +26,17 @@ public class AuditoriaLoginsController : Controller
     {
         var resultado = await _auditoriaService.SearchAsync(busqueda, ip, soloFallidos, pagina, tamanio, ct);
 
-        ViewBag.Busqueda = busqueda;
-        ViewBag.Ip = ip;
-        ViewBag.SoloFallidos = soloFallidos;
-        ViewBag.Pagina = resultado.Pagina;
-        ViewBag.Tamanio = resultado.Tamanio;
-        ViewBag.Total = resultado.Total;
+        var viewModel = new AuditoriaLoginsIndexViewModel
+        {
+            Items = resultado.Items,
+            Busqueda = busqueda,
+            Ip = ip,
+            SoloFallidos = soloFallidos,
+            Pagina = resultado.Pagina,
+            Tamanio = resultado.Tamanio,
+            Total = resultado.Total,
+        };
 
-        return View(resultado.Items);
+        return View(viewModel);
     }
 }

--- a/src/ExtraGasMVC/Controllers/AuditoriaLoginsController.cs
+++ b/src/ExtraGasMVC/Controllers/AuditoriaLoginsController.cs
@@ -1,0 +1,37 @@
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Services.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ExtraGasMVC.Controllers;
+
+[Authorize(Policy = "AdminOnly")]
+public class AuditoriaLoginsController : Controller
+{
+    private readonly IAuditoriaLoginService _auditoriaService;
+
+    public AuditoriaLoginsController(IAuditoriaLoginService auditoriaService)
+    {
+        _auditoriaService = auditoriaService;
+    }
+
+    public async Task<IActionResult> Index(
+        string? busqueda,
+        string? ip,
+        bool soloFallidos = false,
+        int pagina = 1,
+        int tamanio = 50,
+        CancellationToken ct = default)
+    {
+        var resultado = await _auditoriaService.SearchAsync(busqueda, ip, soloFallidos, pagina, tamanio, ct);
+
+        ViewBag.Busqueda = busqueda;
+        ViewBag.Ip = ip;
+        ViewBag.SoloFallidos = soloFallidos;
+        ViewBag.Pagina = resultado.Pagina;
+        ViewBag.Tamanio = resultado.Tamanio;
+        ViewBag.Total = resultado.Total;
+
+        return View(resultado.Items);
+    }
+}

--- a/src/ExtraGasMVC/Controllers/UsuariosController.cs
+++ b/src/ExtraGasMVC/Controllers/UsuariosController.cs
@@ -9,10 +9,12 @@ namespace ExtraGasMVC.Controllers;
 public class UsuariosController : BaseController
 {
     private readonly IUsuarioService _usuarioService;
+    private readonly IPasswordPolicyService _passwordPolicy;
 
-    public UsuariosController(IUsuarioService usuarioService)
+    public UsuariosController(IUsuarioService usuarioService, IPasswordPolicyService passwordPolicy)
     {
         _usuarioService = usuarioService;
+        _passwordPolicy = passwordPolicy;
     }
 
     public async Task<IActionResult> Index(string? busqueda, ulong? rolId, bool soloActivos = false,
@@ -49,6 +51,15 @@ public class UsuariosController : BaseController
     {
         if (!ModelState.IsValid)
         {
+            ViewBag.EmpleadosSinUsuario = await _usuarioService.GetEmpleadosSinUsuarioAsync(ct);
+            return View(dto);
+        }
+
+        var policyResult = _passwordPolicy.Validate(dto.Password);
+        if (!policyResult.IsValid)
+        {
+            foreach (var err in policyResult.Errors)
+                ModelState.AddModelError(nameof(dto.Password), err);
             ViewBag.EmpleadosSinUsuario = await _usuarioService.GetEmpleadosSinUsuarioAsync(ct);
             return View(dto);
         }
@@ -149,6 +160,13 @@ public class UsuariosController : BaseController
         if (!ModelState.IsValid)
         {
             TempData["Error"] = "Verifique los datos ingresados.";
+            return RedirectToAction(nameof(Edit), new { id });
+        }
+
+        var policyResult = _passwordPolicy.Validate(dto.NewPassword);
+        if (!policyResult.IsValid)
+        {
+            TempData["Error"] = string.Join(" ", policyResult.Errors);
             return RedirectToAction(nameof(Edit), new { id });
         }
 

--- a/src/ExtraGasMVC/Controllers/UsuariosController.cs
+++ b/src/ExtraGasMVC/Controllers/UsuariosController.cs
@@ -100,6 +100,16 @@ public class UsuariosController : BaseController
             Activo = usuario.Activo
         };
 
+        // TempData de la password temporal se consume en este render: Peek para leer
+        // sin borrarla del storage, Remove para invalidarla. Asi un refresh posterior
+        // del admin NO re-mostrara la password (cumpliendo "se muestra una sola vez").
+        var temporaryPassword = TempData.Peek("TemporaryPassword") as string;
+        var temporaryPasswordUsername = TempData.Peek("TemporaryPasswordUsername") as string;
+        if (temporaryPassword is not null) TempData.Remove("TemporaryPassword");
+        if (temporaryPasswordUsername is not null) TempData.Remove("TemporaryPasswordUsername");
+
+        ViewBag.TemporaryPassword = temporaryPassword;
+        ViewBag.TemporaryPasswordUsername = temporaryPasswordUsername;
         ViewBag.Usuario = usuario;
         ViewBag.Roles = await _usuarioService.GetRolesAsync(ct);
         ViewBag.CurrentUserId = GetCurrentUserId();

--- a/src/ExtraGasMVC/Controllers/UsuariosController.cs
+++ b/src/ExtraGasMVC/Controllers/UsuariosController.cs
@@ -102,6 +102,7 @@ public class UsuariosController : BaseController
 
         ViewBag.Usuario = usuario;
         ViewBag.Roles = await _usuarioService.GetRolesAsync(ct);
+        ViewBag.CurrentUserId = GetCurrentUserId();
         return View(updateDto);
     }
 
@@ -149,6 +150,36 @@ public class UsuariosController : BaseController
             ? "Usuario desactivado correctamente."
             : "No se encontro el usuario.";
         return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> ResetPassword(ulong id, CancellationToken ct = default)
+    {
+        var currentUserId = GetCurrentUserId();
+        if (id == currentUserId)
+        {
+            TempData["Error"] = "No puede resetear su propia contrasena. Use el formulario de cambio.";
+            return RedirectToAction(nameof(Edit), new { id });
+        }
+
+        try
+        {
+            var temporaryPassword = await _usuarioService.ResetPasswordAsync(id, currentUserId, ct);
+            TempData["TemporaryPassword"] = temporaryPassword;
+            TempData["TemporaryPasswordUsername"] = (await _usuarioService.GetByIdAsync(id, ct))?.Username;
+            TempData["Success"] = "Contrasena reseteada. La password temporal se muestra debajo UNA SOLA VEZ.";
+        }
+        catch (KeyNotFoundException)
+        {
+            TempData["Error"] = "No se encontro el usuario.";
+        }
+        catch (Exception ex)
+        {
+            TempData["Error"] = $"No se pudo resetear la contrasena: {ex.Message}";
+        }
+
+        return RedirectToAction(nameof(Edit), new { id });
     }
 
     [HttpPost]

--- a/src/ExtraGasMVC/DTOs/AccountChangePasswordDto.cs
+++ b/src/ExtraGasMVC/DTOs/AccountChangePasswordDto.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ExtraGasMVC.DTOs;
+
+public class AccountChangePasswordDto
+{
+    [Required(ErrorMessage = "La nueva contrasena es obligatoria.")]
+    [DataType(DataType.Password)]
+    public string NewPassword { get; set; } = null!;
+
+    [Required(ErrorMessage = "Debes confirmar la nueva contrasena.")]
+    [DataType(DataType.Password)]
+    [Compare(nameof(NewPassword), ErrorMessage = "Las contrasenas no coinciden.")]
+    public string ConfirmPassword { get; set; } = null!;
+}

--- a/src/ExtraGasMVC/DTOs/AuditoriaLoginListDto.cs
+++ b/src/ExtraGasMVC/DTOs/AuditoriaLoginListDto.cs
@@ -1,0 +1,17 @@
+using ExtraGasMVC.DTOs;
+
+namespace ExtraGasMVC.DTOs;
+
+public class AuditoriaLoginListDto
+{
+    public ulong Id { get; set; }
+    public string UsernameIntentado { get; set; } = null!;
+    public ulong? UsuarioId { get; set; }
+    public string? UsuarioNombre { get; set; }
+    public bool Exito { get; set; }
+    public string? MotivoFallo { get; set; }
+    public string? MotivoFalloLegible { get; set; }
+    public string? IpOrigen { get; set; }
+    public string? UserAgent { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/src/ExtraGasMVC/DTOs/UsuarioDto.cs
+++ b/src/ExtraGasMVC/DTOs/UsuarioDto.cs
@@ -34,7 +34,6 @@ public class CreateUsuarioDto
     public string? Email { get; set; }
 
     [Required(ErrorMessage = "La contrasena es obligatoria.")]
-    [StringLength(100, MinimumLength = 6, ErrorMessage = "La contrasena debe tener al menos 6 caracteres.")]
     [DataType(DataType.Password)]
     public string Password { get; set; } = null!;
 
@@ -69,7 +68,6 @@ public class ChangePasswordDto
     public string CurrentPassword { get; set; } = null!;
 
     [Required(ErrorMessage = "La nueva contrasena es obligatoria.")]
-    [StringLength(100, MinimumLength = 6, ErrorMessage = "La contrasena debe tener al menos 6 caracteres.")]
     [DataType(DataType.Password)]
     public string NewPassword { get; set; } = null!;
 

--- a/src/ExtraGasMVC/DTOs/UsuarioDto.cs
+++ b/src/ExtraGasMVC/DTOs/UsuarioDto.cs
@@ -12,6 +12,7 @@ public class UsuarioDto
     public string? RolNombre { get; set; }
     public bool Activo { get; set; }
     public DateTime? UltimoLogin { get; set; }
+    public bool DebeCambiarPassword { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
     public ulong? CreatedBy { get; set; }

--- a/src/ExtraGasMVC/Data/Configurations/AuditoriaLoginConfiguration.cs
+++ b/src/ExtraGasMVC/Data/Configurations/AuditoriaLoginConfiguration.cs
@@ -1,0 +1,54 @@
+using ExtraGasMVC.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ExtraGasMVC.Data.Configurations;
+
+public class AuditoriaLoginConfiguration : IEntityTypeConfiguration<AuditoriaLogin>
+{
+    public void Configure(EntityTypeBuilder<AuditoriaLogin> builder)
+    {
+        builder.ToTable("auditoria_logins");
+
+        builder.HasKey(a => a.Id);
+        builder.Property(a => a.Id).HasColumnName("id");
+
+        builder.Property(a => a.UsernameIntentado)
+            .HasColumnName("username_intentado")
+            .HasMaxLength(50)
+            .IsRequired();
+
+        builder.Property(a => a.UsuarioId).HasColumnName("usuario_id");
+        builder.Property(a => a.Exito)
+            .HasColumnName("exito")
+            .HasColumnType("tinyint(1)");
+
+        builder.Property(a => a.MotivoFallo)
+            .HasColumnName("motivo_fallo")
+            .HasMaxLength(20);
+
+        builder.Property(a => a.IpOrigen)
+            .HasColumnName("ip_origen")
+            .HasMaxLength(45);
+
+        builder.Property(a => a.UserAgent)
+            .HasColumnName("user_agent")
+            .HasMaxLength(255);
+
+        builder.Property(a => a.CreatedAt)
+            .HasColumnName("created_at")
+            .HasColumnType("datetime")
+            .ValueGeneratedOnAdd()
+            .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+        builder.HasOne(a => a.Usuario)
+            .WithMany()
+            .HasForeignKey(a => a.UsuarioId)
+            .OnDelete(DeleteBehavior.SetNull)
+            .HasConstraintName("fk_auditoria_logins_usuario");
+
+        builder.HasIndex(a => a.CreatedAt).HasDatabaseName("idx_auditoria_logins_created_at");
+        builder.HasIndex(a => a.UsuarioId).HasDatabaseName("idx_auditoria_logins_usuario_id");
+        builder.HasIndex(a => a.IpOrigen).HasDatabaseName("idx_auditoria_logins_ip_origen");
+    }
+}

--- a/src/ExtraGasMVC/Data/Configurations/UsuarioConfiguration.cs
+++ b/src/ExtraGasMVC/Data/Configurations/UsuarioConfiguration.cs
@@ -37,6 +37,15 @@ public class UsuarioConfiguration : IEntityTypeConfiguration<Usuario>
             .HasColumnName("ultimo_login")
             .HasColumnType("datetime");
 
+        builder.Property(u => u.IntentosFallidos)
+            .HasColumnName("intentos_fallidos")
+            .HasColumnType("smallint unsigned")
+            .HasDefaultValue(0);
+
+        builder.Property(u => u.BloqueadoHasta)
+            .HasColumnName("bloqueado_hasta")
+            .HasColumnType("datetime");
+
         builder.Property(u => u.CreatedAt)
             .HasColumnName("created_at")
             .HasColumnType("datetime")

--- a/src/ExtraGasMVC/Data/Configurations/UsuarioConfiguration.cs
+++ b/src/ExtraGasMVC/Data/Configurations/UsuarioConfiguration.cs
@@ -46,6 +46,11 @@ public class UsuarioConfiguration : IEntityTypeConfiguration<Usuario>
             .HasColumnName("bloqueado_hasta")
             .HasColumnType("datetime");
 
+        builder.Property(u => u.DebeCambiarPassword)
+            .HasColumnName("debe_cambiar_password")
+            .HasColumnType("tinyint(1)")
+            .HasDefaultValue(false);
+
         builder.Property(u => u.CreatedAt)
             .HasColumnName("created_at")
             .HasColumnType("datetime")

--- a/src/ExtraGasMVC/Data/Context/ExtraGasDbContext.cs
+++ b/src/ExtraGasMVC/Data/Context/ExtraGasDbContext.cs
@@ -24,6 +24,7 @@ public class ExtraGasDbContext : DbContext
     // ============== Personas y seguridad ==============
     public DbSet<Usuario> Usuarios => Set<Usuario>();
     public DbSet<Empleado> Empleados => Set<Empleado>();
+    public DbSet<AuditoriaLogin> AuditoriaLogins => Set<AuditoriaLogin>();
     public DbSet<Cliente> Clientes => Set<Cliente>();
     public DbSet<ClienteContacto> ClienteContactos => Set<ClienteContacto>();
     public DbSet<Proveedor> Proveedores => Set<Proveedor>();

--- a/src/ExtraGasMVC/Data/Entities/AuditoriaLogin.cs
+++ b/src/ExtraGasMVC/Data/Entities/AuditoriaLogin.cs
@@ -1,0 +1,19 @@
+namespace ExtraGasMVC.Data.Entities;
+
+/// <summary>
+/// Registro de un intento de login (exitoso o fallido).
+/// Se inserta una fila por cada intento, exista o no el usuario.
+/// </summary>
+public class AuditoriaLogin
+{
+    public ulong Id { get; set; }
+    public string UsernameIntentado { get; set; } = null!;
+    public ulong? UsuarioId { get; set; }
+    public bool Exito { get; set; }
+    public string? MotivoFallo { get; set; }
+    public string? IpOrigen { get; set; }
+    public string? UserAgent { get; set; }
+    public DateTime CreatedAt { get; set; }
+
+    public Usuario? Usuario { get; set; }
+}

--- a/src/ExtraGasMVC/Data/Entities/Usuario.cs
+++ b/src/ExtraGasMVC/Data/Entities/Usuario.cs
@@ -11,6 +11,7 @@ public class Usuario
     public DateTime? UltimoLogin { get; set; }
     public ushort IntentosFallidos { get; set; }
     public DateTime? BloqueadoHasta { get; set; }
+    public bool DebeCambiarPassword { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
     public ulong? CreatedBy { get; set; }

--- a/src/ExtraGasMVC/Data/Entities/Usuario.cs
+++ b/src/ExtraGasMVC/Data/Entities/Usuario.cs
@@ -9,6 +9,8 @@ public class Usuario
     public ulong RolId { get; set; }
     public bool Activo { get; set; }
     public DateTime? UltimoLogin { get; set; }
+    public ushort IntentosFallidos { get; set; }
+    public DateTime? BloqueadoHasta { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
     public ulong? CreatedBy { get; set; }

--- a/src/ExtraGasMVC/Models/ViewModels/AuditoriaLoginsIndexViewModel.cs
+++ b/src/ExtraGasMVC/Models/ViewModels/AuditoriaLoginsIndexViewModel.cs
@@ -1,0 +1,24 @@
+using ExtraGasMVC.DTOs;
+
+namespace ExtraGasMVC.Models.ViewModels;
+
+/// <summary>
+/// ViewModel tipado para la pantalla de auditoria de logins. Reemplaza el
+/// uso de ViewBag en AuditoriaLoginsController.Index y permite que la vista
+/// sea descubrible desde el compilador.
+/// </summary>
+public class AuditoriaLoginsIndexViewModel
+{
+    public required IReadOnlyList<AuditoriaLoginListDto> Items { get; init; }
+
+    /// <summary>Filtros aplicados (eco para mantener el estado de los inputs del form).</summary>
+    public string? Busqueda { get; init; }
+    public string? Ip { get; init; }
+    public bool SoloFallidos { get; init; }
+
+    /// <summary>Estado de paginacion.</summary>
+    public int Pagina { get; init; } = 1;
+    public int Tamanio { get; init; } = 50;
+    public int Total { get; init; }
+    public int TotalPaginas => Tamanio > 0 ? (int)Math.Ceiling(Total / (double)Tamanio) : 0;
+}

--- a/src/ExtraGasMVC/Program.cs
+++ b/src/ExtraGasMVC/Program.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Sockets;
 using System.Security.Claims;
 using ExtraGasMVC.Configuration;
 using ExtraGasMVC.Data.Context;
@@ -76,6 +78,43 @@ if (!app.Environment.IsDevelopment())
     app.UseHsts();
 }
 
+// Soporte para reverse proxies (Caddy, nginx, IIS, Cloudflare): el middleware
+// reescribe HttpContext.Connection.RemoteIpAddress con el primer IP de
+// X-Forwarded-For cuando el request proviene de un proxy/red confiable.
+// Solo se aplica si hay al menos un KnownProxy/Network configurado; sin
+// ninguno, ASP.NET falla a "closed" y no se reescribe nada (defensa contra
+// spoofing de IP). Configurar via appsettings:
+//   "ForwardedHeaders": {
+//     "KnownProxies":  ["10.0.0.5", "192.168.1.20"],
+//     "KnownNetworks": ["10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12"]
+//   }
+var forwardedHeadersSection = builder.Configuration.GetSection("ForwardedHeaders");
+var hasForwardedConfig = forwardedHeadersSection.Exists();
+if (hasForwardedConfig)
+{
+    var forwardedOptions = new Microsoft.AspNetCore.Builder.ForwardedHeadersOptions
+    {
+        ForwardedHeaders = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedFor
+                         | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto,
+        RequireHeaderSymmetry = false,
+        ForwardLimit = 2,
+    };
+
+    var knownProxies = forwardedHeadersSection.GetSection("KnownProxies").Get<string[]>();
+    if (knownProxies is not null)
+        foreach (var ip in knownProxies)
+            if (System.Net.IPAddress.TryParse(ip, out var addr))
+                forwardedOptions.KnownProxies.Add(addr);
+
+    var knownNetworks = forwardedHeadersSection.GetSection("KnownNetworks").Get<string[]>();
+    if (knownNetworks is not null)
+        foreach (var cidr in knownNetworks)
+            if (TryParseCidr(cidr, out var network))
+                forwardedOptions.KnownIPNetworks.Add(network);
+
+    app.UseForwardedHeaders(forwardedOptions);
+}
+
 app.UseHttpsRedirection();
 app.UseRouting();
 
@@ -90,3 +129,25 @@ app.MapControllerRoute(
     .WithStaticAssets();
 
 app.Run();
+
+// Parsea un CIDR ("192.168.0.0/16") a IPNetwork. Usado por la configuracion
+// de ForwardedHeaders.KnownNetworks.
+static bool TryParseCidr(string cidr, out IPNetwork network)
+{
+    network = default;
+    var parts = cidr.Split('/');
+    if (parts.Length != 2) return false;
+    if (!IPAddress.TryParse(parts[0], out var prefix)) return false;
+    if (!int.TryParse(parts[1], out var bits)) return false;
+    var max = prefix.AddressFamily == AddressFamily.InterNetwork ? 32 : 128;
+    if (bits < 0 || bits > max) return false;
+    try
+    {
+        network = IPNetwork.Parse(cidr);
+        return true;
+    }
+    catch
+    {
+        return false;
+    }
+}

--- a/src/ExtraGasMVC/Program.cs
+++ b/src/ExtraGasMVC/Program.cs
@@ -36,6 +36,9 @@ builder.Services.AddAuthorization(options =>
 builder.Services.Configure<AuthLockoutOptions>(
     builder.Configuration.GetSection(AuthLockoutOptions.SectionName));
 
+builder.Services.Configure<PasswordPolicyOptions>(
+    builder.Configuration.GetSection(PasswordPolicyOptions.SectionName));
+
 // Registrar AutoMapper
 builder.Services.AddAutoMapper(typeof(MappingProfile).Assembly);
 
@@ -61,6 +64,7 @@ builder.Services.AddScoped<IUsuarioService, UsuarioService>();
 builder.Services.AddScoped<IEmpleadoService, EmpleadoService>();
 builder.Services.AddScoped<IRecepcionService, RecepcionService>();
 builder.Services.AddScoped<IAuditoriaLoginService, AuditoriaLoginService>();
+builder.Services.AddSingleton<IPasswordPolicyService, PasswordPolicyService>();
 
 var app = builder.Build();
 

--- a/src/ExtraGasMVC/Program.cs
+++ b/src/ExtraGasMVC/Program.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using ExtraGasMVC.Configuration;
 using ExtraGasMVC.Data.Context;
 using ExtraGasMVC.Mappings;
 using ExtraGasMVC.Services.Implementations;
@@ -30,6 +31,10 @@ builder.Services.AddAuthorization(options =>
     options.AddPolicy("AdminOnly", policy => policy.RequireRole("ADMIN"));
     options.AddPolicy("OperadorOrAdmin", policy => policy.RequireRole("ADMIN", "OPERADOR"));
 });
+
+// Bind AuthLockoutOptions desde appsettings (sección "Auth:Lockout").
+builder.Services.Configure<AuthLockoutOptions>(
+    builder.Configuration.GetSection(AuthLockoutOptions.SectionName));
 
 // Registrar AutoMapper
 builder.Services.AddAutoMapper(typeof(MappingProfile).Assembly);

--- a/src/ExtraGasMVC/Program.cs
+++ b/src/ExtraGasMVC/Program.cs
@@ -60,6 +60,7 @@ builder.Services.AddScoped<IGarrafaService, GarrafaService>();
 builder.Services.AddScoped<IUsuarioService, UsuarioService>();
 builder.Services.AddScoped<IEmpleadoService, EmpleadoService>();
 builder.Services.AddScoped<IRecepcionService, RecepcionService>();
+builder.Services.AddScoped<IAuditoriaLoginService, AuditoriaLoginService>();
 
 var app = builder.Build();
 

--- a/src/ExtraGasMVC/Services/Implementations/AuditoriaLoginService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/AuditoriaLoginService.cs
@@ -1,0 +1,121 @@
+using ExtraGasMVC.Data.Context;
+using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace ExtraGasMVC.Services.Implementations;
+
+public class AuditoriaLoginService : IAuditoriaLoginService
+{
+    private readonly ExtraGasDbContext _context;
+
+    public AuditoriaLoginService(ExtraGasDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task RecordAsync(
+        string usernameIntentado,
+        ulong? usuarioId,
+        bool exito,
+        LoginFailureReason motivoFallo,
+        string? ipOrigen,
+        string? userAgent,
+        CancellationToken ct = default)
+    {
+        var registro = new AuditoriaLogin
+        {
+            UsernameIntentado = usernameIntentado,
+            UsuarioId = usuarioId,
+            Exito = exito,
+            MotivoFallo = exito ? null : MapMotivo(motivoFallo),
+            IpOrigen = ipOrigen,
+            UserAgent = userAgent,
+            CreatedAt = DateTime.UtcNow,
+        };
+
+        _context.AuditoriaLogins.Add(registro);
+        await _context.SaveChangesAsync(ct);
+    }
+
+    public async Task<SearchResultDto<AuditoriaLoginListDto>> SearchAsync(
+        string? busqueda,
+        string? ip,
+        bool soloFallidos,
+        int pagina,
+        int tamanio,
+        CancellationToken ct = default)
+    {
+        var query = _context.AuditoriaLogins
+            .AsNoTracking()
+            .Include(a => a.Usuario)
+            .AsQueryable();
+
+        if (soloFallidos)
+            query = query.Where(a => !a.Exito);
+
+        if (!string.IsNullOrWhiteSpace(busqueda))
+        {
+            var q = busqueda.Trim().ToLower();
+            query = query.Where(a => a.UsernameIntentado.ToLower().Contains(q));
+        }
+
+        if (!string.IsNullOrWhiteSpace(ip))
+        {
+            var ipFilter = ip.Trim();
+            query = query.Where(a => a.IpOrigen == ipFilter);
+        }
+
+        var total = await query.CountAsync(ct);
+
+        var items = await query
+            .OrderByDescending(a => a.CreatedAt)
+            .Skip((pagina - 1) * tamanio)
+            .Take(tamanio)
+            .ToListAsync(ct);
+
+        var dtos = items.Select(a => new AuditoriaLoginListDto
+        {
+            Id = a.Id,
+            UsernameIntentado = a.UsernameIntentado,
+            UsuarioId = a.UsuarioId,
+            UsuarioNombre = a.Usuario?.Username,
+            Exito = a.Exito,
+            MotivoFallo = a.MotivoFallo,
+            MotivoFalloLegible = a.Exito ? "OK" : MapMotivoLegible(a.MotivoFallo),
+            IpOrigen = a.IpOrigen,
+            UserAgent = a.UserAgent,
+            CreatedAt = a.CreatedAt,
+        }).ToList();
+
+        return new SearchResultDto<AuditoriaLoginListDto>
+        {
+            Items = dtos,
+            Total = total,
+            Pagina = pagina,
+            Tamanio = tamanio,
+        };
+    }
+
+    private static string? MapMotivo(LoginFailureReason motivo) => motivo switch
+    {
+        LoginFailureReason.None => null,
+        LoginFailureReason.UserNotFound => "USER_NOT_FOUND",
+        LoginFailureReason.UserInactive => "USER_INACTIVE",
+        LoginFailureReason.UserDeleted => "USER_DELETED",
+        LoginFailureReason.InvalidPassword => "INVALID_PASSWORD",
+        LoginFailureReason.LockedOut => "LOCKED_OUT",
+        _ => "UNKNOWN",
+    };
+
+    private static string MapMotivoLegible(string? motivoCodigo) => motivoCodigo switch
+    {
+        "USER_NOT_FOUND" => "Usuario inexistente",
+        "USER_INACTIVE" => "Usuario inactivo",
+        "USER_DELETED" => "Usuario eliminado",
+        "INVALID_PASSWORD" => "Password incorrecta",
+        "LOCKED_OUT" => "Cuenta bloqueada",
+        _ => motivoCodigo ?? "Desconocido",
+    };
+}

--- a/src/ExtraGasMVC/Services/Implementations/PasswordPolicyService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/PasswordPolicyService.cs
@@ -1,0 +1,61 @@
+using ExtraGasMVC.Configuration;
+using ExtraGasMVC.Services.Interfaces;
+using Microsoft.Extensions.Options;
+
+namespace ExtraGasMVC.Services.Implementations;
+
+public class PasswordPolicyService : IPasswordPolicyService
+{
+    private readonly PasswordPolicyOptions _options;
+
+    public PasswordPolicyService(IOptions<PasswordPolicyOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public PasswordPolicyResult Validate(string? password)
+    {
+        if (string.IsNullOrEmpty(password))
+            return PasswordPolicyResult.Fail("La contrasena es obligatoria.");
+
+        var errors = new List<string>();
+
+        if (_options.MinLength > 0 && password.Length < _options.MinLength)
+            errors.Add($"La contrasena debe tener al menos {_options.MinLength} caracteres.");
+
+        if (_options.RequireUppercase && !password.Any(char.IsUpper))
+            errors.Add("La contrasena debe incluir al menos una letra mayuscula.");
+
+        if (_options.RequireLowercase && !password.Any(char.IsLower))
+            errors.Add("La contrasena debe incluir al menos una letra minuscula.");
+
+        if (_options.RequireDigit && !password.Any(char.IsDigit))
+            errors.Add("La contrasena debe incluir al menos un digito.");
+
+        if (_options.RequireSpecialChar && !password.Any(c => !char.IsLetterOrDigit(c)))
+            errors.Add("La contrasena debe incluir al menos un caracter especial.");
+
+        if (_options.MaxConsecutiveChars > 0 && HasTooManyConsecutiveChars(password, _options.MaxConsecutiveChars))
+            errors.Add($"La contrasena no puede tener mas de {_options.MaxConsecutiveChars} caracteres consecutivos repetidos.");
+
+        return errors.Count == 0 ? PasswordPolicyResult.Ok() : PasswordPolicyResult.Fail(errors.ToArray());
+    }
+
+    private static bool HasTooManyConsecutiveChars(string password, int max)
+    {
+        var consecutive = 1;
+        for (var i = 1; i < password.Length; i++)
+        {
+            if (password[i] == password[i - 1])
+            {
+                consecutive++;
+                if (consecutive > max) return true;
+            }
+            else
+            {
+                consecutive = 1;
+            }
+        }
+        return false;
+    }
+}

--- a/src/ExtraGasMVC/Services/Implementations/UsuarioService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/UsuarioService.cs
@@ -247,10 +247,47 @@ public class UsuarioService : IUsuarioService
             return false;
 
         usuario.PasswordHash = BCrypt.Net.BCrypt.HashPassword(newPassword);
+        usuario.DebeCambiarPassword = false;
         usuario.UpdatedAt = DateTime.UtcNow;
         await _context.SaveChangesAsync(ct);
 
         return true;
+    }
+
+    public async Task ChangePasswordWithoutCurrentAsync(ulong id, string newPassword, CancellationToken ct = default)
+    {
+        var usuario = await _context.Usuarios
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(u => u.Id == id, ct);
+
+        if (usuario is null)
+            throw new KeyNotFoundException($"Usuario con Id {id} no encontrado.");
+
+        usuario.PasswordHash = BCrypt.Net.BCrypt.HashPassword(newPassword);
+        usuario.DebeCambiarPassword = false;
+        usuario.UpdatedAt = DateTime.UtcNow;
+        await _context.SaveChangesAsync(ct);
+    }
+
+    public async Task<string> ResetPasswordAsync(ulong id, ulong? updatedBy, CancellationToken ct = default)
+    {
+        var usuario = await _context.Usuarios
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(u => u.Id == id, ct);
+
+        if (usuario is null)
+            throw new KeyNotFoundException($"Usuario con Id {id} no encontrado.");
+
+        var temporaryPassword = TemporaryPasswordGenerator.Generate(12);
+        usuario.PasswordHash = BCrypt.Net.BCrypt.HashPassword(temporaryPassword);
+        usuario.DebeCambiarPassword = true;
+        usuario.IntentosFallidos = 0;
+        usuario.BloqueadoHasta = null;
+        usuario.UpdatedAt = DateTime.UtcNow;
+        usuario.UpdatedBy = updatedBy;
+        await _context.SaveChangesAsync(ct);
+
+        return temporaryPassword;
     }
 
     private async Task EnrichDtoAsync(UsuarioDto dto, Usuario usuario, CancellationToken ct)

--- a/src/ExtraGasMVC/Services/Implementations/UsuarioService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/UsuarioService.cs
@@ -1,9 +1,11 @@
 using AutoMapper;
+using ExtraGasMVC.Configuration;
 using ExtraGasMVC.Data.Context;
 using ExtraGasMVC.Data.Entities;
 using ExtraGasMVC.DTOs;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace ExtraGasMVC.Services.Implementations;
 
@@ -11,11 +13,16 @@ public class UsuarioService : IUsuarioService
 {
     private readonly ExtraGasDbContext _context;
     private readonly IMapper _mapper;
+    private readonly AuthLockoutOptions _lockout;
 
-    public UsuarioService(ExtraGasDbContext context, IMapper mapper)
+    public UsuarioService(
+        ExtraGasDbContext context,
+        IMapper mapper,
+        IOptions<AuthLockoutOptions> lockout)
     {
         _context = context;
         _mapper = mapper;
+        _lockout = lockout.Value;
     }
 
     public async Task<UsuarioDto?> GetByIdAsync(ulong id, CancellationToken ct = default)
@@ -115,24 +122,55 @@ public class UsuarioService : IUsuarioService
         return usuario is null ? null : _mapper.Map<UsuarioDto>(usuario);
     }
 
-    public async Task<UsuarioDto?> ValidateAndLoadForAuthAsync(string username, string password, CancellationToken ct = default)
+    public async Task<LoginResult> ValidateAndLoadForAuthAsync(string username, string password, CancellationToken ct = default)
     {
         var usuario = await _context.Usuarios
-            .AsNoTracking()
             .IgnoreQueryFilters()
             .Include(u => u.Rol)
             .FirstOrDefaultAsync(u => u.Username == username, ct);
 
-        if (usuario is null) return null;
-        if (usuario.DeletedAt is not null) return null;
-        if (!usuario.Activo) return null;
-        if (!BCrypt.Net.BCrypt.Verify(password, usuario.PasswordHash)) return null;
+        if (usuario is null)
+            return LoginResult.Fail(LoginFailureReason.UserNotFound);
 
+        if (usuario.DeletedAt is not null)
+            return LoginResult.Fail(LoginFailureReason.UserDeleted);
+
+        if (!usuario.Activo)
+            return LoginResult.Fail(LoginFailureReason.UserInactive);
+
+        // Lockout vigente: rechazar sin re-hashear (no delatar si la password era correcta).
+        if (usuario.BloqueadoHasta is not null && usuario.BloqueadoHasta > DateTime.UtcNow)
+            return LoginResult.Fail(LoginFailureReason.LockedOut);
+
+        if (!BCrypt.Net.BCrypt.Verify(password, usuario.PasswordHash))
+        {
+            await HandleFailedAttemptAsync(usuario, ct);
+            return LoginResult.Fail(LoginFailureReason.InvalidPassword);
+        }
+
+        // Éxito: resetear contador y lockout, actualizar último login.
+        usuario.IntentosFallidos = 0;
+        usuario.BloqueadoHasta = null;
         usuario.UltimoLogin = DateTime.UtcNow;
         usuario.UpdatedAt = DateTime.UtcNow;
         await _context.SaveChangesAsync(ct);
 
-        return _mapper.Map<UsuarioDto>(usuario);
+        return LoginResult.Ok(_mapper.Map<UsuarioDto>(usuario));
+    }
+
+    private async Task HandleFailedAttemptAsync(Usuario usuario, CancellationToken ct)
+    {
+        // MaxFailedAttempts <= 0 desactiva el lockout (útil para tests o si se quiere apagar).
+        if (_lockout.MaxFailedAttempts <= 0)
+            return;
+
+        usuario.IntentosFallidos++;
+
+        if (usuario.IntentosFallidos >= _lockout.MaxFailedAttempts)
+            usuario.BloqueadoHasta = DateTime.UtcNow.AddMinutes(_lockout.LockoutMinutes);
+
+        usuario.UpdatedAt = DateTime.UtcNow;
+        await _context.SaveChangesAsync(ct);
     }
 
     public async Task<UsuarioDto> CreateAsync(CreateUsuarioDto dto, ulong? createdBy, CancellationToken ct = default)

--- a/src/ExtraGasMVC/Services/Implementations/UsuarioService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/UsuarioService.cs
@@ -130,22 +130,25 @@ public class UsuarioService : IUsuarioService
             .FirstOrDefaultAsync(u => u.Username == username, ct);
 
         if (usuario is null)
-            return LoginResult.Fail(LoginFailureReason.UserNotFound);
+            return LoginResult.Fail(attemptedUserId: null, LoginFailureReason.UserNotFound);
 
+        // Precedencia: DeletedAt antes que Activo. Si el usuario esta soft-deleted
+        // (independientemente de su Activo), reportamos UserDeleted para preservar
+        // la fidelidad del historial aunque se restaure Activo=true a posteriori.
         if (usuario.DeletedAt is not null)
-            return LoginResult.Fail(LoginFailureReason.UserDeleted);
+            return LoginResult.Fail(attemptedUserId: usuario.Id, LoginFailureReason.UserDeleted);
 
         if (!usuario.Activo)
-            return LoginResult.Fail(LoginFailureReason.UserInactive);
+            return LoginResult.Fail(attemptedUserId: usuario.Id, LoginFailureReason.UserInactive);
 
         // Lockout vigente: rechazar sin re-hashear (no delatar si la password era correcta).
         if (usuario.BloqueadoHasta is not null && usuario.BloqueadoHasta > DateTime.UtcNow)
-            return LoginResult.Fail(LoginFailureReason.LockedOut);
+            return LoginResult.Fail(attemptedUserId: usuario.Id, LoginFailureReason.LockedOut);
 
         if (!BCrypt.Net.BCrypt.Verify(password, usuario.PasswordHash))
         {
             await HandleFailedAttemptAsync(usuario, ct);
-            return LoginResult.Fail(LoginFailureReason.InvalidPassword);
+            return LoginResult.Fail(attemptedUserId: usuario.Id, LoginFailureReason.InvalidPassword);
         }
 
         // Éxito: resetear contador y lockout, actualizar último login.

--- a/src/ExtraGasMVC/Services/Interfaces/IAuditoriaLoginService.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IAuditoriaLoginService.cs
@@ -1,0 +1,28 @@
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Services;
+
+namespace ExtraGasMVC.Services.Interfaces;
+
+public interface IAuditoriaLoginService
+{
+    /// <summary>
+    /// Registra un intento de login. Se llama una vez por intento,
+    /// exista o no el usuario (usernameIntentado siempre se persiste).
+    /// </summary>
+    Task RecordAsync(
+        string usernameIntentado,
+        ulong? usuarioId,
+        bool exito,
+        LoginFailureReason motivoFallo,
+        string? ipOrigen,
+        string? userAgent,
+        CancellationToken ct = default);
+
+    Task<SearchResultDto<AuditoriaLoginListDto>> SearchAsync(
+        string? busqueda,
+        string? ip,
+        bool soloFallidos,
+        int pagina,
+        int tamanio,
+        CancellationToken ct = default);
+}

--- a/src/ExtraGasMVC/Services/Interfaces/IPasswordPolicyService.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IPasswordPolicyService.cs
@@ -1,0 +1,12 @@
+using ExtraGasMVC.Services;
+
+namespace ExtraGasMVC.Services.Interfaces;
+
+public interface IPasswordPolicyService
+{
+    /// <summary>
+    /// Valida una contraseña contra la política configurada.
+    /// Devuelve PasswordPolicyResult.Ok() si cumple todas las reglas.
+    /// </summary>
+    PasswordPolicyResult Validate(string? password);
+}

--- a/src/ExtraGasMVC/Services/Interfaces/IUsuarioService.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IUsuarioService.cs
@@ -2,6 +2,7 @@ using ExtraGasMVC.DTOs;
 
 namespace ExtraGasMVC.Services.Interfaces;
 
+
 public interface IUsuarioService
 {
     Task<UsuarioDto?> GetByIdAsync(ulong id, CancellationToken ct = default);
@@ -15,5 +16,5 @@ public interface IUsuarioService
     Task<UsuarioDto> UpdateAsync(UpdateUsuarioDto dto, ulong? updatedBy, CancellationToken ct = default);
     Task<bool> DeleteAsync(ulong id, CancellationToken ct = default);
     Task<bool> ChangePasswordAsync(ulong id, string currentPassword, string newPassword, CancellationToken ct = default);
-    Task<UsuarioDto?> ValidateAndLoadForAuthAsync(string username, string password, CancellationToken ct = default);
+    Task<LoginResult> ValidateAndLoadForAuthAsync(string username, string password, CancellationToken ct = default);
 }

--- a/src/ExtraGasMVC/Services/Interfaces/IUsuarioService.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IUsuarioService.cs
@@ -16,5 +16,18 @@ public interface IUsuarioService
     Task<UsuarioDto> UpdateAsync(UpdateUsuarioDto dto, ulong? updatedBy, CancellationToken ct = default);
     Task<bool> DeleteAsync(ulong id, CancellationToken ct = default);
     Task<bool> ChangePasswordAsync(ulong id, string currentPassword, string newPassword, CancellationToken ct = default);
+
+    /// <summary>
+    /// Cambia la password de un usuario sin pedir la actual. Usado cuando el
+    /// usuario esta forzado a cambiar su password (debe_cambiar_password = true).
+    /// </summary>
+    Task ChangePasswordWithoutCurrentAsync(ulong id, string newPassword, CancellationToken ct = default);
+
+    /// <summary>
+    /// Genera una password temporal aleatoria, la hashea, setea
+    /// debe_cambiar_password = true y la devuelve (se muestra una sola vez).
+    /// </summary>
+    Task<string> ResetPasswordAsync(ulong id, ulong? updatedBy, CancellationToken ct = default);
+
     Task<LoginResult> ValidateAndLoadForAuthAsync(string username, string password, CancellationToken ct = default);
 }

--- a/src/ExtraGasMVC/Services/LoginResult.cs
+++ b/src/ExtraGasMVC/Services/LoginResult.cs
@@ -17,11 +17,19 @@ public enum LoginFailureReason
     LockedOut
 }
 
-public record LoginResult(UsuarioDto? User, LoginFailureReason FailureReason)
+/// <summary>
+/// Resultado de un intento de login. <see cref="AttemptedUserId"/> lleva el id
+/// del usuario que fue encontrado en la BD (aunque después el login falle por
+/// inactivo, eliminado, lockout o password incorrecta) para que la auditoría
+/// pueda vincular el intento al usuario real. Es null solo cuando el username
+/// no existe en la tabla.
+/// </summary>
+public record LoginResult(UsuarioDto? User, LoginFailureReason FailureReason, ulong? AttemptedUserId = null)
 {
     public bool Success => User is not null;
 
-    public static LoginResult Ok(UsuarioDto user) => new(user, LoginFailureReason.None);
+    public static LoginResult Ok(UsuarioDto user) => new(user, LoginFailureReason.None, user.Id);
 
-    public static LoginResult Fail(LoginFailureReason reason) => new(null, reason);
+    public static LoginResult Fail(ulong? attemptedUserId, LoginFailureReason reason)
+        => new(null, reason, attemptedUserId);
 }

--- a/src/ExtraGasMVC/Services/LoginResult.cs
+++ b/src/ExtraGasMVC/Services/LoginResult.cs
@@ -1,0 +1,27 @@
+using ExtraGasMVC.DTOs;
+
+namespace ExtraGasMVC.Services;
+
+/// <summary>
+/// Resultado de un intento de login, usado por IUsuarioService.ValidateAndLoadForAuthAsync.
+/// Permite distinguir el motivo de fallo (necesario para mensajes específicos
+/// cuando hay lockout y para la auditoría de logins).
+/// </summary>
+public enum LoginFailureReason
+{
+    None,
+    UserNotFound,
+    UserInactive,
+    UserDeleted,
+    InvalidPassword,
+    LockedOut
+}
+
+public record LoginResult(UsuarioDto? User, LoginFailureReason FailureReason)
+{
+    public bool Success => User is not null;
+
+    public static LoginResult Ok(UsuarioDto user) => new(user, LoginFailureReason.None);
+
+    public static LoginResult Fail(LoginFailureReason reason) => new(null, reason);
+}

--- a/src/ExtraGasMVC/Services/PasswordPolicyResult.cs
+++ b/src/ExtraGasMVC/Services/PasswordPolicyResult.cs
@@ -1,0 +1,12 @@
+namespace ExtraGasMVC.Services;
+
+/// <summary>
+/// Resultado de validar una contraseña contra la política configurada.
+/// Errors contiene mensajes legibles para mostrar al usuario (uno por regla violada).
+/// </summary>
+public record PasswordPolicyResult(bool IsValid, IReadOnlyList<string> Errors)
+{
+    public static PasswordPolicyResult Ok() => new(true, Array.Empty<string>());
+
+    public static PasswordPolicyResult Fail(params string[] errors) => new(false, errors);
+}

--- a/src/ExtraGasMVC/Services/TemporaryPasswordGenerator.cs
+++ b/src/ExtraGasMVC/Services/TemporaryPasswordGenerator.cs
@@ -1,0 +1,43 @@
+using System.Security.Cryptography;
+
+namespace ExtraGasMVC.Services;
+
+/// <summary>
+/// Generador de passwords temporales aleatorios para el flujo de
+/// reseteo admin-assisted. Usa RandomNumberGenerator (criptografico)
+/// para que el resultado no sea predecible.
+/// </summary>
+public static class TemporaryPasswordGenerator
+{
+    private const string Lowercase = "abcdefghijklmnopqrstuvwxyz";
+    private const string Uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private const string Digits = "0123456789";
+    private const string Symbols = "!@#$%&*+-=?";
+    private const string AllChars = Lowercase + Uppercase + Digits + Symbols;
+
+    public static string Generate(int length = 12)
+    {
+        if (length < 8)
+            throw new ArgumentException("La password temporal debe tener al menos 8 caracteres.", nameof(length));
+
+        var password = new char[length];
+
+        // Garantizar al menos un caracter de cada set (lower/upper/digit/symbol)
+        password[0] = Lowercase[RandomNumberGenerator.GetInt32(Lowercase.Length)];
+        password[1] = Uppercase[RandomNumberGenerator.GetInt32(Uppercase.Length)];
+        password[2] = Digits[RandomNumberGenerator.GetInt32(Digits.Length)];
+        password[3] = Symbols[RandomNumberGenerator.GetInt32(Symbols.Length)];
+
+        for (var i = 4; i < length; i++)
+            password[i] = AllChars[RandomNumberGenerator.GetInt32(AllChars.Length)];
+
+        // Mezclar (Fisher-Yates) para que las primeras 4 posiciones no sean siempre el mismo set.
+        for (var i = length - 1; i > 0; i--)
+        {
+            var j = RandomNumberGenerator.GetInt32(i + 1);
+            (password[i], password[j]) = (password[j], password[i]);
+        }
+
+        return new string(password);
+    }
+}

--- a/src/ExtraGasMVC/Views/Account/ChangePassword.cshtml
+++ b/src/ExtraGasMVC/Views/Account/ChangePassword.cshtml
@@ -2,6 +2,7 @@
 @{
     ViewData["Title"] = "Cambiar contrasena";
     Layout = "_AccountLayout";
+    var policy = ViewBag.PasswordPolicy as ExtraGasMVC.Configuration.PasswordPolicyOptions;
 }
 <div class="login-box" style="width: 420px;">
     <div class="login-logo">
@@ -17,13 +18,45 @@
                 @Html.AntiForgeryToken()
                 <div asp-validation-summary="All" class="text-danger small mb-3"></div>
                 <div class="input-group mb-3">
-                    <input type="password" name="NewPassword" class="form-control" placeholder="Nueva contrasena" required autofocus minlength="8" />
+                    <input type="password" name="NewPassword" id="NewPassword" class="form-control" placeholder="Nueva contrasena" required autofocus />
                     <div class="input-group-text"><span class="bi bi-lock-fill"></span></div>
                 </div>
                 <div class="input-group mb-3">
-                    <input type="password" name="ConfirmPassword" class="form-control" placeholder="Confirmar contrasena" required minlength="8" />
+                    <input type="password" name="ConfirmPassword" id="ConfirmPassword" class="form-control" placeholder="Confirmar contrasena" required />
                     <div class="input-group-text"><span class="bi bi-lock-fill"></span></div>
                 </div>
+                @if (policy is not null)
+                {
+                    <div class="text-secondary small mb-3">
+                        <p class="mb-1">Tu nueva contrasena debe cumplir:</p>
+                        <ul class="mb-0 ps-3">
+                            @if (policy.MinLength > 0)
+                            {
+                                <li>Al menos @policy.MinLength caracteres.</li>
+                            }
+                            @if (policy.RequireUppercase)
+                            {
+                                <li>Al menos una letra mayuscula (A-Z).</li>
+                            }
+                            @if (policy.RequireLowercase)
+                            {
+                                <li>Al menos una letra minuscula (a-z).</li>
+                            }
+                            @if (policy.RequireDigit)
+                            {
+                                <li>Al menos un digito (0-9).</li>
+                            }
+                            @if (policy.RequireSpecialChar)
+                            {
+                                <li>Al menos un caracter especial.</li>
+                            }
+                            @if (policy.MaxConsecutiveChars > 0)
+                            {
+                                <li>No mas de @policy.MaxConsecutiveChars caracteres consecutivos repetidos.</li>
+                            }
+                        </ul>
+                    </div>
+                }
                 <div class="row">
                     <div class="col-12 d-grid">
                         <button type="submit" class="btn btn-primary">

--- a/src/ExtraGasMVC/Views/Account/ChangePassword.cshtml
+++ b/src/ExtraGasMVC/Views/Account/ChangePassword.cshtml
@@ -1,0 +1,37 @@
+@model ExtraGasMVC.DTOs.AccountChangePasswordDto
+@{
+    ViewData["Title"] = "Cambiar contrasena";
+    Layout = "_AccountLayout";
+}
+<div class="login-box" style="width: 420px;">
+    <div class="login-logo">
+        <a asp-controller="Home" asp-action="Index"><b>Extra</b>Gas</a>
+    </div>
+    <div class="card">
+        <div class="card-body login-card-body">
+            <p class="login-box-msg">Cambiar tu contrasena</p>
+            <p class="text-secondary small">
+                Tu contrasena fue reseteada por un administrador. Define una nueva antes de continuar.
+            </p>
+            <form asp-action="ChangePassword" method="post">
+                @Html.AntiForgeryToken()
+                <div asp-validation-summary="All" class="text-danger small mb-3"></div>
+                <div class="input-group mb-3">
+                    <input type="password" name="NewPassword" class="form-control" placeholder="Nueva contrasena" required autofocus minlength="8" />
+                    <div class="input-group-text"><span class="bi bi-lock-fill"></span></div>
+                </div>
+                <div class="input-group mb-3">
+                    <input type="password" name="ConfirmPassword" class="form-control" placeholder="Confirmar contrasena" required minlength="8" />
+                    <div class="input-group-text"><span class="bi bi-lock-fill"></span></div>
+                </div>
+                <div class="row">
+                    <div class="col-12 d-grid">
+                        <button type="submit" class="btn btn-primary">
+                            <i class="bi bi-key me-1"></i> Guardar y continuar
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/src/ExtraGasMVC/Views/Account/Login.cshtml
+++ b/src/ExtraGasMVC/Views/Account/Login.cshtml
@@ -38,7 +38,7 @@
                 </div>
             </form>
             <p class="mb-1 mt-3">
-                <a href="#" class="text-decoration-none">Recuperar contrasena</a>
+                <span class="text-secondary small">Si olvidaste tu contrasena, contacta a un administrador para que la resetee.</span>
             </p>
             <p class="mb-0">
                 <a asp-controller="Home" asp-action="Index" class="text-center text-decoration-none">

--- a/src/ExtraGasMVC/Views/AuditoriaLogins/Index.cshtml
+++ b/src/ExtraGasMVC/Views/AuditoriaLogins/Index.cshtml
@@ -1,0 +1,175 @@
+@model IEnumerable<ExtraGasMVC.DTOs.AuditoriaLoginListDto>
+@using ExtraGasMVC.Extensions
+@{
+    ViewData["Title"] = "Auditoria de logins";
+    var busqueda = ViewBag.Busqueda as string;
+    var ip = ViewBag.Ip as string;
+    var soloFallidos = (bool)(ViewBag.SoloFallidos ?? false);
+    var pagina = (int)(ViewBag.Pagina ?? 1);
+    var tamanio = (int)(ViewBag.Tamanio ?? 50);
+    var total = (int)(ViewBag.Total ?? 0);
+    var totalPaginas = tamanio > 0 ? (int)Math.Ceiling(total / (double)tamanio) : 0;
+    ViewData["Breadcrumbs"] = new List<BreadcrumbItem>
+    {
+        new() { Label = "Sistema" },
+        new() { Label = "Auditoria de logins" }
+    };
+}
+
+<div class="card">
+    <div class="card-header">
+        <form method="get" class="row g-2 align-items-end">
+            <div class="col-md-4">
+                <label class="form-label small mb-1" for="busqueda">Username intentado</label>
+                <input type="text" id="busqueda" name="busqueda" value="@busqueda" class="form-control" placeholder="ej: jperez" />
+            </div>
+            <div class="col-md-3">
+                <label class="form-label small mb-1" for="ip">IP de origen</label>
+                <input type="text" id="ip" name="ip" value="@ip" class="form-control" placeholder="ej: 192.168.1.10" />
+            </div>
+            <div class="col-md-2">
+                <div class="form-check mt-3">
+                    <input class="form-check-input" type="checkbox" id="soloFallidos" name="soloFallidos" value="true" @(soloFallidos ? "checked" : "") />
+                    <input type="hidden" name="soloFallidos" value="false" />
+                    <label class="form-check-label" for="soloFallidos">Solo fallidos</label>
+                </div>
+            </div>
+            <div class="col-md-3 d-grid gap-2 d-md-flex">
+                <button type="submit" class="btn btn-primary flex-fill">
+                    <i class="bi bi-search me-1"></i> Buscar
+                </button>
+                <a asp-action="Index" class="btn btn-outline-secondary">
+                    <i class="bi bi-arrow-counterclockwise"></i>
+                </a>
+            </div>
+        </form>
+    </div>
+    <div class="card-body table-responsive p-0">
+        <table class="table table-hover table-striped align-middle mb-0">
+            <thead>
+                <tr>
+                    <th>Fecha</th>
+                    <th>Username intentado</th>
+                    <th>Usuario real</th>
+                    <th class="text-center">Resultado</th>
+                    <th>Motivo</th>
+                    <th>IP origen</th>
+                    <th>User agent</th>
+                </tr>
+            </thead>
+            <tbody>
+                @if (!Model.Any())
+                {
+                    <tr><td colspan="7" class="text-center py-4 text-secondary">No hay intentos que coincidan con los filtros.</td></tr>
+                }
+                @foreach (var a in Model)
+                {
+                    <tr>
+                        <td>@a.CreatedAt.ToShortDateTime()</td>
+                        <td><strong>@a.UsernameIntentado</strong></td>
+                        <td>@(a.UsuarioNombre ?? (a.UsuarioId.HasValue ? $"#{a.UsuarioId}" : "-"))</td>
+                        <td class="text-center">
+                            @if (a.Exito)
+                            {
+                                <span class="badge text-bg-success">OK</span>
+                            }
+                            else
+                            {
+                                <span class="badge text-bg-danger">Fallo</span>
+                            }
+                        </td>
+                        <td>@(a.MotivoFalloLegible ?? "-")</td>
+                        <td><code class="small">@(a.IpOrigen ?? "-")</code></td>
+                        <td class="small text-secondary text-truncate" style="max-width: 280px;" title="@a.UserAgent">
+                            @(a.UserAgent ?? "-")
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+    <div class="card-footer clearfix">
+        <div class="float-end">
+            <small class="text-secondary me-2">@total registro@(total == 1 ? "" : "s")</small>
+        </div>
+        @if (totalPaginas > 1)
+        {
+            <nav>
+                <ul class="pagination pagination-sm m-0 float-end">
+                    @if (pagina > 1)
+                    {
+                        <li class="page-item">
+                            <a class="page-link"
+                               asp-action="Index"
+                               asp-route-busqueda="@busqueda"
+                               asp-route-ip="@ip"
+                               asp-route-soloFallidos="@soloFallidos"
+                               asp-route-pagina="@(pagina - 1)"
+                               asp-route-tamanio="@tamanio">&laquo;</a>
+                        </li>
+                    }
+                    @{
+                        var start = Math.Max(1, pagina - 2);
+                        var end = Math.Min(totalPaginas, pagina + 2);
+                        if (start > 1)
+                        {
+                            <li class="page-item">
+                                <a class="page-link"
+                                   asp-action="Index"
+                                   asp-route-busqueda="@busqueda"
+                                   asp-route-ip="@ip"
+                                   asp-route-soloFallidos="@soloFallidos"
+                                   asp-route-pagina="1"
+                                   asp-route-tamanio="@tamanio">1</a>
+                            </li>
+                            if (start > 2)
+                            {
+                                <li class="page-item disabled"><span class="page-link">...</span></li>
+                            }
+                        }
+                        for (var i = start; i <= end; i++)
+                        {
+                            <li class="page-item @(i == pagina ? "active" : "")">
+                                <a class="page-link"
+                                   asp-action="Index"
+                                   asp-route-busqueda="@busqueda"
+                                   asp-route-ip="@ip"
+                                   asp-route-soloFallidos="@soloFallidos"
+                                   asp-route-pagina="@i"
+                                   asp-route-tamanio="@tamanio">@i</a>
+                            </li>
+                        }
+                        if (end < totalPaginas)
+                        {
+                            if (end < totalPaginas - 1)
+                            {
+                                <li class="page-item disabled"><span class="page-link">...</span></li>
+                            }
+                            <li class="page-item">
+                                <a class="page-link"
+                                   asp-action="Index"
+                                   asp-route-busqueda="@busqueda"
+                                   asp-route-ip="@ip"
+                                   asp-route-soloFallidos="@soloFallidos"
+                                   asp-route-pagina="@totalPaginas"
+                                   asp-route-tamanio="@tamanio">@totalPaginas</a>
+                            </li>
+                        }
+                    }
+                    @if (pagina < totalPaginas)
+                    {
+                        <li class="page-item">
+                            <a class="page-link"
+                               asp-action="Index"
+                               asp-route-busqueda="@busqueda"
+                               asp-route-ip="@ip"
+                               asp-route-soloFallidos="@soloFallidos"
+                               asp-route-pagina="@(pagina + 1)"
+                               asp-route-tamanio="@tamanio">&raquo;</a>
+                        </li>
+                    }
+                </ul>
+            </nav>
+        }
+    </div>
+</div>

--- a/src/ExtraGasMVC/Views/AuditoriaLogins/Index.cshtml
+++ b/src/ExtraGasMVC/Views/AuditoriaLogins/Index.cshtml
@@ -1,14 +1,7 @@
-@model IEnumerable<ExtraGasMVC.DTOs.AuditoriaLoginListDto>
+@model ExtraGasMVC.Models.ViewModels.AuditoriaLoginsIndexViewModel
 @using ExtraGasMVC.Extensions
 @{
     ViewData["Title"] = "Auditoria de logins";
-    var busqueda = ViewBag.Busqueda as string;
-    var ip = ViewBag.Ip as string;
-    var soloFallidos = (bool)(ViewBag.SoloFallidos ?? false);
-    var pagina = (int)(ViewBag.Pagina ?? 1);
-    var tamanio = (int)(ViewBag.Tamanio ?? 50);
-    var total = (int)(ViewBag.Total ?? 0);
-    var totalPaginas = tamanio > 0 ? (int)Math.Ceiling(total / (double)tamanio) : 0;
     ViewData["Breadcrumbs"] = new List<BreadcrumbItem>
     {
         new() { Label = "Sistema" },
@@ -21,15 +14,15 @@
         <form method="get" class="row g-2 align-items-end">
             <div class="col-md-4">
                 <label class="form-label small mb-1" for="busqueda">Username intentado</label>
-                <input type="text" id="busqueda" name="busqueda" value="@busqueda" class="form-control" placeholder="ej: jperez" />
+                <input type="text" id="busqueda" name="busqueda" value="@Model.Busqueda" class="form-control" placeholder="ej: jperez" />
             </div>
             <div class="col-md-3">
                 <label class="form-label small mb-1" for="ip">IP de origen</label>
-                <input type="text" id="ip" name="ip" value="@ip" class="form-control" placeholder="ej: 192.168.1.10" />
+                <input type="text" id="ip" name="ip" value="@Model.Ip" class="form-control" placeholder="ej: 192.168.1.10" />
             </div>
             <div class="col-md-2">
                 <div class="form-check mt-3">
-                    <input class="form-check-input" type="checkbox" id="soloFallidos" name="soloFallidos" value="true" @(soloFallidos ? "checked" : "") />
+                    <input class="form-check-input" type="checkbox" id="soloFallidos" name="soloFallidos" value="true" @(Model.SoloFallidos ? "checked" : "") />
                     <input type="hidden" name="soloFallidos" value="false" />
                     <label class="form-check-label" for="soloFallidos">Solo fallidos</label>
                 </div>
@@ -58,11 +51,11 @@
                 </tr>
             </thead>
             <tbody>
-                @if (!Model.Any())
+                @if (Model.Items.Count == 0)
                 {
                     <tr><td colspan="7" class="text-center py-4 text-secondary">No hay intentos que coincidan con los filtros.</td></tr>
                 }
-                @foreach (var a in Model)
+                @foreach (var a in Model.Items)
                 {
                     <tr>
                         <td>@a.CreatedAt.ToShortDateTime()</td>
@@ -90,37 +83,37 @@
     </div>
     <div class="card-footer clearfix">
         <div class="float-end">
-            <small class="text-secondary me-2">@total registro@(total == 1 ? "" : "s")</small>
+            <small class="text-secondary me-2">@Model.Total registro@(Model.Total == 1 ? "" : "s")</small>
         </div>
-        @if (totalPaginas > 1)
+        @if (Model.TotalPaginas > 1)
         {
             <nav>
                 <ul class="pagination pagination-sm m-0 float-end">
-                    @if (pagina > 1)
+                    @if (Model.Pagina > 1)
                     {
                         <li class="page-item">
                             <a class="page-link"
                                asp-action="Index"
-                               asp-route-busqueda="@busqueda"
-                               asp-route-ip="@ip"
-                               asp-route-soloFallidos="@soloFallidos"
-                               asp-route-pagina="@(pagina - 1)"
-                               asp-route-tamanio="@tamanio">&laquo;</a>
+                               asp-route-busqueda="@Model.Busqueda"
+                               asp-route-ip="@Model.Ip"
+                               asp-route-soloFallidos="@Model.SoloFallidos"
+                               asp-route-pagina="@(Model.Pagina - 1)"
+                               asp-route-tamanio="@Model.Tamanio">&laquo;</a>
                         </li>
                     }
                     @{
-                        var start = Math.Max(1, pagina - 2);
-                        var end = Math.Min(totalPaginas, pagina + 2);
+                        var start = Math.Max(1, Model.Pagina - 2);
+                        var end = Math.Min(Model.TotalPaginas, Model.Pagina + 2);
                         if (start > 1)
                         {
                             <li class="page-item">
                                 <a class="page-link"
                                    asp-action="Index"
-                                   asp-route-busqueda="@busqueda"
-                                   asp-route-ip="@ip"
-                                   asp-route-soloFallidos="@soloFallidos"
+                                   asp-route-busqueda="@Model.Busqueda"
+                                   asp-route-ip="@Model.Ip"
+                                   asp-route-soloFallidos="@Model.SoloFallidos"
                                    asp-route-pagina="1"
-                                   asp-route-tamanio="@tamanio">1</a>
+                                   asp-route-tamanio="@Model.Tamanio">1</a>
                             </li>
                             if (start > 2)
                             {
@@ -129,43 +122,43 @@
                         }
                         for (var i = start; i <= end; i++)
                         {
-                            <li class="page-item @(i == pagina ? "active" : "")">
+                            <li class="page-item @(i == Model.Pagina ? "active" : "")">
                                 <a class="page-link"
                                    asp-action="Index"
-                                   asp-route-busqueda="@busqueda"
-                                   asp-route-ip="@ip"
-                                   asp-route-soloFallidos="@soloFallidos"
+                                   asp-route-busqueda="@Model.Busqueda"
+                                   asp-route-ip="@Model.Ip"
+                                   asp-route-soloFallidos="@Model.SoloFallidos"
                                    asp-route-pagina="@i"
-                                   asp-route-tamanio="@tamanio">@i</a>
+                                   asp-route-tamanio="@Model.Tamanio">@i</a>
                             </li>
                         }
-                        if (end < totalPaginas)
+                        if (end < Model.TotalPaginas)
                         {
-                            if (end < totalPaginas - 1)
+                            if (end < Model.TotalPaginas - 1)
                             {
                                 <li class="page-item disabled"><span class="page-link">...</span></li>
                             }
                             <li class="page-item">
                                 <a class="page-link"
                                    asp-action="Index"
-                                   asp-route-busqueda="@busqueda"
-                                   asp-route-ip="@ip"
-                                   asp-route-soloFallidos="@soloFallidos"
-                                   asp-route-pagina="@totalPaginas"
-                                   asp-route-tamanio="@tamanio">@totalPaginas</a>
+                                   asp-route-busqueda="@Model.Busqueda"
+                                   asp-route-ip="@Model.Ip"
+                                   asp-route-soloFallidos="@Model.SoloFallidos"
+                                   asp-route-pagina="@Model.TotalPaginas"
+                                   asp-route-tamanio="@Model.Tamanio">@Model.TotalPaginas</a>
                             </li>
                         }
                     }
-                    @if (pagina < totalPaginas)
+                    @if (Model.Pagina < Model.TotalPaginas)
                     {
                         <li class="page-item">
                             <a class="page-link"
                                asp-action="Index"
-                               asp-route-busqueda="@busqueda"
-                               asp-route-ip="@ip"
-                               asp-route-soloFallidos="@soloFallidos"
-                               asp-route-pagina="@(pagina + 1)"
-                               asp-route-tamanio="@tamanio">&raquo;</a>
+                               asp-route-busqueda="@Model.Busqueda"
+                               asp-route-ip="@Model.Ip"
+                               asp-route-soloFallidos="@Model.SoloFallidos"
+                               asp-route-pagina="@(Model.Pagina + 1)"
+                               asp-route-tamanio="@Model.Tamanio">&raquo;</a>
                         </li>
                     }
                 </ul>

--- a/src/ExtraGasMVC/Views/Shared/_Sidebar.cshtml
+++ b/src/ExtraGasMVC/Views/Shared/_Sidebar.cshtml
@@ -199,6 +199,12 @@
                             <p>Usuarios</p>
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a asp-controller="AuditoriaLogins" asp-action="Index" class="nav-link @(isCurrent("AuditoriaLogins") ? "active" : "")">
+                            <i class="nav-icon bi bi-shield-check"></i>
+                            <p>Auditoria logins</p>
+                        </a>
+                    </li>
                 }
                 <li class="nav-item">
                     <a asp-controller="Home" asp-action="Privacy" class="nav-link @(isCurrent("Home", "Privacy") ? "active" : "")">

--- a/src/ExtraGasMVC/Views/Usuarios/Edit.cshtml
+++ b/src/ExtraGasMVC/Views/Usuarios/Edit.cshtml
@@ -3,8 +3,11 @@
     var usuario = ViewBag.Usuario as ExtraGasMVC.DTOs.UsuarioDto;
     var roles = ViewBag.Roles as List<ExtraGasMVC.DTOs.RolDto>;
     var currentUserId = ViewBag.CurrentUserId as ulong?;
-    var temporaryPassword = TempData["TemporaryPassword"] as string;
-    var temporaryPasswordUsername = TempData["TemporaryPasswordUsername"] as string;
+    // La password temporal se consume una sola vez en el controller (Peek+Remove)
+    // y llega a la vista como ViewBag. Asi un refresh posterior del admin NO la
+    // re-muestra (cumpliendo "se muestra una sola vez").
+    var temporaryPassword = ViewBag.TemporaryPassword as string;
+    var temporaryPasswordUsername = ViewBag.TemporaryPasswordUsername as string;
     ViewData["Title"] = "Editar usuario";
     ViewData["Breadcrumbs"] = new List<BreadcrumbItem>
     {

--- a/src/ExtraGasMVC/Views/Usuarios/Edit.cshtml
+++ b/src/ExtraGasMVC/Views/Usuarios/Edit.cshtml
@@ -103,11 +103,11 @@
                 </div>
                 <div class="col-md-4">
                     <label class="form-label" for="NewPassword">Nueva contraseña</label> <span class="text-danger">*</span>
-                    <input type="password" id="NewPassword" name="NewPassword" class="form-control" required minlength="6" />
+                    <input type="password" id="NewPassword" name="NewPassword" class="form-control" required />
                 </div>
                 <div class="col-md-4">
                     <label class="form-label" for="ConfirmPassword">Confirmar nueva contraseña</label> <span class="text-danger">*</span>
-                    <input type="password" id="ConfirmPassword" name="ConfirmPassword" class="form-control" required minlength="6" />
+                    <input type="password" id="ConfirmPassword" name="ConfirmPassword" class="form-control" required />
                 </div>
             </div>
         </div>
@@ -152,10 +152,9 @@
                     e.preventDefault();
                     alert('Las contraseñas no coinciden.');
                 }
-                if (np.length < 8) {
-                    e.preventDefault();
-                    alert('La nueva contraseña debe tener al menos 8 caracteres.');
-                }
+                // Validaciones de policy (longitud minima, caracteres requeridos) son
+                // autoridad del servidor (IPasswordPolicyService). No se duplican en
+                // el cliente porque harian mentir a la UI si la policy cambia.
             });
         });
     </script>

--- a/src/ExtraGasMVC/Views/Usuarios/Edit.cshtml
+++ b/src/ExtraGasMVC/Views/Usuarios/Edit.cshtml
@@ -2,6 +2,9 @@
 @{
     var usuario = ViewBag.Usuario as ExtraGasMVC.DTOs.UsuarioDto;
     var roles = ViewBag.Roles as List<ExtraGasMVC.DTOs.RolDto>;
+    var currentUserId = ViewBag.CurrentUserId as ulong?;
+    var temporaryPassword = TempData["TemporaryPassword"] as string;
+    var temporaryPasswordUsername = TempData["TemporaryPasswordUsername"] as string;
     ViewData["Title"] = "Editar usuario";
     ViewData["Breadcrumbs"] = new List<BreadcrumbItem>
     {
@@ -14,6 +17,17 @@
         <a asp-action="Index" class="btn btn-outline-secondary">
             <i class="bi bi-arrow-left me-1"></i> Volver
         </a>
+    </div>
+}
+
+@if (!string.IsNullOrEmpty(temporaryPassword))
+{
+    <div class="alert alert-warning" role="alert">
+        <h5 class="alert-heading"><i class="bi bi-exclamation-triangle-fill me-1"></i> Password temporal para @temporaryPasswordUsername</h5>
+        <p class="mb-2">Anota esta contraseña. <strong>No se volvera a mostrar.</strong> El usuario debera cambiarla en su proximo login.</p>
+        <p class="mb-0">
+            <code class="fs-5 user-select-all">@temporaryPassword</code>
+        </p>
     </div>
 }
 
@@ -102,6 +116,28 @@
     </form>
 </div>
 
+@if (currentUserId.HasValue && currentUserId.Value != Model.Id)
+{
+    <div class="card mt-4 border-warning">
+        <div class="card-header bg-warning-subtle"><h3 class="card-title">Resetear contrasena (admin)</h3></div>
+        <form asp-action="ResetPassword" asp-route-id="@Model.Id" method="post">
+            @Html.AntiForgeryToken()
+            <div class="card-body">
+                <p class="text-secondary mb-0">
+                    Genera una password temporal aleatoria para este usuario y lo obliga a cambiarla en su proximo login.
+                    La password temporal se mostrara <strong>una sola vez</strong> tras confirmar.
+                </p>
+            </div>
+            <div class="card-footer">
+                <button type="submit" class="btn btn-warning"
+                        onclick="return confirm('Vas a resetear la contrasena de @(usuario?.Username). El usuario debera cambiarla en su proximo login. Continuar?');">
+                    <i class="bi bi-arrow-clockwise me-1"></i> Generar password temporal
+                </button>
+            </div>
+        </form>
+    </div>
+}
+
 @section Scripts {
     <script>
         document.addEventListener('DOMContentLoaded', function () {
@@ -113,9 +149,9 @@
                     e.preventDefault();
                     alert('Las contraseñas no coinciden.');
                 }
-                if (np.length < 6) {
+                if (np.length < 8) {
                     e.preventDefault();
-                    alert('La nueva contraseña debe tener al menos 6 caracteres.');
+                    alert('La nueva contraseña debe tener al menos 8 caracteres.');
                 }
             });
         });

--- a/src/ExtraGasMVC/appsettings.Development.json
+++ b/src/ExtraGasMVC/appsettings.Development.json
@@ -4,5 +4,19 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Auth": {
+    "Lockout": {
+      "MaxFailedAttempts": 3,
+      "LockoutMinutes": 5
+    },
+    "PasswordPolicy": {
+      "MinLength": 6,
+      "RequireUppercase": false,
+      "RequireLowercase": true,
+      "RequireDigit": true,
+      "RequireSpecialChar": false,
+      "MaxConsecutiveChars": 0
+    }
   }
 }

--- a/src/ExtraGasMVC/appsettings.json
+++ b/src/ExtraGasMVC/appsettings.json
@@ -13,6 +13,14 @@
     "Lockout": {
       "MaxFailedAttempts": 5,
       "LockoutMinutes": 15
+    },
+    "PasswordPolicy": {
+      "MinLength": 8,
+      "RequireUppercase": true,
+      "RequireLowercase": true,
+      "RequireDigit": true,
+      "RequireSpecialChar": false,
+      "MaxConsecutiveChars": 4
     }
   }
 }

--- a/src/ExtraGasMVC/appsettings.json
+++ b/src/ExtraGasMVC/appsettings.json
@@ -8,5 +8,11 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "ExtraGas": "---"
+  },
+  "Auth": {
+    "Lockout": {
+      "MaxFailedAttempts": 5,
+      "LockoutMinutes": 15
+    }
   }
 }

--- a/tests/ExtraGasMVC.Tests/ExtraGasMVC.Tests.csproj
+++ b/tests/ExtraGasMVC.Tests/ExtraGasMVC.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>ExtraGasMVC.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ExtraGasMVC\ExtraGasMVC.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/ExtraGasMVC.Tests/LoginResultTests.cs
+++ b/tests/ExtraGasMVC.Tests/LoginResultTests.cs
@@ -1,0 +1,57 @@
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Services;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+public class LoginResultTests
+{
+    [Fact]
+    public void Ok_HasUser_Success_True()
+    {
+        var user = new UsuarioDto { Id = 42, Username = "jperez" };
+
+        var result = LoginResult.Ok(user);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.User);
+        Assert.Equal(42UL, result.User!.Id);
+        Assert.Equal(LoginFailureReason.None, result.FailureReason);
+        Assert.Equal(42UL, result.AttemptedUserId); // Ok() propaga el id
+    }
+
+    [Fact]
+    public void Fail_WithAttemptedUserId_NoUser_Success_False()
+    {
+        var result = LoginResult.Fail(attemptedUserId: 7UL, LoginFailureReason.InvalidPassword);
+
+        Assert.False(result.Success);
+        Assert.Null(result.User);
+        Assert.Equal(LoginFailureReason.InvalidPassword, result.FailureReason);
+        Assert.Equal(7UL, result.AttemptedUserId); // se preserva para auditoria
+    }
+
+    [Fact]
+    public void Fail_WithoutAttemptedUserId_NullId()
+    {
+        var result = LoginResult.Fail(attemptedUserId: null, LoginFailureReason.UserNotFound);
+
+        Assert.False(result.Success);
+        Assert.Null(result.User);
+        Assert.Equal(LoginFailureReason.UserNotFound, result.FailureReason);
+        Assert.Null(result.AttemptedUserId);
+    }
+
+    [Fact]
+    public void FailureReasons_AreDistinct()
+    {
+        // Sanity: el enum tiene los valores esperados.
+        Assert.Equal(6, Enum.GetValues<LoginFailureReason>().Length);
+        Assert.True(Enum.IsDefined(typeof(LoginFailureReason), LoginFailureReason.None));
+        Assert.True(Enum.IsDefined(typeof(LoginFailureReason), LoginFailureReason.UserNotFound));
+        Assert.True(Enum.IsDefined(typeof(LoginFailureReason), LoginFailureReason.UserInactive));
+        Assert.True(Enum.IsDefined(typeof(LoginFailureReason), LoginFailureReason.UserDeleted));
+        Assert.True(Enum.IsDefined(typeof(LoginFailureReason), LoginFailureReason.InvalidPassword));
+        Assert.True(Enum.IsDefined(typeof(LoginFailureReason), LoginFailureReason.LockedOut));
+    }
+}

--- a/tests/ExtraGasMVC.Tests/PasswordPolicyServiceTests.cs
+++ b/tests/ExtraGasMVC.Tests/PasswordPolicyServiceTests.cs
@@ -1,0 +1,163 @@
+using ExtraGasMVC.Configuration;
+using ExtraGasMVC.Services.Implementations;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+public class PasswordPolicyServiceTests
+{
+    private static PasswordPolicyService CreateService(PasswordPolicyOptions? options = null)
+    {
+        options ??= new PasswordPolicyOptions();
+        return new PasswordPolicyService(Options.Create(options));
+    }
+
+    // ---------- Defaults (MinLength=8, Upper+Lower+Digit, no special, MaxConsecutive=4) ----------
+
+    [Fact]
+    public void Validate_NullOrEmpty_Fails()
+    {
+        var svc = CreateService();
+
+        Assert.False(svc.Validate(null).IsValid);
+        Assert.False(svc.Validate("").IsValid);
+    }
+
+    [Fact]
+    public void Validate_ValidPassword_Passes()
+    {
+        var svc = CreateService();
+
+        Assert.True(svc.Validate("Abcdef1!").IsValid);
+        Assert.True(svc.Validate("Passw0rdOK").IsValid);
+    }
+
+    [Fact]
+    public void Validate_TooShort_Fails()
+    {
+        var svc = CreateService();
+
+        var result = svc.Validate("Ab1");
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("al menos 8"));
+    }
+
+    [Fact]
+    public void Validate_MissingUppercase_Fails()
+    {
+        var svc = CreateService();
+
+        var result = svc.Validate("abcdefgh1");
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("mayuscula"));
+    }
+
+    [Fact]
+    public void Validate_MissingLowercase_Fails()
+    {
+        var svc = CreateService();
+
+        var result = svc.Validate("ABCDEFGH1");
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("minuscula"));
+    }
+
+    [Fact]
+    public void Validate_MissingDigit_Fails()
+    {
+        var svc = CreateService();
+
+        var result = svc.Validate("Abcdefgh");
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("digito"));
+    }
+
+    [Fact]
+    public void Validate_MultipleViolations_ReportedAsMultiple()
+    {
+        var svc = CreateService();
+
+        var result = svc.Validate("abc");
+        Assert.False(result.IsValid);
+        // Al menos longitud + mayuscula + digito
+        Assert.True(result.Errors.Count >= 3, $"Expected >=3 errors, got {result.Errors.Count}: {string.Join("; ", result.Errors)}");
+    }
+
+    [Fact]
+    public void Validate_ConsecutiveRepeated_AboveLimit_Fails()
+    {
+        var svc = CreateService(new PasswordPolicyOptions { MaxConsecutiveChars = 4 });
+
+        var result = svc.Validate("Abcde11111!"); // 5 unos consecutivos
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("consecutivos"));
+    }
+
+    [Fact]
+    public void Validate_ConsecutiveRepeated_AtLimit_Passes()
+    {
+        var svc = CreateService(new PasswordPolicyOptions { MaxConsecutiveChars = 4 });
+
+        var result = svc.Validate("Abcde1111!"); // 4 unos consecutivos: dentro del limite
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void Validate_MaxConsecutiveZero_DisablesRule()
+    {
+        var svc = CreateService(new PasswordPolicyOptions { MaxConsecutiveChars = 0 });
+
+        var result = svc.Validate("Ab111111111111111111111111111cdefgh"); // muchos repetidos, regla desactivada
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void Validate_MinLengthZero_DisablesRule()
+    {
+        var svc = CreateService(new PasswordPolicyOptions { MinLength = 0 });
+
+        // "ab1" tiene 3 chars (menor a default 8, pero MinLength=0 la desactiva),
+        // falta mayuscula. Tiene minuscula y digito, asi que falla SOLO por mayuscula.
+        var result = svc.Validate("ab1");
+        Assert.False(result.IsValid);
+        Assert.DoesNotContain(result.Errors, e => e.Contains("caracteres")); // mensaje de longitud deshabilitada
+        Assert.Contains(result.Errors, e => e.Contains("mayuscula"));
+    }
+
+    [Fact]
+    public void Validate_RequireSpecialChar_True_FailsWithoutSymbol()
+    {
+        var svc = CreateService(new PasswordPolicyOptions { RequireSpecialChar = true });
+
+        var result = svc.Validate("Abcdefg1");
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("especial"));
+    }
+
+    [Fact]
+    public void Validate_RequireSpecialChar_True_PassesWithSymbol()
+    {
+        var svc = CreateService(new PasswordPolicyOptions { RequireSpecialChar = true });
+
+        var result = svc.Validate("Abcdefg1!");
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void Validate_AllRulesOff_PassesAnythingNonEmpty()
+    {
+        var svc = CreateService(new PasswordPolicyOptions
+        {
+            MinLength = 0,
+            RequireUppercase = false,
+            RequireLowercase = false,
+            RequireDigit = false,
+            RequireSpecialChar = false,
+            MaxConsecutiveChars = 0,
+        });
+
+        Assert.True(svc.Validate("x").IsValid);
+        Assert.True(svc.Validate("anything goes here").IsValid);
+    }
+}

--- a/tests/ExtraGasMVC.Tests/TemporaryPasswordGeneratorTests.cs
+++ b/tests/ExtraGasMVC.Tests/TemporaryPasswordGeneratorTests.cs
@@ -1,0 +1,103 @@
+using ExtraGasMVC.Services;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+public class TemporaryPasswordGeneratorTests
+{
+    [Fact]
+    public void Generate_DefaultLength_Is12()
+    {
+        var pwd = TemporaryPasswordGenerator.Generate();
+
+        Assert.Equal(12, pwd.Length);
+    }
+
+    [Theory]
+    [InlineData(8)]
+    [InlineData(10)]
+    [InlineData(16)]
+    [InlineData(32)]
+    public void Generate_RequestedLength_IsRespected(int length)
+    {
+        var pwd = TemporaryPasswordGenerator.Generate(length);
+
+        Assert.Equal(length, pwd.Length);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(4)]
+    [InlineData(7)]
+    public void Generate_BelowMinimumLength_Throws(int length)
+    {
+        Assert.Throws<ArgumentException>(() => TemporaryPasswordGenerator.Generate(length));
+    }
+
+    [Fact]
+    public void Generate_AlwaysContainsOneLowercase()
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            var pwd = TemporaryPasswordGenerator.Generate();
+            Assert.Contains(pwd, c => c >= 'a' && c <= 'z');
+        }
+    }
+
+    [Fact]
+    public void Generate_AlwaysContainsOneUppercase()
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            var pwd = TemporaryPasswordGenerator.Generate();
+            Assert.Contains(pwd, c => c >= 'A' && c <= 'Z');
+        }
+    }
+
+    [Fact]
+    public void Generate_AlwaysContainsOneDigit()
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            var pwd = TemporaryPasswordGenerator.Generate();
+            Assert.Contains(pwd, c => c >= '0' && c <= '9');
+        }
+    }
+
+    [Fact]
+    public void Generate_AlwaysContainsOneSymbol()
+    {
+        var symbols = "!@#$%&*+-=?";
+        for (var i = 0; i < 100; i++)
+        {
+            var pwd = TemporaryPasswordGenerator.Generate();
+            Assert.Contains(pwd, c => symbols.Contains(c));
+        }
+    }
+
+    [Fact]
+    public void Generate_TwoCallsAlmostAlwaysDiffer()
+    {
+        // Probabilistico: con 12 chars de un alfabeto de ~70, la chance de
+        // colision es astronomicamente baja. Lo corremos varias veces y
+        // esperamos que TODAS sean distintas.
+        var passwords = new HashSet<string>();
+        for (var i = 0; i < 1000; i++)
+            passwords.Add(TemporaryPasswordGenerator.Generate());
+
+        Assert.Equal(1000, passwords.Count);
+    }
+
+    [Fact]
+    public void Generate_OnlyContainsValidChars()
+    {
+        // Alfabeto valido segun el codigo: lower + upper + digit + symbols "!@#$%&*+-=?"
+        const string validChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%&*+-=?";
+        for (var i = 0; i < 100; i++)
+        {
+            var pwd = TemporaryPasswordGenerator.Generate();
+            foreach (var c in pwd)
+                Assert.Contains(c, validChars);
+        }
+    }
+}


### PR DESCRIPTION
## Resumen

Implementa las 4 mejoras de la issue #90 para fortalecer la autenticación sin migrar a ASP.NET Core Identity.

## Commits (orden sugerido de revisión)

1. **`d8fd864` — feat(auth): lockout por intentos fallidos** (#1)
   - Columnas `intentos_fallidos` y `bloqueado_hasta` en `usuarios`
   - `AuthLockoutOptions` configurable (`MaxFailedAttempts: 5`, `LockoutMinutes: 15`)
   - Mensaje específico cuando la cuenta está bloqueada
   - `LoginResult` + `LoginFailureReason` para distinguir motivo de fallo

2. **`37b4def` — feat(auth): auditoría de intentos de login** (#4)
   - Tabla `auditoria_logins` con FK `ON DELETE SET NULL` (preserva historial)
   - `IAuditoriaLoginService.Record/Search` con filtros y paginación
   - `AccountController.Login` registra cada intento con IP + User-Agent
   - Vista `AuditoriaLogins/Index` (solo Admin) con filtros y paginación

3. **`f8ed54d` — feat(auth): política de contraseña configurable** (#3)
   - `PasswordPolicyOptions`: MinLength, RequireUppercase/Lowercase/Digit/SpecialChar, MaxConsecutiveChars
   - `IPasswordPolicyService.Validate` con `PasswordPolicyResult` (errores legibles)
   - Quitados `[StringLength(MinimumLength=6)]` hardcodeados de los DTOs
   - Aplicado en `Create` y `ChangePassword`

4. **`e81dda7` — feat(auth): recuperación de contraseña admin-assisted** (#2)
   - Columna `debe_cambiar_password` en `usuarios`
   - `TemporaryPasswordGenerator` con `RandomNumberGenerator` (12 chars, lower/upper/digit/symbol garantizados)
   - `UsuariosController.ResetPassword` (solo Admin, bloquea self-reset)
   - `AccountController.ChangePassword` GET/POST para el flujo post-reset
   - Login redirige automáticamente si `debe_cambiar_password=true`
   - Link muerto "Recuperar contraseña" del Login reemplazado por texto informativo

## Decisiones de diseño

- **Mensaje genérico para "usuario no existe" / "password inválida"**: evita user enumeration. Solo "bloqueado" se distingue porque el usuario legítimo necesita saber por qué no entra.
- **`LoginResult` + `LoginFailureReason`** se diseñó pensando en #4 desde #1: la misma fuente de verdad del motivo de fallo sirve para mostrar mensaje al usuario y para registrar en auditoría.
- **`AccountController`** cambió de `[AllowAnonymous]` a nivel clase a `[AllowAnonymous]` por método, para que `[Authorize]` funcione en `ChangePassword`.
- **`AuditoriaLoginsController`** es un controller dedicado en vez de agregar una acción a `ReportesController` (que el sidebar referencia pero no existe en `Controllers/` — bug preexistente, queda fuera de este PR).

## Migraciones SQL (3)

- `20260828_000001_add_usuarios_lockout.sql`
- `20260828_000002_create_auditoria_logins.sql`
- `20260828_000003_add_debe_cambiar_password.sql`

Todas idempotentes con patrón `information_schema` + `PREPARE/EXECUTE` consistente con las migraciones previas del repo.

## Testing aplicado

- ✅ `dotnet build` en cada commit (0 errores; warnings preexistentes de AutoMapper y un nullable en `Recepciones/Create.cshtml`)
- ✅ Cada migración aplicada a homelab (`192.168.0.216`) — schema correcto + idempotencia verificada al re-ejecutar
- ⚠️ No hay tests automatizados en el repo todavía; la validación es manual con build + smoke contra la BD real

## Checklist

- [x] 4 commits separados, uno por mejora
- [x] Cada cambio compila sin errores
- [x] Cada migración es idempotente
- [x] Mensajes de error coherentes con la política anti-user-enumeration
- [x] `[Authorize]` policies respetadas en los controllers nuevos
- [ ] Revisión de seguridad (recomendable pedir review a alguien con foco en auth)
- [ ] Tests automatizados (fuera del scope de esta issue)

Closes #90