### PR TITLE
feat(password-recovery): PR2 — email infra (MailKit sender, templates, options, DI)

### DIFF
--- a/src/ExtraGasMVC/Configuration/EmailOptions.cs
+++ b/src/ExtraGasMVC/Configuration/EmailOptions.cs
@@ -1,0 +1,61 @@
+namespace ExtraGasMVC.Configuration;
+
+/// <summary>
+/// Opciones para el envio de emails transaccionales (SMTP via MailKit).
+/// Bound desde la seccion "Email" de appsettings.
+///
+/// IMPORTANTE: el binding se hace en el arranque del proceso con IOptions&lt;&gt;.
+/// Cambios en appsettings.json requieren reinicio de la aplicacion.
+/// Si se necesita hot-reload, migrar a IOptionsMonitor&lt;&gt;.
+///
+/// En produccion las credenciales (Username/Password) NO van en appsettings.json:
+/// se setean con <c>dotnet user-secrets set "Email:Username" "..." --project src/ExtraGasMVC</c>
+/// y su equivalente para <c>Email:Password</c>.
+/// </summary>
+public class EmailOptions
+{
+    public const string SectionName = "Email";
+
+    /// <summary>
+    /// Host SMTP (ej. "smtp.gmail.com" en prod, "localhost" en dev con MailHog).
+    /// </summary>
+    public string Host { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Puerto SMTP. 587 para STARTTLS, 465 para SSL implicito, 1025 para MailHog dev.
+    /// </summary>
+    public int Port { get; set; } = 587;
+
+    /// <summary>
+    /// Si true, usa STARTTLS (<c>SecureSocketOptions.StartTlsWhenAvailable</c>) sobre el puerto 587.
+    /// Si false, conecto en plano (util para MailHog local).
+    /// </summary>
+    public bool UseSsl { get; set; } = true;
+
+    /// <summary>
+    /// Direccion del remitente (ej. "noreply@extragas.com").
+    /// </summary>
+    public string FromAddress { get; set; } = "noreply@example.com";
+
+    /// <summary>
+    /// Nombre a mostrar del remitente (ej. "ExtraGas").
+    /// </summary>
+    public string FromDisplayName { get; set; } = "ExtraGas";
+
+    /// <summary>
+    /// Usuario SMTP (opcional: MailHog en dev no requiere auth).
+    /// En prod se setea por user-secrets.
+    /// </summary>
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Password SMTP (opcional: MailHog en dev no requiere auth).
+    /// En prod se setea por user-secrets.
+    /// </summary>
+    public string? Password { get; set; }
+
+    /// <summary>
+    /// URL base para construir links en emails (ej. "https://extragas.example.com").
+    /// </summary>
+    public string BaseUrl { get; set; } = "http://localhost:5000";
+}

--- a/src/ExtraGasMVC/Program.cs
+++ b/src/ExtraGasMVC/Program.cs
@@ -8,6 +8,7 @@ using ExtraGasMVC.Services.Implementations;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -41,6 +42,11 @@ builder.Services.Configure<AuthLockoutOptions>(
 builder.Services.Configure<PasswordPolicyOptions>(
     builder.Configuration.GetSection(PasswordPolicyOptions.SectionName));
 
+// Bind EmailOptions desde appsettings (seccion "Email"). En produccion las
+// credenciales (Username/Password) se setean con dotnet user-secrets — ver README.
+builder.Services.Configure<EmailOptions>(
+    builder.Configuration.GetSection(EmailOptions.SectionName));
+
 // Registrar AutoMapper
 builder.Services.AddAutoMapper(typeof(MappingProfile).Assembly);
 
@@ -63,12 +69,35 @@ builder.Services.AddScoped<IProveedorService, ProveedorService>();
 builder.Services.AddScoped<IPagoService, PagoService>();
 builder.Services.AddScoped<IGarrafaService, GarrafaService>();
 builder.Services.AddScoped<IUsuarioService, UsuarioService>();
+builder.Services.AddScoped<IEmailSender, MailKitEmailSender>();
 builder.Services.AddScoped<IEmpleadoService, EmpleadoService>();
 builder.Services.AddScoped<IRecepcionService, RecepcionService>();
 builder.Services.AddScoped<IAuditoriaLoginService, AuditoriaLoginService>();
 builder.Services.AddSingleton<IPasswordPolicyService, PasswordPolicyService>();
 
 var app = builder.Build();
+
+// Sanity check de configuracion SMTP fuera de Development: si hay Host pero
+// faltan Username/Password, loggear warning y NO crashear (MailKit fallara
+// al primer envio; el caller hace fire-and-forget y loggea). En dev (MailHog)
+// los campos son opcionales por lo que no se valida.
+if (!app.Environment.IsDevelopment())
+{
+    var emailOptions = app.Services.GetRequiredService<IOptions<EmailOptions>>().Value;
+    if (!string.IsNullOrWhiteSpace(emailOptions.Host))
+    {
+        if (string.IsNullOrEmpty(emailOptions.Username) || string.IsNullOrEmpty(emailOptions.Password))
+        {
+            var startupLogger = app.Services.GetRequiredService<ILoggerFactory>()
+                .CreateLogger("EmailStartup");
+            startupLogger.LogWarning(
+                "Email:Host configurado ({Host}) pero Email:Username/Email:Password no estan seteados. " +
+                "Defini las credenciales SMTP via 'dotnet user-secrets set' antes de enviar emails. " +
+                "Los envios fallaran silenciosamente.",
+                emailOptions.Host);
+        }
+    }
+}
 
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())

--- a/src/ExtraGasMVC/Services/Implementations/EmailTemplates.cs
+++ b/src/ExtraGasMVC/Services/Implementations/EmailTemplates.cs
@@ -1,0 +1,54 @@
+namespace ExtraGasMVC.Services.Implementations;
+
+/// <summary>
+/// Plantillas de email en espanol para el flujo de recuperacion de password.
+/// Cada metodo devuelve el cuerpo plain-text listo para enviar.
+/// </summary>
+public static class EmailTemplates
+{
+    /// <summary>
+    /// Asunto para el email de restablecimiento.
+    /// </summary>
+    public const string ResetLinkSubject = "Restablecé tu contraseña — ExtraGas";
+
+    /// <summary>
+    /// Asunto para el email de notificacion de cambio exitoso.
+    /// </summary>
+    public const string PasswordChangedSubject = "Tu contraseña fue cambiada — ExtraGas";
+
+    /// <summary>
+    /// Email con el link de restablecimiento de contrasena (valido 1 hora).
+    /// </summary>
+    /// <param name="recipientName">Nombre a mostrar (ej. "Juan").</param>
+    /// <param name="resetUrl">URL completa con el token raw (ej. "https://app/Account/ResetPassword?token=...").</param>
+    public static string ResetLink(string recipientName, string resetUrl)
+    {
+        return $@"Hola {recipientName},
+
+Recibimos un pedido para restablecer la contrasena de tu cuenta en ExtraGas.
+
+Para elegir una nueva contrasena hace clic en el siguiente enlace (caduca en 1 hora):
+
+{resetUrl}
+
+Si no lo solicitaste vos, ignora este mensaje.
+
+— Equipo ExtraGas";
+    }
+
+    /// <summary>
+    /// Email de notificacion de cambio de contrasena exitoso.
+    /// NO contiene link de reset; advierte contactar al admin si no fue el usuario.
+    /// </summary>
+    /// <param name="recipientName">Nombre a mostrar (ej. "Juan").</param>
+    public static string PasswordChanged(string recipientName)
+    {
+        return $@"Hola {recipientName},
+
+Te confirmamos que la contrasena de tu cuenta en ExtraGas fue cambiada exitosamente.
+
+Si no realizaste este cambio, contacta inmediatamente al administrador.
+
+— Equipo ExtraGas";
+    }
+}

--- a/src/ExtraGasMVC/Services/Implementations/MailKitEmailSender.cs
+++ b/src/ExtraGasMVC/Services/Implementations/MailKitEmailSender.cs
@@ -1,0 +1,71 @@
+using ExtraGasMVC.Configuration;
+using ExtraGasMVC.Services.Interfaces;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using Microsoft.Extensions.Options;
+using MimeKit;
+
+namespace ExtraGasMVC.Services.Implementations;
+
+/// <summary>
+/// Implementacion de <see cref="IEmailSender"/> usando MailKit + MimeKit.
+/// Cualquier fallo de transporte (connect/auth/send) se loggea y se traga:
+/// un fallo SMTP NO debe propagarse al caller (fire-and-forget design).
+/// </summary>
+public class MailKitEmailSender : IEmailSender
+{
+    private readonly EmailOptions _options;
+    private readonly ILogger<MailKitEmailSender> _logger;
+
+    public MailKitEmailSender(
+        IOptions<EmailOptions> options,
+        ILogger<MailKitEmailSender> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task SendAsync(
+        string to,
+        string subject,
+        string htmlBody,
+        string? textBody = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var message = new MimeMessage();
+            message.From.Add(new MailboxAddress(_options.FromDisplayName, _options.FromAddress));
+            message.To.Add(MailboxAddress.Parse(to));
+            message.Subject = subject;
+
+            // Por ahora usamos texto plano (textBody) como cuerpo principal;
+            // htmlBody queda disponible para una version futura con BodyBuilder.TextPart/HtmlPart.
+            var bodyText = textBody ?? htmlBody;
+            message.Body = new TextPart("plain")
+            {
+                Text = bodyText
+            };
+
+            using var client = new SmtpClient();
+
+            var secureOptions = _options.UseSsl
+                ? SecureSocketOptions.StartTlsWhenAvailable
+                : SecureSocketOptions.None;
+
+            await client.ConnectAsync(_options.Host, _options.Port, secureOptions, ct);
+
+            if (!string.IsNullOrEmpty(_options.Username) && _options.Password is not null)
+            {
+                await client.AuthenticateAsync(_options.Username, _options.Password, ct);
+            }
+
+            await client.SendAsync(message, ct);
+            await client.DisconnectAsync(quit: true, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send email to {Recipient}", to);
+        }
+    }
+}

--- a/src/ExtraGasMVC/Services/Interfaces/IEmailSender.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IEmailSender.cs
@@ -1,0 +1,24 @@
+namespace ExtraGasMVC.Services.Interfaces;
+
+/// <summary>
+/// Abstraccion para envio de emails transaccionales.
+/// Permite reemplazar el transporte real (MailKit/SMTP) en tests.
+/// </summary>
+public interface IEmailSender
+{
+    /// <summary>
+    /// Envia un email. La implementacion debe loggear y tragar excepciones SMTP
+    /// (fire-and-forget design): un fallo de transporte NO debe propagarse al caller.
+    /// </summary>
+    /// <param name="to">Direccion del destinatario.</param>
+    /// <param name="subject">Asunto del mensaje.</param>
+    /// <param name="htmlBody">Cuerpo HTML (alternativa enriquecida).</param>
+    /// <param name="textBody">Cuerpo plain-text (fallback y version principal para password-recovery).</param>
+    /// <param name="ct">Token de cancelacion.</param>
+    Task SendAsync(
+        string to,
+        string subject,
+        string htmlBody,
+        string? textBody = null,
+        CancellationToken ct = default);
+}

--- a/src/ExtraGasMVC/appsettings.Development.json
+++ b/src/ExtraGasMVC/appsettings.Development.json
@@ -5,6 +5,14 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Email": {
+    "Host": "localhost",
+    "Port": 1025,
+    "UseSsl": false,
+    "FromAddress": "noreply@localhost",
+    "FromDisplayName": "ExtraGas Dev",
+    "BaseUrl": "https://localhost:5001"
+  },
   "Auth": {
     "Lockout": {
       "MaxFailedAttempts": 3,

--- a/src/ExtraGasMVC/appsettings.json
+++ b/src/ExtraGasMVC/appsettings.json
@@ -9,6 +9,14 @@
   "ConnectionStrings": {
     "ExtraGas": "---"
   },
+  "Email": {
+    "Host": "smtp.example.com",
+    "Port": 587,
+    "UseSsl": true,
+    "FromAddress": "noreply@extragas.com",
+    "FromDisplayName": "ExtraGas",
+    "BaseUrl": "https://extragas.example.com"
+  },
   "Auth": {
     "Lockout": {
       "MaxFailedAttempts": 5,


### PR DESCRIPTION
## Summary

PR2 of 4 (stacked-to-develop) for the `password-recovery` change. Wires the SMTP transport layer: MailKit-based `IEmailSender`, Spanish email templates, `EmailOptions` configuration, DI registration, and non-secret appsettings entries.

## Tasks covered

- **T5** — Email infrastructure (options + sender interface + MailKit implementation + templates)
- **T6** — Wire `EmailOptions` + appsettings (`Program.cs` + `appsettings.json` + `appsettings.Development.json`)

## Out of scope

- **T1–T4** shipped in [PR1 #93](https://github.com/elflacoseba/ExtraGas/pull/93) (MailKit NuGet, migration, entity/config/DbSet).
- **T7–T15** planned for PR3 (service layer + DTOs) and PR4 (controllers + views + smoke).
- `Controllers/AccountController.cs`, `IUsuarioService.cs`, `UsuarioService.cs`, entities/configs/migrations, `UsuariosController.cs` — **not touched** in this PR.

## Spec scenario coverage

T5+T6 are infrastructure-only: **no spec scenarios are directly exercised in this PR.** Per `openspec/changes/password-recovery/tasks.md` §4, the scenarios map to PR3/PR4 (service logic + controller + views + smoke). The plumbing they will call (`IEmailSender.SendAsync`, `EmailTemplates.ResetLink`, `EmailTemplates.PasswordChanged`, `EmailOptions.BaseUrl`) is now in place.

## Implementation notes

- `MailKitEmailSender.SendAsync`: try/catch with `ILogger.LogError` and **swallow** (per design §Ambiguity #3) so SMTP failures never propagate. Uses `SecureSocketOptions.StartTlsWhenAvailable` (dev MailHog accepts no auth, prod STARTTLS on 587).
- `Program.cs` startup sanity check: `LogWarning` (no crash) when `Email:Host` is set but `Email:Username`/`Password` missing in non-Development. Dev is excluded (MailHog has no auth).
- `EmailTemplates.ResetLink` / `PasswordChanged`: plain-text Spanish, ~10 lines each. Subjects exposed as `const string` constants.

## Credentials handling

**SMTP credentials are NOT in source.** `Email:Username` and `Email:Password` are deliberately absent from both `appsettings.json` files (commit would leak them). On the deploy/host machine they must be set via:

```bash
dotnet user-secrets set "Email:Username" "..." --project src/ExtraGasMVC
dotnet user-secrets set "Email:Password" "..." --project src/ExtraGasMVC
```

User Secrets ID is already declared in `ExtraGasMVC.csproj` (`ba3f102f-767f-4c7e-9384-6736bab751b9`).

## Verification

- `dotnet build src/ExtraGasMVC` → **succeeded**, 0 errors.
- Warnings count: 3 pre-existing on `develop` (AutoMapper NU1903 advisory + Recepciones/Create.cshtml CS8602) — **0 new warnings** introduced by this PR.
- 255 lines added (under the 300-line PR2 budget).

## Risk register

| Risk | Mitigation |
|---|---|
| SMTP misconfig in prod causes silent failures | Fire-and-forget design accepted per design.md §Ambiguity #3; admin monitors app logs for `MailKitEmailSender` errors. |
| Startup warning visibility | `ILogger` from `ILoggerFactory.CreateLogger("EmailStartup")` lands in the standard ASP.NET logging pipeline. |
| `appsettings.json` accidentally gains credentials in a future PR | This PR sets the precedent — code review must flag any future addition of `Username`/`Password` keys to the tracked file. |