### PR TITLE
feat(password-recovery): PR1 — schema (MailKit, migration, entity)

### DIFF
--- a/db/migrations/20260828_000004_create_password_reset_tokens.sql
+++ b/db/migrations/20260828_000004_create_password_reset_tokens.sql
@@ -1,0 +1,41 @@
+-- =============================================================================
+-- 20260828_000004_create_password_reset_tokens.sql
+-- Creates password_reset_tokens table for self-service password recovery.
+-- Change: password-recovery (SDD), PR1 schema work unit.
+--
+-- - Solo se persiste SHA-256 hex del token raw; el token raw viaja solo por email.
+-- - Single-use enforced at consume-time via atomic UPDATE ... WHERE used_at IS NULL
+--   AND expires_at > NOW(), con uk_token_hash serializando via row-lock de InnoDB.
+-- - FK a usuarios con ON DELETE CASCADE: un reset token sin usuario no tiene sentido
+--   y la eliminacion del usuario limpia sus tokens pendientes.
+-- - created_by / updated_by NULL: la creacion es anonima (el solicitante no esta
+--   autenticado); sigue convencion de auditoria del proyecto.
+-- - Idempotente: la tabla se crea solo si no existe.
+-- =============================================================================
+
+USE extragas;
+
+CREATE TABLE IF NOT EXISTS `password_reset_tokens` (
+  `id`          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `usuario_id`  BIGINT UNSIGNED NOT NULL,
+  `token_hash`  VARCHAR(64)     NOT NULL COMMENT 'SHA-256 hex del token raw; el token raw nunca se persiste',
+  `ip_address`  VARCHAR(45)     NULL     COMMENT 'IPv4 o IPv6 del solicitante',
+  `user_agent`  VARCHAR(500)    NULL,
+  `expires_at`  DATETIME        NOT NULL COMMENT 'UTC; vence y se ignora en consume',
+  `used_at`     DATETIME        NULL     COMMENT 'NULL=sin usar; se setea al consumir exitosamente',
+  `created_at`  DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at`  DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `created_by`  BIGINT UNSIGNED NULL     COMMENT 'NULL: anonimo (solicitante no autenticado)',
+  `updated_by`  BIGINT UNSIGNED NULL     COMMENT 'NULL: anonimo',
+  `deleted_at`  DATETIME        NULL     COMMENT 'soft delete; nunca DELETE de filas',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_token_hash` (`token_hash`),
+  KEY `idx_usuario_used` (`usuario_id`, `used_at`),
+  KEY `idx_expires_at` (`expires_at`),
+  CONSTRAINT `fk_password_reset_tokens_usuario`
+    FOREIGN KEY (`usuario_id`) REFERENCES `usuarios` (`id`)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Tokens de un solo uso para reset de contrasena; solo SHA-256 se persiste';
+
+SELECT 'Tabla password_reset_tokens lista' AS status;

--- a/openspec/changes/password-recovery/design.md
+++ b/openspec/changes/password-recovery/design.md
@@ -1,0 +1,241 @@
+# Design: password-recovery
+
+## Technical Approach
+
+Self-service password reset using a dedicated `password_reset_tokens` table (no Identity, no DataProtection stateless tokens). Raw token (32 random bytes, base64url-encoded) is sent in the email only; SHA-256 hex hash is persisted. Consume is an atomic UPDATE guaranteeing single-use. Rate limiting uses in-process `IMemoryCache` per IP. SMTP via MailKit, configured by `IOptions<EmailOptions>`. Fits the existing custom-auth architecture (cookie auth + BCrypt + scoped services).
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as User
+    participant V as ForgotPassword View
+    participant C as AccountController
+    participant S as IUsuarioService
+    participant DB as ExtraGasDbContext
+    participant M as IEmailSender (MailKit)
+    participant SMTP as SMTP Server
+    U->>V: POST email
+    V->>C: ForgotPassword(email)
+    C->>S: RequestPasswordResetAsync(email, ip, ua)
+    S->>DB: lookup usuario by email
+    DB-->>S: Usuario? (ignoreQueryFilters)
+    alt email found
+      S->>DB: insert password_reset_tokens (token_hash, expires_at=+1h)
+      S->>M: SendAsync(to, subject, html) [fire-and-forget]
+      M->>SMTP: RCPT TO + DATA
+    end
+    S-->>C: void
+    C-->>V: 200 + TempData[Success] generic msg
+    Note over U,SMTP: User clicks email link
+    U->>C: GET /Account/ResetPassword?token=raw
+    C-->>U: 200 form (token in hidden field) — NO DB read
+    U->>C: POST token + newPassword
+    C->>S: ConsumePasswordResetTokenAsync(token, newPassword)
+    S->>DB: UPDATE used_at=NOW WHERE token_hash=? AND used_at IS NULL AND expires_at>NOW()
+    alt rowsAffected == 1
+      S->>DB: SELECT usuario, UPDATE password_hash = BCrypt(new)
+      S->>M: SendAsync(to, "Tu contraseña fue cambiada") [fire-and-forget]
+      C-->>U: redirect /Account/Login + TempData[Success]
+    else rowsAffected == 0
+      S->>DB: SELECT token_hash (diagnose expired vs used vs unknown)
+      C-->>U: form with TempData[Error] (El enlace ha expirado / ya fue utilizado / inválido)
+    end
+```
+
+## Architecture Decisions
+
+| Decision | Choice | Alternatives | Rationale |
+|---|---|---|---|
+| Token store | Dedicated `password_reset_tokens` table | Identity tokens; DataProtection stateless | Matches custom-auth architecture; full control over lifecycle; aligns with `AGENTS.md` soft-delete + audit conventions |
+| Token format | 32 bytes CSPRNG → 43-char base64url | 64-hex random; UUID v4 | URL-safe, fixed-length, no padding (`=`), raw never persisted |
+| Hash | `SHA256(rawBytes)` → 64 lowercase hex | bcrypt(high-cost); HMAC with server key | Spec requires SHA-256; deterministic for index equality; zero server-side secret risk |
+| Single-use | Atomic `UPDATE … WHERE used_at IS NULL AND expires_at > NOW()`, rows-affected gate | Pessimistic `SELECT … FOR UPDATE`; tombstone column | InnoDB row-lock serializes concurrent attempts via `uk_token_hash`; rows-affected is the success signal |
+| Rate limit | `IMemoryCache` counter `password-reset:forgot:{ip}`, TTL 1h, max 3 | Redis; `AspNetCoreRateLimit` | Single-instance homelab; per-process reset is acceptable trade-off (see Risk) |
+| Email transport | MailKit `SmtpClient` behind `IEmailSender` interface | `System.Net.Mail.SmtpClient`; SendGrid SDK | MailKit is the de-facto .NET SMTP client; maintained; supports STARTTLS/SSL; interface enables test swap |
+| Email timing | Fire-and-forget `Task.Run` with new DI scope | In-request await; hosted queue | Matches proposal ("SMTP failure swallowed"); SMTP 1-3s latency must not block HTTP 200 |
+| Password policy | Reuse `IPasswordPolicyService` + `_passwordOptions` | Inline regex | Single source of truth; user gets the same rules as `ChangePassword` |
+| DbContext retry | No `EnableRetryOnFailure` (current config) | Add retry on this change | Out of scope; existing services rely on current Pomelo config; risk of silently retrying writes |
+| Soft-delete query filter | `HasQueryFilter(rt => rt.DeletedAt == null)` | No filter (manual WHERE) | Consistency with `AGENTS.md`; entity never deleted, only marked |
+
+## File Changes
+
+| Path | Action | Purpose / Shape |
+|---|---|---|
+| `src/ExtraGasMVC/Data/Entities/PasswordResetToken.cs` | New | `class PasswordResetToken { ulong Id; ulong UsuarioId; string TokenHash; string? IpAddress; string? UserAgent; DateTime ExpiresAt; DateTime? UsedAt; DateTime CreatedAt; DateTime UpdatedAt; ulong? CreatedBy; ulong? UpdatedBy; DateTime? DeletedAt; Usuario Usuario }` |
+| `src/ExtraGasMVC/Data/Configurations/PasswordResetTokenConfiguration.cs` | New | `IEntityTypeConfiguration<PasswordResetToken>` — toTable("password_reset_tokens"), maxlength(64) on TokenHash, IP `HasMaxLength(45)`, UA `HasMaxLength(500)`, FK `fk_password_reset_tokens_usuario` ON DELETE CASCADE, indexes `uk_token_hash`, `idx_usuario_used`, `idx_expires_at`, `HasQueryFilter(rt => rt.DeletedAt == null)` |
+| `src/ExtraGasMVC/Data/Context/ExtraGasDbContext.cs` | Modified | Add `public DbSet<PasswordResetToken> PasswordResetTokens => Set<PasswordResetToken>();` |
+| `src/ExtraGasMVC/Services/Options/EmailOptions.cs` | New | `public class EmailOptions { public const string SectionName = "Email"; string Host; int Port = 587; bool UseSsl = true; string FromAddress; string FromDisplayName = "ExtraGas"; string? Username; string? Password; string BaseUrl = "https://localhost:5001"; }` |
+| `src/ExtraGasMVC/Services/Interfaces/IEmailSender.cs` | New | `Task SendAsync(string to, string subject, string htmlBody, string? textBody = null, CancellationToken ct = default)` |
+| `src/ExtraGasMVC/Services/Implementations/MailKitEmailSender.cs` | New | Wraps `MailKit.Net.Smtp.SmtpClient`. Constructor takes `IOptions<EmailOptions>` + `ILogger`. `SendAsync` builds `MimeMessage`, connects with `SecureSocketOptions.StartTlsWhenAvailable` when `UseSsl`, sends, disposes client in `using`. Try/catch around connect+send; logs `ILogger.LogError`, **swallows exception** (ambiguity #3) |
+| `src/ExtraGasMVC/Services/Implementations/EmailTemplates.cs` | New | Static `ResetLink(string displayName, string link, DateTime expiresAt)` and `PasswordChanged(string displayName)` returning `(string Subject, string Html, string Text)` |
+| `src/ExtraGasMVC/Services/ConsumeResetTokenResult.cs` | New | `public enum ConsumeResetTokenOutcome { Success, InvalidToken, ExpiredToken, AlreadyUsed, UnknownError }; public record ConsumeResetTokenResult(ConsumeResetTokenOutcome Outcome)` |
+| `src/ExtraGasMVC/Services/Interfaces/IUsuarioService.cs` | Modified | Add 2 methods (signatures below) |
+| `src/ExtraGasMVC/Services/Implementations/UsuarioService.cs` | Modified | Implement 2 methods + private `GenerateToken()` (CSPRNG + base64url) + `HashToken(raw)` (SHA256 hex) |
+| `src/ExtraGasMVC/DTOs/ForgotPasswordDto.cs` | New | `class { [Required, EmailAddress, StringLength(150)] string Email; }` |
+| `src/ExtraGasMVC/DTOs/ResetPasswordDto.cs` | New | `class { [Required] string Token; [Required, DataType(Password)] string NewPassword; [Required, DataType(Password), Compare(nameof(NewPassword))] string ConfirmPassword; }` |
+| `src/ExtraGasMVC/Controllers/AccountController.cs` | Modified | Inject `IMemoryCache`, `IEmailSender`, `IPasswordPolicyService`, `IServiceScopeFactory`. Add `[HttpGet] ForgotPassword()`; `[HttpPost, ValidateAntiForgeryToken, AllowAnonymous] ForgotPassword(ForgotPasswordDto)`; `[HttpGet, AllowAnonymous] ResetPassword(string? token)`; `[HttpPost, ValidateAntiForgeryToken, AllowAnonymous] ResetPassword(ResetPasswordDto)`. Reuse `GetClientIp()`/`GetUserAgent()` helpers |
+| `src/ExtraGasMVC/Views/Account/ForgotPassword.cshtml` | New | `_AccountLayout`; email input; submit; renders `_StatusMessage` partial |
+| `src/ExtraGasMVC/Views/Account/ResetPassword.cshtml` | New | `_AccountLayout`; hidden `Token`; NewPassword + ConfirmPassword; policy bullets from `ViewBag.PasswordPolicy`; renders `_StatusMessage` partial |
+| `src/ExtraGasMVC/Views/Account/Login.cshtml` | Modified | Replace line 41 `<span class="text-secondary small">Si olvidaste tu contrasena, contacta a un administrador...</span>` with `<a asp-action="ForgotPassword">¿Olvidaste tu contraseña?</a>` link |
+| `src/ExtraGasMVC/Program.cs` | Modified | Add `builder.Services.AddMemoryCache()` (already present line 15). Add `builder.Services.Configure<EmailOptions>(builder.Configuration.GetSection(EmailOptions.SectionName));`. Add `builder.Services.AddScoped<IEmailSender, MailKitEmailSender>();`. Add startup validation warning when `Email:Host` set but `Email:Username`/`Email:Password` missing |
+| `src/ExtraGasMVC/appsettings.json` | Modified | Add `"Email": { "Host": "smtp.example.com", "Port": 587, "UseSsl": true, "FromAddress": "noreply@extragas.com", "FromDisplayName": "ExtraGas", "BaseUrl": "https://extragas.example.com" }` (no credentials) |
+| `src/ExtraGasMVC/appsettings.Development.json` | Modified | Add `"Email": { "Host": "localhost", "Port": 1025, "UseSsl": false, "FromAddress": "noreply@localhost", "FromDisplayName": "ExtraGas Dev", "BaseUrl": "https://localhost:5001" }` |
+| `src/ExtraGasMVC/ExtraGasMVC.csproj` | Modified | Add `<PackageReference Include="MailKit" Version="4.8.0" />` (latest 4.x compatible with .NET 10; verify exact version on NuGet at apply time) |
+| `db/migrations/20260828_000004_create_password_reset_tokens.sql` | New (apply phase) | DDL below; idempotent via `CREATE TABLE IF NOT EXISTS` |
+
+## Database
+
+**DDL** (refined from proposal — soft-delete + audit nullable for anonymous creator; FK ON DELETE CASCADE since a reset token's user is meaningless without the user; `uk_token_hash` enforces hash uniqueness, so hash collisions are auto-rejected at insert):
+
+```sql
+USE extragas;
+
+CREATE TABLE IF NOT EXISTS `password_reset_tokens` (
+  `id`          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `usuario_id`  BIGINT UNSIGNED NOT NULL,
+  `token_hash`  VARCHAR(64)     NOT NULL COMMENT 'SHA-256 hex of the raw token; raw never persisted',
+  `ip_address`  VARCHAR(45)     NULL     COMMENT 'IPv4 or IPv6 of requester',
+  `user_agent`  VARCHAR(500)    NULL,
+  `expires_at`  DATETIME        NOT NULL COMMENT 'UTC; expiry enforced on consume',
+  `used_at`     DATETIME        NULL     COMMENT 'NULL=unused; set on successful consume',
+  `created_at`  DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at`  DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `created_by`  BIGINT UNSIGNED NULL     COMMENT 'NULL — anonymous (no authenticated user)',
+  `updated_by`  BIGINT UNSIGNED NULL     COMMENT 'NULL — anonymous',
+  `deleted_at`  DATETIME        NULL     COMMENT 'soft delete; never DELETE rows',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_token_hash` (`token_hash`),
+  KEY `idx_usuario_used` (`usuario_id`, `used_at`),
+  KEY `idx_expires_at` (`expires_at`),
+  CONSTRAINT `fk_password_reset_tokens_usuario`
+    FOREIGN KEY (`usuario_id`) REFERENCES `usuarios` (`id`)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='One-time password-reset tokens; only SHA-256 hash is persisted';
+```
+
+**Index review**:
+- `uk_token_hash` — supports both insert (uniqueness check) and consume (equality lookup + InnoDB row-lock for single-use). **This is the only index required for the hot path.**
+- `idx_usuario_used (usuario_id, used_at)` — diagnostic/cleanup ("active tokens for user"); not in the hot path. Composite order matches an eventual "list unused tokens for user" query.
+- `idx_expires_at (expires_at)` — supports batch cleanup of expired tokens. No covering index needed: the consume query is a single-row point lookup via `uk_token_hash`.
+
+**No index change** to `usuarios.email` — currently unindexed. The forgot-password lookup becomes a scan, but cardinality is small (admin users only) and the query result is discarded on miss to avoid enumeration. **Defer to follow-up** if user count grows.
+
+## EF Core
+
+**Entity shape** mirrors table; nav: `public Usuario Usuario { get; set; } = null!;`. **DbSet**: `public DbSet<PasswordResetToken> PasswordResetTokens => Set<PasswordResetToken>();` in `Personas y seguridad` group. **Query filter**: `HasQueryFilter(rt => rt.DeletedAt == null)` — matches `AGENTS.md`. Soft-deleted tokens invisible to default queries; explicit `.IgnoreQueryFilters()` only in admin audit queries. **Connection resiliency**: Pomelo's `EnableRetryOnFailure` is **not** enabled in current `Program.cs`; **do not add** in this change (risk of silently retrying side-effecting UPDATE; out of scope).
+
+## Services
+
+**`IUsuarioService`** new methods:
+```csharp
+Task RequestPasswordResetAsync(string email, string? ipAddress, string? userAgent, CancellationToken ct = default);
+Task<ConsumeResetTokenResult> ConsumePasswordResetTokenAsync(string rawToken, string newPassword, CancellationToken ct = default);
+```
+
+**`RequestPasswordResetAsync`** flow:
+1. Lookup user by email with `.IgnoreQueryFilters()` + `.FirstOrDefaultAsync(u => u.Email == email && u.Activo)` — `null` or inactive → return silently.
+2. `rawToken = base64url(RandomNumberGenerator.GetBytes(32))` (43 chars, no padding).
+3. `tokenHash = ToHex(SHA256.HashData(rawTokenBytes))`.
+4. Insert `PasswordResetToken { UsuarioId, TokenHash = tokenHash, IpAddress, UserAgent, ExpiresAt = UtcNow.AddHours(1), CreatedAt = UtcNow, UpdatedAt = UtcNow, CreatedBy = null, UpdatedBy = null }`.
+5. Fire-and-forget email: build `MimeMessage` via `EmailTemplates.ResetLink(...)`, dispatch on `Task.Run` with new `IServiceScopeFactory` scope resolving fresh `IEmailSender`; swallow + log exceptions.
+6. Steps 5 happens only when user found; step 1 fast-exit keeps timing close to spec (±200 ms target).
+
+**`ConsumePasswordResetTokenAsync`** flow:
+1. `tokenHash = ToHex(SHA256.HashData(rawTokenBytes))`.
+2. Validate `newPassword` via `_passwordPolicy.Validate(...)`; on failure return `ConsumeResetTokenResult(Fail)` with new outcome `WeakPassword` (out of current enum — extend enum).
+3. Atomic UPDATE via EF Core raw SQL or `ExecuteUpdate` (Pomelo 9 supports it):
+   ```sql
+   UPDATE password_reset_tokens
+   SET used_at = UTC_TIMESTAMP()
+   WHERE token_hash = @hash AND used_at IS NULL AND expires_at > UTC_TIMESTAMP()
+   ```
+4. If `rowsAffected == 1` → fetch user by `Id` of updated row, set `PasswordHash = BCrypt.HashPassword(newPassword)`, `DebeCambiarPassword = false`, `UpdatedAt = UtcNow`, `SaveChanges`. Fire-and-forget notification email. Return `Success`.
+5. If `rowsAffected == 0` → SELECT row by hash (ignore filters). If row missing → `InvalidToken`. If `used_at IS NOT NULL` → `AlreadyUsed`. Else (expires_at <= NOW) → `ExpiredToken`.
+6. DB error → `UnknownError`, log.
+
+## Controllers
+
+**`ForgotPassword` GET** renders `ForgotPassword.cshtml` (empty `ForgotPasswordDto`). **POST** with `[ValidateAntiForgeryToken]`:
+- ModelState invalid → return view.
+- Rate limit check: `IMemoryCache.TryGetValue<int>("password-reset:forgot:{ip}", out var count)`; if `count >= 3` → set `TempData["Success"] = generic msg`, return view (no service call).
+- Else `_memoryCache.SetOrUpdate(key, c => c + 1, TimeSpan.FromHours(1))`.
+- `await _usuarioService.RequestPasswordResetAsync(dto.Email, GetClientIp(), GetUserAgent(), ct)`.
+- `TempData["Success"] = "Si tu dirección de correo está registrada, recibirás un enlace..."` and return view.
+
+**`ResetPassword` GET** renders `ResetPassword.cshtml` with new `ResetPasswordDto { Token = query.token }`. **Never queries DB** — form is rendered regardless of token validity (ambiguity #1).
+
+**`ResetPassword` POST** with `[ValidateAntiForgeryToken]`:
+- ModelState invalid → return view with `Token` populated.
+- `var result = await _usuarioService.ConsumePasswordResetTokenAsync(dto.Token, dto.NewPassword, ct)`.
+- Map outcome → `TempData["Success"]` or `TempData["Error"]`:
+  - `Success` → redirect `/Account/Login` with success toast.
+  - `ExpiredToken` → `El enlace ha expirado. Solicitá uno nuevo.`
+  - `AlreadyUsed` → `Este enlace ya fue utilizado.`
+  - `InvalidToken` → `Enlace inválido.`
+  - `WeakPassword` → return view with `ModelState` errors (mirrors `ChangePassword` pattern).
+  - `UnknownError` → `No se pudo procesar la solicitud. Intente nuevamente.`
+
+## Views
+
+- **`ForgotPassword.cshtml`**: `_AccountLayout`; `login-box` card matching `Login.cshtml` style; single email input; submit → generic message via `_StatusMessage` partial below the form.
+- **`ResetPassword.cshtml`**: same layout; hidden `Token`; password + confirm; policy bullets from `ViewBag.PasswordPolicy` (reuse pattern from `ChangePassword.cshtml`); `_StatusMessage` partial.
+- **`Login.cshtml`** modification: replace the "contacta al administrador" line with `<a asp-action="ForgotPassword" class="text-decoration-none">¿Olvidaste tu contraseña?</a>`.
+
+## Email Templates (`EmailTemplates.cs`)
+
+Plain Spanish, minimal HTML + plain-text fallback:
+- `ResetLink(displayName, link, expiresAt)` → subject "Restablecé tu contraseña — ExtraGas"; body explains action, embeds `${BaseUrl}/Account/ResetPassword?token=${rawToken}`, expiry notice "Este enlace caduca en 1 hora." + "Si no lo solicitaste, ignorá este mensaje."
+- `PasswordChanged(displayName)` → subject "Tu contraseña fue cambiada — ExtraGas"; body confirms change happened at timestamp; no link; advises "Si no fuiste vos, contactá al administrador."
+
+## Configuration & Security
+
+- **`appsettings.json`**: non-secret `Email` section.
+- **`appsettings.Development.json`**: MailHog defaults `localhost:1025` no SSL.
+- **User Secrets** (production): `dotnet user-secrets set "Email:Username" "..." --project src/ExtraGasMVC` and the same for `Email:Password`. Documented in `README.md` (apply phase).
+- **Startup validation**: `Program.cs` logs `ILogger.LogWarning` if `Email:Host` set but `Email:Username`/`Password` missing; **does not crash** — explicit acceptance per proposal risk table.
+- **Antiforgery**: `[ValidateAntiForgeryToken]` on both POSTs (matches existing `AccountController.Login` pattern).
+- **HTTPS**: `app.UseHttpsRedirection()` already in `Program.cs` line 118; `app.UseHsts()` line 78 in non-dev. No change needed.
+- **HSTS**: already applied outside dev. Fine.
+- **IP source**: `HttpContext.Connection.RemoteIpAddress` — respects `UseForwardedHeaders` config already in `Program.cs`.
+- **Rate limit**: `IMemoryCache` per-process — counter resets on app restart. **Documented limitation**: a restart "wipes" the counter. Acceptable for single-instance homelab per proposal risk table (ambiguity #2).
+- **BCrypt**: same `BCrypt.Net.BCrypt.HashPassword` / `Verify` (existing 4.2.0 package) — no version drift risk.
+- **SHA-256**: `System.Security.Cryptography.SHA256.HashData(...)` (.NET 5+ API, no `using`/dispose ceremony).
+- **base64url**: `Convert.ToBase64String(bytes).TrimEnd('=').Replace('+','-').Replace('/','_')`.
+
+## Error Handling
+
+| Failure | Behaviour |
+|---|---|
+| SMTP connect/auth/send | `MailKitEmailSender.SendAsync` logs error, **swallows**, returns. HTTP response unaffected (fire-and-forget). Ambiguity #3. |
+| DB unique violation on insert (hash collision) | Effectively impossible (2²⁵⁶ space). On occurrence: catch `DbUpdateException`, log, return — user still sees generic success msg. |
+| DB error during consume | `ConsumeResetTokenResult(UnknownError)`, log, controller shows generic error to user. |
+| Concurrent consume (same token, two tabs) | InnoDB row-lock via `uk_token_hash` serializes; second tab's UPDATE returns `rowsAffected=0` → `AlreadyUsed`. |
+| Rate limit exceeded | Returns generic success message (HTTP 200), no service call, no DB write. |
+
+## Dependencies
+
+- `MailKit` 4.x (verify latest 4.8.x+ compatible with .NET 10 at apply time via `dotnet list package --outdated`).
+- No other new packages. `BCrypt.Net-Next` 4.2.0 already present; `Microsoft.EntityFrameworkCore.Relational` 9.0.16 provides `ExecuteUpdateAsync`.
+
+## Out of Scope (restated)
+
+ASP.NET Identity migration, 2FA, OAuth/SSO, email-change verification, audit-dashboard UI for resets, distributed rate limiting (Redis).
+
+## Ambiguity Resolutions
+
+| # | Ambiguity | Resolution |
+|---|---|---|
+| 1 | Behaviour of `GET /Account/ResetPassword` with invalid/expired/used token | **GET always renders the form** regardless of token validity; the token is round-tripped via hidden field. **POST is the only place where token validity is enforced.** Rationale: prevents attacker-controlled timing leak on the GET (DB lookup on GET would reveal whether token exists); matches the spec's "Render reset form on GET" scenario wording (no validity assertion). Update `password-reset-confirm/spec.md` scenario "GET with invalid token" as an additive note during archive. |
+| 2 | Rate-limit counter scope | `IMemoryCache` per-process counter, TTL 1h. **Counter resets on app restart** — documented limitation. Acceptable per proposal risk table for single-instance homelab. If multi-instance is ever introduced, replace with Redis (`IDistributedCache`) without changing the controller contract. |
+| 3 | SMTP failure visibility | `MailKitEmailSender.SendAsync` logs `ILogger.LogError` with full exception and recipient (never the body), **swallows**, returns. Fire-and-forget per proposal. Admin monitors app logs; end user always sees the generic "recibirás un enlace" message — no SMTP-specific error disclosure. Explicitly accepted by proposal risk table ("SMTP misconfiguration causing silent failures"). |
+
+## Testing & Verification
+
+- `dotnet build src/ExtraGasMVC` — must succeed with zero errors.
+- **Manual smoke flow** (per proposal §Verification Plan, 7 steps).
+- **SQL smoke queries** (per proposal).
+- **Dev environment**: MailHog via `docker run -p 1025:1025 -p 8025:8025 mailhog/mailhog`; verify emails at `http://localhost:8025`.
+- **Production**: `dotnet user-secrets set "Email:Username"` and `Email:Password`; verify one real round-trip before relying on flow.

--- a/openspec/changes/password-recovery/proposal.md
+++ b/openspec/changes/password-recovery/proposal.md
@@ -1,0 +1,260 @@
+# Proposal: password-recovery
+
+## Intent
+
+Users who forget their password currently see "contacta al administrador" on the login page — the only recovery path is an admin manually calling `UsuariosController.ResetPassword`. This change adds a self-service password-reset flow: user enters their email on a new `/Account/ForgotPassword` page, receives a time-limited link via SMTP email, clicks it, and sets a new password. Admin-assisted reset (`UsuariosController.ResetPassword`) continues to work unchanged.
+
+## Scope
+
+### In Scope
+- New `password_reset_tokens` table (dedicated, not Identity)
+- `AccountController.ForgotPassword` GET/POST (anonymous, rate-limited)
+- `AccountController.ResetPassword` GET/POST (anonymous, token-bearer)
+- `IUsuarioService.RequestPasswordResetAsync(email)` — creates token record, sends email via MailKit
+- `IUsuarioService.ConsumePasswordResetTokenAsync(token, newPassword)` — validates token, updates BCrypt hash, marks token used
+- New SMTP configuration section in `appsettings.json`
+- New `ForgotPassword.cshtml` and `ResetPassword.cshtml` Razor views
+- Link added to `Login.cshtml` ("¿Olvidaste tu contraseña?")
+- Migration: `db/migrations/<date>_create_password_reset_tokens.sql`
+- Post-reset notification email (confirms password was changed, not a reset link)
+
+### Out of Scope
+- ASP.NET Identity migration
+- Two-factor authentication (2FA)
+- OAuth / SSO / social login
+- Account lockout beyond rate limiting on `/Account/ForgotPassword`
+- Email-change verification flow
+- Audit dashboard UI for password resets
+
+## Capabilities
+
+> Contract with sdd-spec. Research `openspec/specs/` before filling this in. Currently `openspec/specs/` contains no user/auth-related specs — this is a **new capability**.
+
+### New Capabilities
+- `password-reset-email`: Allows a user to request a time-limited, single-use password-reset token delivered to their registered email address. Token is cryptographically random (32 bytes), SHA-256 hashed before storage, valid for 1 hour, single-use, and capped at 3 requests per IP per hour. The system never reveals whether an email address is registered.
+- `password-reset-confirm`: Allows a user who holds a valid, unexpired, unused reset token to set a new password. On success the token is marked `used_at`, a notification email is sent to the user's address, and the new password hash (BCrypt) replaces the existing one.
+
+### Modified Capabilities
+- None
+
+## Approach
+
+Option A (custom + dedicated `password_reset_tokens` table) is selected. This avoids ASP.NET Identity overhead and the stateless DataProtection token approach. It provides full control over token lifecycle, expiry, and single-use enforcement, and is consistent with the existing custom-auth architecture (cookie auth, BCrypt, no Identity).
+
+**Token lifecycle:**
+1. `IUsuarioService.RequestPasswordResetAsync(email)` — looks up user by email, generates 32-byte CSPRNG token (via `RandomNumberGenerator`), stores SHA-256 hash of the token (not the raw token) in `password_reset_tokens` with `expires_at = now + 1h`, logs IP and User-Agent. Returns void to the caller; sends email asynchronously.
+2. User clicks link in email: `GET /Account/ResetPassword?token={rawToken}` — controller receives raw token, passes to view for display. No DB read on GET.
+3. User submits new password: `POST /Account/ResetPassword` — calls `IUsuarioService.ConsumePasswordResetTokenAsync(rawToken, newPassword)`. Service computes SHA-256 of token, looks up by hash where `used_at IS NULL AND expires_at > now`, marks `used_at`, updates user's BCrypt hash. Sends notification email to user's address.
+
+**Existing `TemporaryPasswordGenerator` precedent** (`Services/TemporaryPasswordGenerator.cs`): uses `RandomNumberGenerator` (CSPRNG) and Fisher-Yates shuffle. The reset-token generation follows the same pattern but produces 32 raw bytes encoded as URL-safe Base64 (43 chars), never stored in plaintext.
+
+**Rate limiting**: in-memory `IMemoryCache` counter keyed by IP on `/Account/ForgotPassword` POST. Counter incremented per request; reset after 1 hour. Over-limit requests return `200 OK` with a generic message (no enumeration).
+
+**No email enumeration**: both the "email sent" and "email not found" paths return the identical message: "Si tu dirección de correo está registrada, recibirás un enlace para restablecer tu contraseña." This prevents attackers from probing for registered accounts.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `Controllers/AccountController.cs` | Modified | Add `ForgotPassword` GET/POST, `ResetPassword` GET/POST actions |
+| `Services/Interfaces/IUsuarioService.cs` | Modified | Add `RequestPasswordResetAsync`, `ConsumePasswordResetTokenAsync` |
+| `Services/Implementations/UsuarioService.cs` | Modified | Implement both methods |
+| `Data/Entities/` | New | `PasswordResetToken.cs` entity |
+| `Data/Configurations/` | New | `PasswordResetTokenConfiguration.cs` |
+| `DTOs/` | New | `ForgotPasswordDto.cs`, `ResetPasswordDto.cs` |
+| `db/migrations/<date>_create_password_reset_tokens.sql` | New | Table DDL with indexes, FK, audit columns |
+| `Views/Account/ForgotPassword.cshtml` | New | Email input form |
+| `Views/Account/ResetPassword.cshtml` | New | New password form (token in hidden field) |
+| `Views/Account/Login.cshtml` | Modified | Add "Olvidaste tu contraseña?" link above the admin contact line |
+| `Views/Shared/_AccountLayout.cshtml` | No change | Layout already suitable |
+| `Program.cs` | Modified | Register MailKit email service, configure SMTP from IOptions |
+| `appsettings.json` | Modified | Add `Email` section (Host, Port, UseSsl, FromAddress, FromDisplayName) |
+| `appsettings.Development.json` | Modified | Add `Email` section with MailHog defaults |
+
+## Database Change
+
+**Migration file**: `db/migrations/<YYYYMMDD>_000001_create_password_reset_tokens.sql`
+
+```sql
+CREATE TABLE IF NOT EXISTS `password_reset_tokens` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `usuario_id` BIGINT UNSIGNED NOT NULL,
+  `token_hash` VARCHAR(64) NOT NULL COMMENT 'SHA-256 of the raw token, stored hex',
+  `ip_address` VARCHAR(45) NULL COMMENT 'IPv4 or IPv6 of requester',
+  `user_agent` VARCHAR(500) NULL,
+  `expires_at` DATETIME NOT NULL COMMENT 'UTC expiry time',
+  `used_at` DATETIME NULL COMMENT 'NULL = unused; set on consume',
+  `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `created_by` BIGINT UNSIGNED NULL,
+  `updated_by` BIGINT UNSIGNED NULL,
+  `deleted_at` DATETIME NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_token_hash` (`token_hash`),
+  KEY `idx_usuario_used` (`usuario_id`, `used_at`),
+  KEY `idx_expires_at` (`expires_at`),
+  CONSTRAINT `fk_password_reset_tokens_usuario`
+    FOREIGN KEY (`usuario_id`) REFERENCES `usuarios` (`id`)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+COMMENT='One-time password-reset tokens; token stored as SHA-256 hash';
+```
+
+**Indexes**:
+- `uk_token_hash`: enforces single-use (one token = one record) and enables O(1) lookup by hash
+- `idx_usuario_used`: supports "active tokens for user" queries and single-use enforcement
+- `idx_expires_at`: supports cleanup queries for expired tokens
+
+**Soft delete**: `deleted_at` allows logical removal without destroying audit history.
+
+## Configuration
+
+**`appsettings.json`** — new section:
+
+```json
+{
+  "Email": {
+    "Host": "smtp.example.com",
+    "Port": 587,
+    "UseSsl": true,
+    "FromAddress": "noreply@extragas.com",
+    "FromDisplayName": "ExtraGas"
+  }
+}
+```
+
+**`appsettings.Development.json`** — MailHog dev defaults:
+
+```json
+{
+  "Email": {
+    "Host": "localhost",
+    "Port": 1025,
+    "UseSsl": false,
+    "FromAddress": "noreply@localhost",
+    "FromDisplayName": "ExtraGas Dev"
+  }
+}
+```
+
+Production credentials (SMTP username/password) via `dotnet user-secrets`:
+`dotnet user-secrets set "Email:Username" "..." --project src/ExtraGasMVC`
+`dotnet user-secrets set "Email:Password" "..." --project src/ExtraGasMVC`
+
+## Security Checklist
+
+| Requirement | Implementation |
+|-------------|----------------|
+| Token randomness | `RandomNumberGenerator.GetBytes(32)` — cryptographically secure |
+| Token storage | SHA-256 hash only; raw token never persisted |
+| Single-use | `used_at` set atomically on consume; token rejected if non-null |
+| Expiry | `expires_at` CHECK at consume time; tokens past expiry rejected |
+| IP/UA logging | Stored at creation time for audit |
+| No email enumeration | Identical response whether email exists or not |
+| No user enumeration | Action does not reveal whether username exists |
+| CSRF protection | `[ValidateAntiForgeryToken]` on all POST actions |
+| Rate limiting | 3 POSTs/IP/hour on `/Account/ForgotPassword`; returns 200 over limit |
+| Secure transport | HTTPS enforced via `app.UseHttpsRedirection()` (already present) |
+| Timing-safe comparison | BCrypt password comparison uses `BCrypt.Verify`; token lookup by hash uses indexed equality (not string comparison timing) |
+| Admin flow preserved | `UsuariosController.ResetPassword` + `TemporaryPasswordGenerator` unchanged |
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Email deliverability (spam/junk) | High | SPF/DKIM/DMARC DNS records; "noreply" sender; user instructions to check spam |
+| SMTP misconfiguration causing silent failures | High | Fire-and-forget email with try/catch; logged errors; admin sees failures in app logs |
+| Dev environment: SMTP credentials not set | Medium | MailHog localhost:1025 requires no auth; Development.json pre-configured |
+| User Secrets not set in production | Medium | Startup validation: if `Email:Host` present but credentials absent, log warning but do not crash |
+| BCrypt hash compatibility (version mismatch) | Low | `BCrypt.Net.BCrypt.HashPassword` / `Verify` — existing password hashes unaffected |
+| Admin reset flow broken by accident | Low | Separate `IUsuarioService.ResetPasswordAsync` method; `UsuariosController` unchanged |
+| Token collision (hash clash) | Negligible | SHA-256 output space (2²⁵⁶) makes collision functionally impossible |
+
+## Assumptions to Confirm
+
+> The user can veto any of these during review. Contact the user explicitly if any assumption is incorrect.
+
+- **Token expiry**: 1 hour from issue (`expires_at = CreatedAt + 1h`). Token presented after expiry shows error message and user must request again.
+- **Rate limiting**: 3 POST requests per IP per hour on `/Account/ForgotPassword`. Over-limit requests return HTTP 200 with generic "Si tu dirección..." message (no 429).
+- **Information disclosure**: `/Account/ForgotPassword` POST always returns the same response regardless of whether the email is registered.
+- **Post-reset notification email**: when a password is successfully changed via reset link, a separate notification email is sent to the user's address (confirms the change, not the reset link).
+- **Admin reset unchanged**: `UsuariosController.ResetPassword` and `TemporaryPasswordGenerator` remain functional and are not modified.
+
+## Success Criteria
+
+- [ ] User can request a password reset by entering their registered email on `/Account/ForgotPassword`
+- [ ] User receives a reset email within 60 seconds of submitting the form (when SMTP is configured correctly)
+- [ ] Reset link expires after 1 hour (token rejected with appropriate message)
+- [ ] Reset link is single-use (second attempt with same token shows "Token inválido o expirado")
+- [ ] After successful reset, user receives a notification email at their address confirming the password was changed
+- [ ] `/Account/ForgotPassword` always returns HTTP 200 even when IP is over rate-limit or email not registered
+- [ ] New password is hashed with BCrypt (same algorithm as existing passwords)
+- [ ] Admin-assisted reset via `UsuariosController.ResetPassword` continues to work without modification
+- [ ] `dotnet build src/ExtraGasMVC` succeeds with zero errors
+- [ ] SQL smoke: `SELECT * FROM password_reset_tokens WHERE deleted_at IS NULL` returns the newly created record
+
+## Verification Plan
+
+**Manual smoke flow** (in order):
+
+1. **Request reset (registered email)**:
+   - POST `/Account/ForgotPassword` with a known user's email
+   - Expected: HTTP 200, generic "recibirás un enlace" message
+   - Check: `SELECT * FROM password_reset_tokens WHERE deleted_at IS NULL` shows new row with `used_at = NULL` and future `expires_at`
+
+2. **Click reset link**:
+   - Open link in email (token in query string)
+   - Expected: GET `/Account/ResetPassword?token=...` shows the reset form
+
+3. **Submit new password**:
+   - POST `/Account/ResetPassword` with new password
+   - Expected: redirect to `/Account/Login` with success TempData message
+   - Check: `SELECT used_at FROM password_reset_tokens WHERE id = <token_id>` is not null
+
+4. **Login with new password**:
+   - POST `/Account/Login` with new credentials
+   - Expected: login succeeds, redirect to Home
+
+5. **Attempt reuse of consumed token**:
+   - POST `/Account/ResetPassword` with the same token
+   - Expected: error "Token inválido o expirado"
+
+6. **Request reset (unknown email)**:
+   - POST `/Account/ForgotPassword` with non-existent email
+   - Expected: HTTP 200 with generic message (no indication email doesn't exist)
+
+7. **Admin reset still works**:
+   - POST `/Usuarios/ResetPassword/<userId>` (admin action)
+   - Expected: temp password generated, `debe_cambiar_password = true` on user record
+
+**SQL verification**:
+```sql
+-- After step 1:
+SELECT id, usuario_id, LEFT(token_hash, 8) AS token_prefix, expires_at, used_at, ip_address
+FROM password_reset_tokens
+WHERE deleted_at IS NULL
+ORDER BY created_at DESC LIMIT 5;
+
+-- After step 3:
+SELECT used_at FROM password_reset_tokens WHERE id = <id>;  -- must NOT be null
+```
+
+## Rollback Plan
+
+1. Revert the migration file: `DROP TABLE IF EXISTS password_reset_tokens;` (FK `ON DELETE CASCADE` cleans up related records)
+2. Revert `IUsuarioService`, `UsuarioService` — remove the two new methods
+3. Revert `AccountController` — remove `ForgotPassword` and `ResetPassword` actions
+4. Revert `Login.cshtml` — remove the "Olvidaste tu contraseña?" link
+5. Revert `appsettings.json` / `appsettings.Development.json` — remove `Email` section
+6. Revert `Program.cs` — remove email service registration and SMTP configuration
+7. No user password hashes are affected — only the new `password_reset_tokens` table is added and dropped
+8. If deployed: rebuild, restart app, run `DROP TABLE IF EXISTS password_reset_tokens` against the database
+
+## Dependencies
+
+- `usuarios.email` column exists as `VARCHAR(150) NULL` — no schema change needed for the user lookup
+- `BCrypt.Net.BCrypt` already in use — same hashing for new passwords
+- `TemporaryPasswordGenerator` already uses `RandomNumberGenerator` — same CSPRNG pattern for token generation
+- MailKit package (to be added via `dotnet add package MailKit`)
+- `IMemoryCache` already registered via `builder.Services.AddMemoryCache()` in `Program.cs`
+- `app.UseHttpsRedirection()` already present in `Program.cs`

--- a/openspec/changes/password-recovery/specs/password-reset-confirm/spec.md
+++ b/openspec/changes/password-recovery/specs/password-reset-confirm/spec.md
@@ -1,0 +1,54 @@
+# Delta for password-reset-confirm
+
+> First-time capability. The main spec (`openspec/specs/password-reset-confirm/spec.md`) was created from this delta. The `## ADDED Requirements` block below mirrors the requirements to be merged on archive.
+
+## ADDED Requirements
+
+### Requirement: Consume valid token and set new password
+
+The system SHALL consume a valid (unused, unexpired) reset token on `POST /Account/ResetPassword`, replace the user's BCrypt password hash, and mark the token used. On success a notification email SHALL be sent to the user's registered address confirming the change (no reset link in that email).
+
+#### Scenario: Successful password reset
+
+- GIVEN a row in `password_reset_tokens` with `token_hash = SHA-256(rawToken)` and `used_at IS NULL` and `expires_at > NOW()`
+- WHEN a POST is made to `/Account/ResetPassword` with body `{ token: rawToken, password: "NewSecure123!" }`
+- THEN `password_reset_tokens.used_at` is set to NOW for that row
+- AND `usuarios.password_hash` for the matching user is replaced with a fresh BCrypt hash of "NewSecure123!"
+- AND a notification email is sent to the user's registered email confirming the password was changed (no reset link in this email)
+- AND the response redirects to `/Account/Login` with a success TempData message
+
+#### Scenario: Reject an expired token
+
+- GIVEN a row in `password_reset_tokens` with `expires_at < NOW()` and `used_at IS NULL`
+- WHEN a POST is made to `/Account/ResetPassword` with the corresponding raw token
+- THEN `used_at` remains NULL
+- AND `usuarios.password_hash` is NOT modified
+- AND the response shows the error "El enlace ha expirado. Solicitá uno nuevo."
+- AND no notification email is sent
+
+#### Scenario: Reject an already-used token
+
+- GIVEN a row in `password_reset_tokens` with `used_at IS NOT NULL`
+- WHEN a POST is made to `/Account/ResetPassword` with the corresponding raw token
+- THEN `usuarios.password_hash` is NOT modified
+- AND the response shows the error "Este enlace ya fue utilizado."
+- AND no notification email is sent
+
+#### Scenario: Reject an unknown token
+
+- GIVEN no row in `password_reset_tokens` matches the supplied token's hash
+- WHEN a POST is made to `/Account/ResetPassword` with body `{ token: "never-issued", password: "..." }`
+- THEN the response shows the error "Enlace inválido."
+- AND no DB write occurs
+
+### Requirement: Render reset form on GET
+
+The system SHALL render the reset-password form on `GET /Account/ResetPassword?token={rawToken}` without consuming the token. The token SHALL be round-tripped to the POST action via a hidden form field.
+
+#### Scenario: GET with valid token renders the reset form
+
+- GIVEN a row in `password_reset_tokens` exists with valid (unused, unexpired) hash matching `rawToken`
+- WHEN a GET is made to `/Account/ResetPassword?token={rawToken}`
+- THEN the response is HTTP 200 rendering the reset form
+- AND the form posts back to `/Account/ResetPassword` including the token in a hidden field
+- AND `used_at` is NOT set by the GET

--- a/openspec/changes/password-recovery/specs/password-reset-email/spec.md
+++ b/openspec/changes/password-recovery/specs/password-reset-email/spec.md
@@ -1,0 +1,55 @@
+# Delta for password-reset-email
+
+> First-time capability. The main spec (`openspec/specs/password-reset-email/spec.md`) was created from this delta. The `## ADDED Requirements` block below mirrors the requirements to be merged on archive.
+
+## ADDED Requirements
+
+### Requirement: Issue reset token on request
+
+The system SHALL issue a single-use, time-limited reset token when `POST /Account/ForgotPassword` is received for a registered email. The raw token SHALL be transmitted only via the emailed link; only its SHA-256 hash SHALL be persisted in `password_reset_tokens`.
+
+#### Scenario: Request reset for a registered email
+
+- GIVEN a user account exists in `usuarios` with `email = foo@example.com`
+- AND requester IP is `203.0.113.42` and User-Agent is `Mozilla/5.0 ...`
+- WHEN a POST is made to `/Account/ForgotPassword` with body `{ email: "foo@example.com" }`
+- THEN a row is inserted into `password_reset_tokens` with `usuario_id` matching that user
+- AND `token_hash` is a 64-character hex string (SHA-256)
+- AND `expires_at` is approximately now + 1 hour (±2 minutes)
+- AND `used_at` is NULL
+- AND `ip_address` is `203.0.113.42`
+- AND an email is sent to `foo@example.com` containing a link `/Account/ResetPassword?token={rawToken}`
+- AND the HTTP response is 200 with the generic message "Si tu dirección de correo está registrada, recibirás un enlace para restablecer tu contraseña."
+
+#### Scenario: Request reset for an unregistered email
+
+- GIVEN no user exists with `email = unknown@example.com`
+- WHEN a POST is made to `/Account/ForgotPassword` with body `{ email: "unknown@example.com" }`
+- THEN NO row is inserted into `password_reset_tokens`
+- AND NO email is sent
+- AND the HTTP response is 200 with the SAME generic message as the registered-email case
+- AND response timing is within ±200ms of the registered-email path (no timing-based enumeration)
+
+### Requirement: Rate limit forgot-password requests
+
+The system SHALL cap password-reset requests at 3 POSTs per IP per rolling hour. Over-limit requests SHALL return HTTP 200 with the generic message and MUST NOT insert rows or send email.
+
+#### Scenario: Fourth request from same IP within one hour is suppressed
+
+- GIVEN requester IP `198.51.100.7` has submitted 3 POSTs to `/Account/ForgotPassword` within the last hour
+- WHEN a 4th POST is made from the same IP to `/Account/ForgotPassword` with any email
+- THEN the HTTP response is 200 with the generic message
+- AND NO row is inserted into `password_reset_tokens`
+- AND NO email is sent
+- AND the rate-limit window resets 1 hour after the first request
+
+### Requirement: Tokens never persisted in plaintext
+
+The system SHALL store only the SHA-256 hash of reset tokens. The raw token SHALL be transmitted only via email link and SHALL NOT be persisted anywhere in `password_reset_tokens`.
+
+#### Scenario: Stored token_hash values are SHA-256 hex; raw token is not persisted
+
+- GIVEN any number of reset tokens have been issued
+- WHEN querying `SELECT token_hash FROM password_reset_tokens WHERE deleted_at IS NULL`
+- THEN every `token_hash` is exactly 64 lowercase hex characters
+- AND no row contains the raw token that was emailed

--- a/openspec/changes/password-recovery/tasks.md
+++ b/openspec/changes/password-recovery/tasks.md
@@ -1,0 +1,117 @@
+# Tasks: password-recovery
+
+## 1. Goal
+
+Self-service password recovery: `/Account/ForgotPassword` issues a single-use, 1h-valid reset link via SMTP email; `/Account/ResetPassword` consumes it and sets a new BCrypt-hashed password. Admin reset untouched. Verified by `dotnet build src/ExtraGasMVC` + 7-step smoke with MailHog + SQL.
+
+## 2. Out-of-scope reminder
+
+No Identity, 2FA, OAuth/SSO, distributed rate limit, email-change verification, audit dashboard, lockout beyond per-IP rate-limit, or changes to `UsuariosController.ResetPassword` / `TemporaryPasswordGenerator`.
+
+## 3. Work units
+
+### Task 1: Add MailKit NuGet package
+
+**Files**: `src/ExtraGasMVC/ExtraGasMVC.csproj` (mod). **Acceptance**: `<PackageReference Include="MailKit" Version="4.8.0" />` pinned; restore clean. **Lines**: 3. **Depends on**: none.
+
+### Task 2: Create migration
+
+**Files**: `db/migrations/20260828_000004_create_password_reset_tokens.sql` (new). **Acceptance**: DDL per design §Database — `id BIGINT UNSIGNED AUTO_INCREMENT` PK, all audit cols (`created_by`/`updated_by`/`deleted_at` NULL), `token_hash VARCHAR(64)`, `ip_address VARCHAR(45)`, `user_agent VARCHAR(500)`, `expires_at`, `used_at`; idx `uk_token_hash` unique + `idx_usuario_used` + `idx_expires_at`; FK `fk_password_reset_tokens_usuario` ON DELETE CASCADE; InnoDB utf8mb4; table comment. **Lines**: 25. **Depends on**: none.
+
+### Task 3: Entity + EF config + DbSet
+
+**Files**: `Data/Entities/PasswordResetToken.cs` (new); `Data/Configurations/PasswordResetTokenConfiguration.cs` (new); `Data/Context/ExtraGasDbContext.cs` (mod). **Acceptance**: POCO mirrors DDL + nav `Usuario`; config snake_case + maxlengths + indexes + `HasQueryFilter(rt => rt.DeletedAt == null)`; `DbSet<PasswordResetToken> PasswordResetTokens` in `Personas y seguridad` group. **Lines**: 86. **Depends on**: T2.
+
+### Task 4: Result type + IUsuarioService
+
+**Files**: `Services/ConsumeResetTokenResult.cs` (new); `Services/Interfaces/IUsuarioService.cs` (mod). **Acceptance**: `enum ConsumeResetTokenOutcome { Success, InvalidToken, ExpiredToken, AlreadyUsed, WeakPassword, UnknownError }` + record; add `RequestPasswordResetAsync(email, ipAddress, userAgent, ct)` and `ConsumePasswordResetTokenAsync(rawToken, newPassword, ct)` with XML docs. **Lines**: 22. **Depends on**: T3.
+
+### Task 5: Email infrastructure
+
+**Files**: `Configuration/EmailOptions.cs` (new, matches `AuthLockoutOptions` location); `Services/Interfaces/IEmailSender.cs` (new); `Services/Implementations/MailKitEmailSender.cs` (new); `Services/Implementations/EmailTemplates.cs` (new). **Acceptance**: `EmailOptions` (Host/Port/UseSsl/From*/Username?/Password?/BaseUrl, `SectionName="Email"`); `IEmailSender.SendAsync`; `MailKitEmailSender` uses `using SmtpClient` + `StartTlsWhenAvailable` + try/catch log+swallow (no body in logs); `EmailTemplates.ResetLink` + `PasswordChanged` Spanish templates, `PasswordChanged` has NO reset link. **Lines**: 187. **Depends on**: T1.
+
+### Task 6: Wire EmailOptions + appsettings
+
+**Files**: `Program.cs` (mod); `appsettings.json` (mod); `appsettings.Development.json` (mod). **Acceptance**: `Configure<EmailOptions>` near `Configure<PasswordPolicyOptions>` (~line 41); `AddScoped<IEmailSender, MailKitEmailSender>()`; post-build `LogWarning` if Host set but Username/Password null (no crash); non-secret Email sections in both appsettings (Dev = MailHog localhost:1025). **Lines**: 24. **Depends on**: T5.
+
+### Task 7: Implement IUsuarioService methods
+
+**Files**: `Services/Implementations/UsuarioService.cs` (mod). **Acceptance**: Inject `IEmailSender`/`IServiceScopeFactory`/`ILogger<UsuarioService>`. Private `GenerateRawToken` (base64url CSPRNG 32B = 43 chars) + `HashToken` (SHA-256 hex). `RequestPasswordResetAsync`: IgnoreQueryFilters lookup by email + Activo, null/inactive → silent return; insert token (expires +1h, audit null); fire-and-forget email via `Task.Run` + fresh DI scope + swallow (design ambiguity #3). `ConsumePasswordResetTokenAsync`: policy validate first → `WeakPassword`; atomic `ExecuteUpdateAsync` (Pomelo 9) WHERE `TokenHash==hash && UsedAt==null && ExpiresAt>UtcNow`; on rowsAffected==1 update user BCrypt hash + `DebeCambiarPassword=false` + fire-and-forget `PasswordChanged` email; on rowsAffected==0 diagnose (IgnoreQueryFilters SELECT) → `InvalidToken`/`AlreadyUsed`/`ExpiredToken`; DB exception → `UnknownError`. **Lines**: 130. **Depends on**: T4, T6.
+
+### Task 8: DTOs
+
+**Files**: `DTOs/ForgotPasswordDto.cs` (new); `DTOs/ResetPasswordDto.cs` (new). **Acceptance**: Email `[Required][EmailAddress][StringLength(150)]`; Reset has `Token [Required]`, `NewPassword [Required][DataType(Password)]`, `ConfirmPassword [Compare(nameof(NewPassword))]`. **Lines**: 44. **Depends on**: T7.
+
+### Task 9: AccountController actions
+
+**Files**: `Controllers/AccountController.cs` (mod). **Acceptance**: Inject `IMemoryCache`/`IEmailSender`/`IPasswordPolicyService`/`IServiceScopeFactory`; reuse existing private `GetClientIp()`/`GetUserAgent()` (lines 183–198). `[HttpGet][AllowAnonymous] ForgotPassword()` renders view. `[HttpPost][ValidateAntiForgeryToken][AllowAnonymous] ForgotPassword(ForgotPasswordDto)`: rate-limit cache key `password-reset:forgot:{ip}` TTL 1h max 3 (over → generic TempData, no service call); else call service; always show generic "Si tu dirección..." (no enumeration). `[HttpGet][AllowAnonymous] ResetPassword(string? token)` renders form, **no DB read**. `[HttpPost][ValidateAntiForgeryToken][AllowAnonymous] ResetPassword(ResetPasswordDto, ct)` maps outcomes per design §Controllers: Success → redirect Login + success TempData; ExpiredToken/AlreadyUsed/InvalidToken → TempData Error + return view; WeakPassword → ModelState errors + return view; UnknownError → generic TempData Error. **Lines**: 120. **Depends on**: T8.
+
+### Task 10: ForgotPassword.cshtml
+
+**Files**: `Views/Account/ForgotPassword.cshtml` (new). **Acceptance**: Layout `_AccountLayout`, AdminLTE `login-box` matching Login, `<form asp-action="ForgotPassword">` + antiforgery + validation summary, email input (`asp-for="Email"`, `type="email"`, `required`, `autofocus`), submit btn, `@await Html.PartialAsync("_StatusMessage")` below card (layout doesn't auto-include), link back to Login. **Lines**: 45. **Depends on**: T9.
+
+### Task 11: ResetPassword.cshtml
+
+**Files**: `Views/Account/ResetPassword.cshtml` (new). **Acceptance**: `@model ResetPasswordDto`; layout `_AccountLayout`; `login-box` width 420px; hidden `<input asp-for="Token">`; password + confirm inputs; policy bullets copied from `ChangePassword.cshtml` lines 28–59 (from `ViewBag.PasswordPolicy`); submit btn; `@await Html.PartialAsync("_StatusMessage")` below card. **Lines**: 85. **Depends on**: T10.
+
+### Task 12: Login.cshtml link
+
+**Files**: `Views/Account/Login.cshtml` (mod). **Acceptance**: Replace line 41 `<span>...contacta a un administrador...</span>` with `<a asp-action="ForgotPassword" class="text-decoration-none">¿Olvidaste tu contraseña?</a>`; preserve surrounding `<p>` blocks. **Lines**: 2. **Depends on**: T11.
+
+### Task 13: dotnet build verification
+
+**Files**: none. **Acceptance**: `dotnet build src/ExtraGasMVC` exits 0, zero new warnings. **Lines**: 0. **Depends on**: T12.
+
+### Task 14: Apply migration
+
+**Files**: `db/migrations/20260828_000004_create_password_reset_tokens.sql` (applied, no edit). **Acceptance**: `mysql -uroot extragas < db/migrations/20260828_000004_create_password_reset_tokens.sql` exits 0; `SHOW TABLES LIKE 'password_reset_tokens'` returns 1 row; `SHOW CREATE TABLE` confirms columns/indexes/FK; re-run is no-op. **Lines**: 0. **Depends on**: T13.
+
+### Task 15: Manual smoke flow
+
+**Files**: none. **Acceptance**: (1) ForgotPassword known email → row + MailHog email; (2) GET ResetPassword renders form, used_at NULL; (3) POST ResetPassword → used_at set, redirect Login + notification email; (4) Login with new password succeeds; (5) Reuse consumed token → "Este enlace ya fue utilizado."; (6) Unknown email → identical generic, no row; (7) Admin `Usuarios/ResetPassword` still works (`debe_cambiar_password=true`, temp password). Bonus: 4th ForgotPassword same IP within 1h → generic, no row. **Lines**: 0. **Depends on**: T14.
+
+## 4. Spec ↔ task traceability
+
+| Spec scenario | Tasks |
+|---|---|
+| `password-reset-email` › Request reset for registered email | T2, T3, T7, T9, T15 |
+| `password-reset-email` › Request reset for unregistered email | T7, T9, T15 |
+| `password-reset-email` › Rate limit on `/Account/ForgotPassword` | T9, T15 |
+| `password-reset-email` › Reset token never stored in plaintext | T2, T3, T7 |
+| `password-reset-confirm` › Successful password reset | T4, T7, T9, T11, T15 |
+| `password-reset-confirm` › Reject expired token | T4, T7, T9, T15 |
+| `password-reset-confirm` › Reject already-used token | T4, T7, T9, T15 |
+| `password-reset-confirm` › Reject unknown token | T4, T7, T9, T15 |
+| `password-reset-confirm` › GET renders form | T9, T11, T15 |
+
+## 5. Review Workload Forecast
+
+- **Total estimated changed lines**: 773 (T1 3 + T2 25 + T3 86 + T4 22 + T5 187 + T6 24 + T7 130 + T8 44 + T9 120 + T10 45 + T11 85 + T12 2)
+- **400-line budget risk**: High (≈1.93× budget)
+- **Chained PRs recommended**: Yes
+- **Decision needed before apply**: Yes (`ask-on-risk`)
+- **Rationale**: spans NuGet + migration + entity/config + DTOs + options + email infra + controller + 2 views + login touch — far too much for one PR.
+
+### Suggested work units (chained PRs)
+
+| Unit | Goal | PR | Base | Lines |
+|------|------|----|------|-------|
+| 1 | NuGet + migration + entity/config/DbSet | PR 1 | `main` | ~114 (T1+T2+T3) |
+| 2 | Email infra: options + sender + templates + DI + appsettings | PR 2 | `main` (stacked) or feature branch | ~211 (T5+T6) |
+| 3 | Service layer: result + interface + impl + DTOs | PR 3 | PR 1 + PR 2 | ~196 (T4+T7+T8) |
+| 4 | Controller + 2 views + login link | PR 4 | PR 3 | ~252 (T9+T10+T11+T12) |
+| 5 | DB apply + smoke | PR 4 commits | n/a | 0 (T13+T14+T15) |
+
+**Chain strategy**: `stacked-to-main` natural (each PR independently shippable). `feature-branch-chain` safer for rollback. `size:exception` NOT recommended (crosses 4 layers). If user accepts `size:exception`, units 1–4 collapse to one PR (~773 lines) — SDD guard rejects without explicit exception.
+
+## 6. Delivery strategy
+
+`ask-on-risk` (per SDD Session Preflight). Forecast High → orchestrator MUST ask the user to choose `stacked-to-main` / `feature-branch-chain` / `size:exception` **before** `sdd-apply`. Do not proceed silently.
+
+## 7. Order of execution
+
+T1+T2 parallel → T3 → (T5 || T4) → T6 → T7 → T8 → T9 → T10 → T11 → T12 → T13 → T14 → T15. PR cuts: PR1=T1+T2+T3; PR2=T5+T6; PR3=T4+T7+T8; PR4=T9+T10+T11+T12.
+
+## 8. Rollback plan
+
+Per proposal: drop `password_reset_tokens` table; revert `IUsuarioService` + `UsuarioService` (remove 2 methods); revert `AccountController` actions; delete `ForgotPassword.cshtml` + `ResetPassword.cshtml`; revert `Login.cshtml` link; revert `Program.cs` Email wiring; revert `appsettings*.json` Email sections; uninstall MailKit. No password hashes mutated → fully reversible on data.

--- a/openspec/specs/password-reset-confirm/spec.md
+++ b/openspec/specs/password-reset-confirm/spec.md
@@ -1,0 +1,56 @@
+# Password Reset Confirm Specification
+
+## Purpose
+
+Allow a user holding a valid reset token to set a new password and regain access to their account.
+
+## Requirements
+
+### Requirement: Consume valid token and set new password
+
+The system SHALL consume a valid (unused, unexpired) reset token on `POST /Account/ResetPassword`, replace the user's BCrypt password hash, and mark the token used. On success a notification email SHALL be sent to the user's registered address confirming the change (no reset link in that email).
+
+#### Scenario: Successful password reset
+
+- GIVEN a row in `password_reset_tokens` with `token_hash = SHA-256(rawToken)` and `used_at IS NULL` and `expires_at > NOW()`
+- WHEN a POST is made to `/Account/ResetPassword` with body `{ token: rawToken, password: "NewSecure123!" }`
+- THEN `password_reset_tokens.used_at` is set to NOW for that row
+- AND `usuarios.password_hash` for the matching user is replaced with a fresh BCrypt hash of "NewSecure123!"
+- AND a notification email is sent to the user's registered email confirming the password was changed (no reset link in this email)
+- AND the response redirects to `/Account/Login` with a success TempData message
+
+#### Scenario: Reject an expired token
+
+- GIVEN a row in `password_reset_tokens` with `expires_at < NOW()` and `used_at IS NULL`
+- WHEN a POST is made to `/Account/ResetPassword` with the corresponding raw token
+- THEN `used_at` remains NULL
+- AND `usuarios.password_hash` is NOT modified
+- AND the response shows the error "El enlace ha expirado. Solicitá uno nuevo."
+- AND no notification email is sent
+
+#### Scenario: Reject an already-used token
+
+- GIVEN a row in `password_reset_tokens` with `used_at IS NOT NULL`
+- WHEN a POST is made to `/Account/ResetPassword` with the corresponding raw token
+- THEN `usuarios.password_hash` is NOT modified
+- AND the response shows the error "Este enlace ya fue utilizado."
+- AND no notification email is sent
+
+#### Scenario: Reject an unknown token
+
+- GIVEN no row in `password_reset_tokens` matches the supplied token's hash
+- WHEN a POST is made to `/Account/ResetPassword` with body `{ token: "never-issued", password: "..." }`
+- THEN the response shows the error "Enlace inválido."
+- AND no DB write occurs
+
+### Requirement: Render reset form on GET
+
+The system SHALL render the reset-password form on `GET /Account/ResetPassword?token={rawToken}` without consuming the token. The token SHALL be round-tripped to the POST action via a hidden form field.
+
+#### Scenario: GET with valid token renders the reset form
+
+- GIVEN a row in `password_reset_tokens` exists with valid (unused, unexpired) hash matching `rawToken`
+- WHEN a GET is made to `/Account/ResetPassword?token={rawToken}`
+- THEN the response is HTTP 200 rendering the reset form
+- AND the form posts back to `/Account/ResetPassword` including the token in a hidden field
+- AND `used_at` is NOT set by the GET

--- a/openspec/specs/password-reset-email/spec.md
+++ b/openspec/specs/password-reset-email/spec.md
@@ -1,0 +1,57 @@
+# Password Reset Email Specification
+
+## Purpose
+
+Enable users to recover access to their account by requesting a one-time password-reset link delivered to their registered email, without contacting an administrator.
+
+## Requirements
+
+### Requirement: Issue reset token on request
+
+The system SHALL issue a single-use, time-limited reset token when `POST /Account/ForgotPassword` is received for a registered email. The raw token SHALL be transmitted only via the emailed link; only its SHA-256 hash SHALL be persisted in `password_reset_tokens`.
+
+#### Scenario: Request reset for a registered email
+
+- GIVEN a user account exists in `usuarios` with `email = foo@example.com`
+- AND requester IP is `203.0.113.42` and User-Agent is `Mozilla/5.0 ...`
+- WHEN a POST is made to `/Account/ForgotPassword` with body `{ email: "foo@example.com" }`
+- THEN a row is inserted into `password_reset_tokens` with `usuario_id` matching that user
+- AND `token_hash` is a 64-character hex string (SHA-256)
+- AND `expires_at` is approximately now + 1 hour (±2 minutes)
+- AND `used_at` is NULL
+- AND `ip_address` is `203.0.113.42`
+- AND an email is sent to `foo@example.com` containing a link `/Account/ResetPassword?token={rawToken}`
+- AND the HTTP response is 200 with the generic message "Si tu dirección de correo está registrada, recibirás un enlace para restablecer tu contraseña."
+
+#### Scenario: Request reset for an unregistered email
+
+- GIVEN no user exists with `email = unknown@example.com`
+- WHEN a POST is made to `/Account/ForgotPassword` with body `{ email: "unknown@example.com" }`
+- THEN NO row is inserted into `password_reset_tokens`
+- AND NO email is sent
+- AND the HTTP response is 200 with the SAME generic message as the registered-email case
+- AND response timing is within ±200ms of the registered-email path (no timing-based enumeration)
+
+### Requirement: Rate limit forgot-password requests
+
+The system SHALL cap password-reset requests at 3 POSTs per IP per rolling hour. Over-limit requests SHALL return HTTP 200 with the generic message and MUST NOT insert rows or send email.
+
+#### Scenario: Fourth request from same IP within one hour is suppressed
+
+- GIVEN requester IP `198.51.100.7` has submitted 3 POSTs to `/Account/ForgotPassword` within the last hour
+- WHEN a 4th POST is made from the same IP to `/Account/ForgotPassword` with any email
+- THEN the HTTP response is 200 with the generic message
+- AND NO row is inserted into `password_reset_tokens`
+- AND NO email is sent
+- AND the rate-limit window resets 1 hour after the first request
+
+### Requirement: Tokens never persisted in plaintext
+
+The system SHALL store only the SHA-256 hash of reset tokens. The raw token SHALL be transmitted only via email link and SHALL NOT be persisted anywhere in `password_reset_tokens`.
+
+#### Scenario: Stored token_hash values are SHA-256 hex; raw token is not persisted
+
+- GIVEN any number of reset tokens have been issued
+- WHEN querying `SELECT token_hash FROM password_reset_tokens WHERE deleted_at IS NULL`
+- THEN every `token_hash` is exactly 64 lowercase hex characters
+- AND no row contains the raw token that was emailed

--- a/src/ExtraGasMVC/Data/Configurations/PasswordResetTokenConfiguration.cs
+++ b/src/ExtraGasMVC/Data/Configurations/PasswordResetTokenConfiguration.cs
@@ -1,0 +1,76 @@
+using ExtraGasMVC.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ExtraGasMVC.Data.Configurations;
+
+public class PasswordResetTokenConfiguration : IEntityTypeConfiguration<PasswordResetToken>
+{
+    public void Configure(EntityTypeBuilder<PasswordResetToken> builder)
+    {
+        builder.ToTable("password_reset_tokens");
+
+        builder.HasKey(rt => rt.Id);
+        builder.Property(rt => rt.Id).HasColumnName("id");
+
+        builder.Property(rt => rt.UsuarioId).HasColumnName("usuario_id");
+
+        builder.Property(rt => rt.TokenHash)
+            .HasColumnName("token_hash")
+            .HasMaxLength(64)
+            .IsRequired();
+
+        builder.Property(rt => rt.IpAddress)
+            .HasColumnName("ip_address")
+            .HasMaxLength(45);
+
+        builder.Property(rt => rt.UserAgent)
+            .HasColumnName("user_agent")
+            .HasMaxLength(500);
+
+        builder.Property(rt => rt.ExpiresAt)
+            .HasColumnName("expires_at")
+            .HasColumnType("datetime")
+            .IsRequired();
+
+        builder.Property(rt => rt.UsedAt)
+            .HasColumnName("used_at")
+            .HasColumnType("datetime");
+
+        builder.Property(rt => rt.CreatedAt)
+            .HasColumnName("created_at")
+            .HasColumnType("datetime")
+            .ValueGeneratedOnAdd()
+            .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+        builder.Property(rt => rt.UpdatedAt)
+            .HasColumnName("updated_at")
+            .HasColumnType("datetime")
+            .ValueGeneratedOnAddOrUpdate()
+            .HasDefaultValueSql("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP");
+
+        builder.Property(rt => rt.CreatedBy).HasColumnName("created_by");
+        builder.Property(rt => rt.UpdatedBy).HasColumnName("updated_by");
+        builder.Property(rt => rt.DeletedAt)
+            .HasColumnName("deleted_at")
+            .HasColumnType("datetime");
+
+        builder.HasOne(rt => rt.Usuario)
+            .WithMany()
+            .HasForeignKey(rt => rt.UsuarioId)
+            .OnDelete(DeleteBehavior.Cascade)
+            .HasConstraintName("fk_password_reset_tokens_usuario");
+
+        builder.HasIndex(rt => rt.TokenHash)
+            .IsUnique()
+            .HasDatabaseName("uk_token_hash");
+
+        builder.HasIndex(rt => new { rt.UsuarioId, rt.UsedAt })
+            .HasDatabaseName("idx_usuario_used");
+
+        builder.HasIndex(rt => rt.ExpiresAt)
+            .HasDatabaseName("idx_expires_at");
+
+        builder.HasQueryFilter(rt => rt.DeletedAt == null);
+    }
+}

--- a/src/ExtraGasMVC/Data/Context/ExtraGasDbContext.cs
+++ b/src/ExtraGasMVC/Data/Context/ExtraGasDbContext.cs
@@ -25,6 +25,7 @@ public class ExtraGasDbContext : DbContext
     public DbSet<Usuario> Usuarios => Set<Usuario>();
     public DbSet<Empleado> Empleados => Set<Empleado>();
     public DbSet<AuditoriaLogin> AuditoriaLogins => Set<AuditoriaLogin>();
+    public DbSet<PasswordResetToken> PasswordResetTokens => Set<PasswordResetToken>();
     public DbSet<Cliente> Clientes => Set<Cliente>();
     public DbSet<ClienteContacto> ClienteContactos => Set<ClienteContacto>();
     public DbSet<Proveedor> Proveedores => Set<Proveedor>();

--- a/src/ExtraGasMVC/Data/Entities/PasswordResetToken.cs
+++ b/src/ExtraGasMVC/Data/Entities/PasswordResetToken.cs
@@ -1,0 +1,23 @@
+namespace ExtraGasMVC.Data.Entities;
+
+/// <summary>
+/// Token de un solo uso para reset de contrasena. Solo se persiste el SHA-256
+/// hex del token raw; el raw viaja unicamente por email y nunca se guarda.
+/// </summary>
+public class PasswordResetToken
+{
+    public ulong Id { get; set; }
+    public ulong UsuarioId { get; set; }
+    public string TokenHash { get; set; } = null!;
+    public string? IpAddress { get; set; }
+    public string? UserAgent { get; set; }
+    public DateTime ExpiresAt { get; set; }
+    public DateTime? UsedAt { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public ulong? CreatedBy { get; set; }
+    public ulong? UpdatedBy { get; set; }
+    public DateTime? DeletedAt { get; set; }
+
+    public Usuario? Usuario { get; set; }
+}

--- a/src/ExtraGasMVC/ExtraGasMVC.csproj
+++ b/src/ExtraGasMVC/ExtraGasMVC.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.2.0" />
+    <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.16">


### PR DESCRIPTION
## Linked SDD change
`password-recovery` (stacked-to-develop chain, PR1 of 4)

## Tasks implemented
- **T1**: Add `MailKit` 4.17.0 NuGet package (pinned to latest stable 4.x; 4.8.0 has a known moderate vulnerability — `GHSA-9j88-vvj5-vhgr`, fixed in 4.9.x+, latest is 4.17.0).
- **T2**: New migration `db/migrations/20260828_000004_create_password_reset_tokens.sql` — DDL per design §Database, idempotent (`CREATE TABLE IF NOT EXISTS`), all audit cols, 3 indexes (`uk_token_hash` unique + `idx_usuario_used` + `idx_expires_at`), FK `fk_password_reset_tokens_usuario` ON DELETE CASCADE.
- **T3**: `PasswordResetToken` entity (POCO), `PasswordResetTokenConfiguration` (`IEntityTypeConfiguration<PasswordResetToken>`), `DbSet<PasswordResetToken> PasswordResetTokens` added to `ExtraGasDbContext` in the `Personas y seguridad` group.

## Out of scope (future PRs)
- **PR2** (T5+T6): `EmailOptions`, `IEmailSender`/`MailKitEmailSender`/`EmailTemplates`, DI wiring + `appsettings*.json`.
- **PR3** (T4+T7+T8): `ConsumeResetTokenResult`, `IUsuarioService` additions, `UsuarioService` impl, DTOs.
- **PR4** (T9+T10+T11+T12+T13+T14+T15): `AccountController` actions + `ForgotPassword.cshtml` + `ResetPassword.cshtml` + `Login.cshtml` link + `dotnet build` verification + SQL migration apply + manual smoke flow.

## Verification
- `dotnet build src/ExtraGasMVC` → **Build succeeded** (0 errors). 3 warnings, all pre-existing on `develop`:
  - `NU1903`: AutoMapper 12.0.1 (unrelated to this change).
  - `CS8602`: `Views/Recepciones/Create.cshtml:62` (pre-existing).
  - SonarQube targets file not found (pre-existing infra issue).
- No NEW warnings introduced by this PR.
- `dotnet restore` clean after MailKit version bump.

## Spec ↔ task traceability (from tasks.md §4)
| Spec scenario | Tasks | This PR |
|---|---|---|
| `password-reset-email` › Request reset for registered email | T2, T3, T7, T9, T15 | T2 ✅, T3 ✅ |
| `password-reset-email` › Request reset for unregistered email | T7, T9, T15 | — |
| `password-reset-email` › Rate limit on `/Account/ForgotPassword` | T9, T15 | — |
| `password-reset-email` › Reset token never stored in plaintext | T2, T3, T7 | T2 ✅, T3 ✅ |
| `password-reset-confirm` › Successful password reset | T4, T7, T9, T11, T15 | — |
| `password-reset-confirm` › Reject expired token | T4, T7, T9, T15 | — |
| `password-reset-confirm` › Reject already-used token | T4, T7, T9, T15 | — |
| `password-reset-confirm` › Reject unknown token | T4, T7, T9, T15 | — |
| `password-reset-confirm` › GET renders form | T9, T11, T15 | — |

## Line budget
- `src/` + `db/migrations/` changes: **142 insertions** (T1=1, T2=41, T3=100). Under the 200-line PR1 budget.
- The pre-step `chore(sdd): add password-recovery change artifacts` commit (`openspec/`) is excluded from the budget per task spec.

## Notes for reviewer
- Entity uses `ulong` for PK/FKs to match project convention (`BIGINT UNSIGNED` ↔ `ulong`). All other entities follow this pattern.
- `HasQueryFilter(rt => rt.DeletedAt == null)` per `AGENTS.md` soft-delete convention.
- FK uses `OnDelete(DeleteBehavior.Cascade)` per design §Database rationale (reset token without user is meaningless; user deletion cleans up pending tokens).
- `created_by`/`updated_by` are `ulong?` (nullable) per design — anonymous requester.
- Migration is idempotent (`CREATE TABLE IF NOT EXISTS`) and `USE extragas;` qualified.