### PR TITLE
feat(password-recovery): PR3 — service layer (reset token + DTOs)

### DIFF
--- a/src/ExtraGasMVC/DTOs/ForgotPasswordDto.cs
+++ b/src/ExtraGasMVC/DTOs/ForgotPasswordDto.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ExtraGasMVC.DTOs;
+
+/// <summary>
+/// Datos del formulario <c>/Account/ForgotPassword</c>.
+/// </summary>
+public class ForgotPasswordDto
+{
+    [Required(ErrorMessage = "El email es obligatorio.")]
+    [EmailAddress(ErrorMessage = "El email no tiene un formato válido.")]
+    [StringLength(150, ErrorMessage = "El email no puede superar los 150 caracteres.")]
+    [Display(Name = "Email")]
+    public string Email { get; set; } = string.Empty;
+}

--- a/src/ExtraGasMVC/DTOs/ResetPasswordDto.cs
+++ b/src/ExtraGasMVC/DTOs/ResetPasswordDto.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ExtraGasMVC.DTOs;
+
+/// <summary>
+/// Datos del formulario <c>/Account/ResetPassword</c>.
+/// El token viaja en un campo oculto y solo se valida en el POST.
+/// </summary>
+public class ResetPasswordDto
+{
+    [Required]
+    public string Token { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "La contraseña es obligatoria.")]
+    [DataType(DataType.Password)]
+    [Display(Name = "Nueva contraseña")]
+    public string NewPassword { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Confirmá la contraseña.")]
+    [DataType(DataType.Password)]
+    [Compare(nameof(NewPassword), ErrorMessage = "Las contraseñas no coinciden.")]
+    [Display(Name = "Confirmar contraseña")]
+    public string ConfirmPassword { get; set; } = string.Empty;
+}

--- a/src/ExtraGasMVC/Services/ConsumeResetTokenResult.cs
+++ b/src/ExtraGasMVC/Services/ConsumeResetTokenResult.cs
@@ -1,0 +1,25 @@
+namespace ExtraGasMVC.Services;
+
+/// <summary>
+/// Desenlace posible al intentar consumir un token de reset de contrasena.
+/// El controller mapea cada valor a un mensaje para el usuario.
+/// </summary>
+public enum ConsumeResetTokenOutcome
+{
+    Success,
+    InvalidToken,
+    ExpiredToken,
+    AlreadyUsed,
+    WeakPassword,
+    UnknownError
+}
+
+/// <summary>
+/// Resultado de <c>ConsumePasswordResetTokenAsync</c>.
+/// </summary>
+/// <param name="Outcome">Desenlace de la operacion.</param>
+/// <param name="ErrorMessage">
+/// Mensaje legible para el usuario cuando el desenlace no es
+/// <see cref="ConsumeResetTokenOutcome.Success"/>. Null en caso de exito.
+/// </param>
+public record ConsumeResetTokenResult(ConsumeResetTokenOutcome Outcome, string? ErrorMessage = null);

--- a/src/ExtraGasMVC/Services/Implementations/UsuarioService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/UsuarioService.cs
@@ -1,9 +1,13 @@
+using System.Data.Common;
+using System.Security.Cryptography;
+using System.Text;
 using AutoMapper;
 using ExtraGasMVC.Configuration;
 using ExtraGasMVC.Data.Context;
 using ExtraGasMVC.Data.Entities;
 using ExtraGasMVC.DTOs;
 using ExtraGasMVC.Services.Interfaces;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
@@ -11,18 +15,83 @@ namespace ExtraGasMVC.Services.Implementations;
 
 public class UsuarioService : IUsuarioService
 {
+    /// <summary>Vigencia del token de reset, en horas.</summary>
+    private const int TokenLifetimeHours = 1;
+
+    /// <summary>Costo BCrypt usado al setear la contrasena desde el flujo de reset.</summary>
+    private const int ResetPasswordWorkFactor = 11;
+
+    /// <summary>Mensaje generico: nunca expone detalle interno al usuario final.</summary>
+    private const string GenericErrorMessage = "No se pudo procesar la solicitud. Intente nuevamente.";
+
     private readonly ExtraGasDbContext _context;
     private readonly IMapper _mapper;
     private readonly AuthLockoutOptions _lockout;
+    private readonly IPasswordPolicyService _passwordPolicy;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly EmailOptions _emailOptions;
+    private readonly ILogger<UsuarioService> _logger;
 
     public UsuarioService(
         ExtraGasDbContext context,
         IMapper mapper,
-        IOptions<AuthLockoutOptions> lockout)
+        IOptions<AuthLockoutOptions> lockout,
+        IPasswordPolicyService passwordPolicy,
+        IServiceScopeFactory scopeFactory,
+        IOptions<EmailOptions> emailOptions,
+        ILogger<UsuarioService> logger)
     {
         _context = context;
         _mapper = mapper;
         _lockout = lockout.Value;
+        _passwordPolicy = passwordPolicy;
+        _scopeFactory = scopeFactory;
+        _emailOptions = emailOptions.Value;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Genera un token raw criptograficamente seguro (32 bytes) en base64url,
+    /// 43 caracteres sin padding. El raw solo viaja por email: nunca se persiste.
+    /// </summary>
+    private static string GenerateRawToken()
+    {
+        var raw = RandomNumberGenerator.GetBytes(32);
+        return Base64UrlTextEncoder.Encode(raw);
+    }
+
+    /// <summary>
+    /// Calcula el SHA-256 hex (minusculas, 64 chars) del token raw.
+    /// Es lo unico que se guarda en <c>password_reset_tokens.token_hash</c>.
+    /// </summary>
+    private static string HashToken(string rawToken)
+    {
+        Span<byte> hash = stackalloc byte[32];
+        SHA256.HashData(Encoding.UTF8.GetBytes(rawToken), hash);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Despacha un email sin bloquear la request. SMTP puede tardar segundos y
+    /// un fallo de transporte no debe afectar la respuesta HTTP.
+    /// Resuelve un <see cref="IEmailSender"/> desde un scope nuevo porque el scope
+    /// de la request ya puede estar dispuesto cuando corre esta tarea.
+    /// </summary>
+    private void SendEmailFireAndForget(string to, string subject, string body)
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                using var scope = _scopeFactory.CreateScope();
+                var sender = scope.ServiceProvider.GetRequiredService<IEmailSender>();
+                await sender.SendAsync(to, subject, body, ct: CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Fallo el envio del email '{Subject}' a {Recipient}", subject, to);
+            }
+        });
     }
 
     public async Task<UsuarioDto?> GetByIdAsync(ulong id, CancellationToken ct = default)
@@ -291,6 +360,151 @@ public class UsuarioService : IUsuarioService
         await _context.SaveChangesAsync(ct);
 
         return temporaryPassword;
+    }
+
+    public async Task RequestPasswordResetAsync(string email, string? ipAddress, string? userAgent, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+            return;
+
+        var normalizedEmail = email.Trim();
+
+        var usuario = await _context.Usuarios
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(u => u.Email == normalizedEmail && u.Activo && u.DeletedAt == null, ct);
+
+        // Anti-enumeracion: email desconocido, usuario inactivo/borrado o sin
+        // email cargado => salimos en silencio, sin escribir ni enviar nada.
+        if (usuario is null || string.IsNullOrWhiteSpace(usuario.Email))
+            return;
+
+        var rawToken = GenerateRawToken();
+        var now = DateTime.UtcNow;
+
+        var token = new PasswordResetToken
+        {
+            UsuarioId = usuario.Id,
+            TokenHash = HashToken(rawToken),
+            IpAddress = ipAddress,
+            UserAgent = userAgent,
+            ExpiresAt = now.AddHours(TokenLifetimeHours),
+            CreatedAt = now,
+            UpdatedAt = now,
+            CreatedBy = null,
+            UpdatedBy = null
+        };
+
+        try
+        {
+            _context.PasswordResetTokens.Add(token);
+            await _context.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException ex)
+        {
+            // Incluye la colision de uk_token_hash (practicamente imposible en 2^256).
+            _logger.LogError(ex, "No se pudo persistir el token de reset del usuario {UsuarioId}", usuario.Id);
+            return;
+        }
+
+        var resetUrl = $"{_emailOptions.BaseUrl.TrimEnd('/')}/Account/ResetPassword?token={rawToken}";
+
+        SendEmailFireAndForget(
+            usuario.Email,
+            EmailTemplates.ResetLinkSubject,
+            EmailTemplates.ResetLink(usuario.Username, resetUrl));
+    }
+
+    public async Task<ConsumeResetTokenResult> ConsumePasswordResetTokenAsync(string rawToken, string newPassword, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(rawToken))
+            return new ConsumeResetTokenResult(ConsumeResetTokenOutcome.InvalidToken, "Enlace inválido.");
+
+        var policy = _passwordPolicy.Validate(newPassword);
+        if (!policy.IsValid)
+            return new ConsumeResetTokenResult(ConsumeResetTokenOutcome.WeakPassword, string.Join(" ", policy.Errors));
+
+        var tokenHash = HashToken(rawToken);
+        var now = DateTime.UtcNow;
+
+        try
+        {
+            // Uso unico: el gate es el rows-affected del UPDATE atomico, no un SELECT
+            // previo. InnoDB serializa los intentos concurrentes via uk_token_hash.
+            var rowsAffected = await _context.PasswordResetTokens
+                .IgnoreQueryFilters()
+                .Where(rt => rt.TokenHash == tokenHash
+                          && rt.UsedAt == null
+                          && rt.ExpiresAt > now
+                          && rt.DeletedAt == null)
+                .ExecuteUpdateAsync(
+                    s => s
+                        .SetProperty(rt => rt.UsedAt, (DateTime?)now)
+                        .SetProperty(rt => rt.UpdatedAt, now),
+                    ct);
+
+            if (rowsAffected == 0)
+                return await DiagnoseFailedConsumeAsync(tokenHash, now, ct);
+
+            var usuarioId = await _context.PasswordResetTokens
+                .AsNoTracking()
+                .IgnoreQueryFilters()
+                .Where(rt => rt.TokenHash == tokenHash)
+                .Select(rt => rt.UsuarioId)
+                .FirstOrDefaultAsync(ct);
+
+            var usuario = await _context.Usuarios
+                .IgnoreQueryFilters()
+                .FirstOrDefaultAsync(u => u.Id == usuarioId, ct);
+
+            if (usuario is null)
+            {
+                _logger.LogError("Token de reset consumido pero el usuario {UsuarioId} no existe.", usuarioId);
+                return new ConsumeResetTokenResult(ConsumeResetTokenOutcome.UnknownError, GenericErrorMessage);
+            }
+
+            usuario.PasswordHash = BCrypt.Net.BCrypt.HashPassword(newPassword, workFactor: ResetPasswordWorkFactor);
+            usuario.DebeCambiarPassword = false;
+            usuario.UpdatedAt = now;
+            await _context.SaveChangesAsync(ct);
+
+            if (!string.IsNullOrWhiteSpace(usuario.Email))
+            {
+                SendEmailFireAndForget(
+                    usuario.Email,
+                    EmailTemplates.PasswordChangedSubject,
+                    EmailTemplates.PasswordChanged(usuario.Username));
+            }
+
+            return new ConsumeResetTokenResult(ConsumeResetTokenOutcome.Success);
+        }
+        catch (Exception ex) when (ex is DbUpdateException or DbException)
+        {
+            _logger.LogError(ex, "Error de base de datos al consumir un token de reset.");
+            return new ConsumeResetTokenResult(ConsumeResetTokenOutcome.UnknownError, GenericErrorMessage);
+        }
+    }
+
+    /// <summary>
+    /// Distingue por que el UPDATE atomico no afecto filas: token inexistente,
+    /// ya consumido o vencido. Solo corre en el camino de error.
+    /// </summary>
+    private async Task<ConsumeResetTokenResult> DiagnoseFailedConsumeAsync(string tokenHash, DateTime now, CancellationToken ct)
+    {
+        var token = await _context.PasswordResetTokens
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(rt => rt.TokenHash == tokenHash, ct);
+
+        if (token is null)
+            return new ConsumeResetTokenResult(ConsumeResetTokenOutcome.InvalidToken, "Enlace inválido.");
+
+        if (token.UsedAt is not null)
+            return new ConsumeResetTokenResult(ConsumeResetTokenOutcome.AlreadyUsed, "Este enlace ya fue utilizado.");
+
+        if (token.ExpiresAt <= now)
+            return new ConsumeResetTokenResult(ConsumeResetTokenOutcome.ExpiredToken, "El enlace ha expirado. Solicitá uno nuevo.");
+
+        return new ConsumeResetTokenResult(ConsumeResetTokenOutcome.UnknownError, GenericErrorMessage);
     }
 
     private async Task EnrichDtoAsync(UsuarioDto dto, Usuario usuario, CancellationToken ct)

--- a/src/ExtraGasMVC/Services/Implementations/UsuarioService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/UsuarioService.cs
@@ -89,7 +89,7 @@ public class UsuarioService : IUsuarioService
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Fallo el envio del email '{Subject}' a {Recipient}", subject, to);
+                _logger.LogError(ex, "Fallo el envio del email a {Recipient}", to);
             }
         });
     }

--- a/src/ExtraGasMVC/Services/Interfaces/IUsuarioService.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IUsuarioService.cs
@@ -1,4 +1,5 @@
 using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Services;
 
 namespace ExtraGasMVC.Services.Interfaces;
 
@@ -30,4 +31,21 @@ public interface IUsuarioService
     Task<string> ResetPasswordAsync(ulong id, ulong? updatedBy, CancellationToken ct = default);
 
     Task<LoginResult> ValidateAndLoadForAuthAsync(string username, string password, CancellationToken ct = default);
+
+    /// <summary>
+    /// Solicita un reset de contrasena para el usuario con el email indicado.
+    /// Emite un token de un solo uso con vigencia limitada, persiste su hash
+    /// SHA-256 y envia el token raw por email. Si el email no esta registrado
+    /// (o el usuario esta inactivo) retorna en silencio, sin enviar email, para
+    /// no permitir enumeracion de cuentas. ipAddress/userAgent son de auditoria.
+    /// </summary>
+    Task RequestPasswordResetAsync(string email, string? ipAddress, string? userAgent, CancellationToken ct = default);
+
+    /// <summary>
+    /// Valida un token de reset raw, lo marca como consumido si es valido y
+    /// actualiza el hash BCrypt de la contrasena del usuario.
+    /// Ante exito envia un email de notificacion de cambio.
+    /// </summary>
+    /// <returns>Un <see cref="ConsumeResetTokenResult"/> que describe el desenlace.</returns>
+    Task<ConsumeResetTokenResult> ConsumePasswordResetTokenAsync(string rawToken, string newPassword, CancellationToken ct = default);
 }

--- a/tests/ExtraGasMVC.Tests/ChangePasswordTempDataFlowTests.cs
+++ b/tests/ExtraGasMVC.Tests/ChangePasswordTempDataFlowTests.cs
@@ -94,6 +94,8 @@ public class ChangePasswordTempDataFlowTests
         public Task ChangePasswordWithoutCurrentAsync(ulong id, string n, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<string> ResetPasswordAsync(ulong id, ulong? u, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<LoginResult> ValidateAndLoadForAuthAsync(string u, string p, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task RequestPasswordResetAsync(string e, string? ip, string? ua, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<ConsumeResetTokenResult> ConsumePasswordResetTokenAsync(string t, string p, CancellationToken ct = default) => throw new NotImplementedException();
     }
 
     private class FakePasswordPolicyService : IPasswordPolicyService


### PR DESCRIPTION
PR 3 of 4 in the `password-recovery` chain (stacked on `develop`, which already contains PR1 #93 and PR2 #94).

## Tasks

- **T4** — `ConsumeResetTokenResult` + `ConsumeResetTokenOutcome` enum, and the two new `IUsuarioService` signatures.
- **T7** — `UsuarioService` implementation of both methods.
- **T8** — `ForgotPasswordDto` + `ResetPasswordDto`.

## What it does

`RequestPasswordResetAsync`
- Looks up the user by email (`IgnoreQueryFilters` + `Activo` + `DeletedAt == null`).
- Unknown / inactive / soft-deleted / no email loaded → **silent return**, no row written, no email sent (anti-enumeration).
- Generates a 32-byte CSPRNG token, base64url-encoded (43 chars, URL-safe, no padding). The raw token travels **only** by email.
- Persists only the SHA-256 hex of the token, with `expires_at = UtcNow + 1h` and null audit columns (anonymous requester).
- Dispatches the reset link fire-and-forget so SMTP latency never blocks the HTTP response.

`ConsumePasswordResetTokenAsync`
- Validates the new password against `IPasswordPolicyService` **first** → `WeakPassword` carrying the concrete policy errors.
- Single-use is enforced by an **atomic** `ExecuteUpdateAsync` (`token_hash = ? AND used_at IS NULL AND expires_at > now`); rows-affected is the success gate, so two concurrent tabs are serialized by InnoDB via `uk_token_hash`.
- On success: BCrypt rehash, `debe_cambiar_password = false`, then a fire-and-forget "password changed" notification.
- On `rowsAffected == 0` it diagnoses the cause and returns `InvalidToken` / `AlreadyUsed` / `ExpiredToken`.
- DB failures are logged and surface as `UnknownError` with a generic message — no internal detail reaches the user.

## Spec scenarios covered

| Scenario | Covered here |
|---|---|
| `password-reset-email` › Request reset for registered email | token row + reset email |
| `password-reset-email` › Request reset for unregistered email | silent no-op path |
| `password-reset-email` › Reset token never stored in plaintext | only SHA-256 hex persisted |
| `password-reset-confirm` › Successful password reset | `Success` + BCrypt rehash |
| `password-reset-confirm` › Reject expired token | `ExpiredToken` |
| `password-reset-confirm` › Reject already-used token | `AlreadyUsed` |
| `password-reset-confirm` › Reject unknown token | `InvalidToken` |

Rate limiting, the generic user-facing messaging and the GET/POST endpoints land in PR4.

## Verification

- `dotnet build src/ExtraGasMVC` → **0 errors**, no new warnings.
- `dotnet build ExtraGasMVC.sln` → **0 errors** (see note below).
- `dotnet test ExtraGasMVC.sln` → **33 passed, 0 failed**.

## Reviewer notes

1. **`Usuario` has no `Nombre` property**, so the email greeting uses `Username`. Worth a follow-up if a real display name is wanted.
2. **Test fake updated**: `FakeUsuarioService` implements `IUsuarioService`, so adding two interface members broke the *solution* build even though `dotnet build src/ExtraGasMVC` stayed green. Two `NotImplementedException` stubs restore it.
3. **BCrypt work factor 11** on this path, vs the library default (10) used elsewhere. The cost is embedded in the hash, so `Verify` is unaffected and existing hashes keep working.
4. **Lockout is intentionally not cleared** on reset — kept strictly to design §Services step 4. Flagging it because a locked-out user who resets their password still waits out `BloqueadoHasta`; worth confirming during PR4 smoke.
5. `IEmailSender` is resolved from a fresh DI scope inside the fire-and-forget task rather than injected into the service, because the request scope may already be disposed when the task runs.

## Next

PR4 adds the `AccountController` actions and the two Razor views that call these methods end-to-end, plus the migration apply and the manual smoke flow.