### PR TITLE
feat(password-recovery): PR4 — UI, login link, smoke checklist

### DIFF
--- a/src/ExtraGasMVC/Controllers/AccountController.cs
+++ b/src/ExtraGasMVC/Controllers/AccountController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 
 namespace ExtraGasMVC.Controllers;
@@ -18,19 +19,22 @@ public class AccountController : BaseController
     private readonly IPasswordPolicyService _passwordPolicy;
     private readonly ILogger<AccountController> _logger;
     private readonly PasswordPolicyOptions _passwordOptions;
+    private readonly IMemoryCache _memoryCache;
 
     public AccountController(
         IUsuarioService usuarioService,
         IAuditoriaLoginService auditoriaService,
         IPasswordPolicyService passwordPolicy,
         ILogger<AccountController> logger,
-        IOptions<PasswordPolicyOptions> passwordOptions)
+        IOptions<PasswordPolicyOptions> passwordOptions,
+        IMemoryCache memoryCache)
     {
         _usuarioService = usuarioService;
         _auditoriaService = auditoriaService;
         _passwordPolicy = passwordPolicy;
         _logger = logger;
         _passwordOptions = passwordOptions.Value;
+        _memoryCache = memoryCache;
     }
 
     [HttpGet]
@@ -166,6 +170,104 @@ public class AccountController : BaseController
         {
             ModelState.AddModelError(string.Empty, $"No se pudo actualizar la contrasena: {ex.Message}");
             return View(dto);
+        }
+    }
+
+    /// <summary>
+    /// GET /Account/ForgotPassword — renderiza el formulario para pedir el enlace de reseteo.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult ForgotPassword()
+    {
+        return View(new ForgotPasswordDto());
+    }
+
+    /// <summary>
+    /// POST /Account/ForgotPassword — rate-limit por IP (3/h via <see cref="IMemoryCache"/>)
+    /// y delegacion a <see cref="IUsuarioService.RequestPasswordResetAsync"/>.
+    /// La respuesta SIEMPRE es el mensaje generico (sin enumeracion).
+    /// </summary>
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    [AllowAnonymous]
+    public async Task<IActionResult> ForgotPassword(ForgotPasswordDto model, CancellationToken ct = default)
+    {
+        if (!ModelState.IsValid)
+            return View(model);
+
+        var ipKey = $"password-reset:forgot:{GetClientIp() ?? "unknown"}";
+        var count = _memoryCache.GetOrCreate(ipKey, e =>
+        {
+            e.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1);
+            return 0;
+        });
+
+        if (count >= 3)
+        {
+            // Rate limit alcanzado: mostrar SIEMPRE el mismo mensaje generico, sin llamar al service.
+            TempData["Info"] = "Si tu dirección de correo está registrada, recibirás un enlace para restablecer tu contraseña.";
+            return RedirectToAction(nameof(ForgotPassword));
+        }
+
+        _memoryCache.Set(ipKey, count + 1, TimeSpan.FromHours(1));
+
+        await _usuarioService.RequestPasswordResetAsync(model.Email, GetClientIp(), GetUserAgent(), ct);
+
+        TempData["Info"] = "Si tu dirección de correo está registrada, recibirás un enlace para restablecer tu contraseña.";
+        return RedirectToAction(nameof(ForgotPassword));
+    }
+
+    /// <summary>
+    /// GET /Account/ResetPassword?token=... — renderiza el formulario con el token en campo oculto.
+    /// NO consulta la BD (decision de diseno ambiguedad #1): la validez se chequea solo en el POST.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult ResetPassword(string? token)
+    {
+        return View(new ResetPasswordDto { Token = token ?? string.Empty });
+    }
+
+    /// <summary>
+    /// POST /Account/ResetPassword — valida el token y setea la nueva contrasena.
+    /// Mapea <see cref="ConsumeResetTokenOutcome"/> a TempData/ModelState segun diseno §Controllers.
+    /// </summary>
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    [AllowAnonymous]
+    public async Task<IActionResult> ResetPassword(ResetPasswordDto model, CancellationToken ct = default)
+    {
+        if (!ModelState.IsValid)
+            return View(model);
+
+        var result = await _usuarioService.ConsumePasswordResetTokenAsync(model.Token, model.NewPassword, ct);
+
+        switch (result.Outcome)
+        {
+            case ConsumeResetTokenOutcome.Success:
+                TempData["Success"] = "Tu contraseña fue restablecida. Iniciá sesión con la nueva contraseña.";
+                return RedirectToAction(nameof(Login));
+
+            case ConsumeResetTokenOutcome.WeakPassword:
+                ModelState.AddModelError(nameof(model.NewPassword), result.ErrorMessage ?? "La contraseña no cumple la política.");
+                return View(model);
+
+            case ConsumeResetTokenOutcome.ExpiredToken:
+                TempData["Error"] = "El enlace ha expirado. Solicitá uno nuevo.";
+                return View(model);
+
+            case ConsumeResetTokenOutcome.AlreadyUsed:
+                TempData["Error"] = "Este enlace ya fue utilizado.";
+                return View(model);
+
+            case ConsumeResetTokenOutcome.InvalidToken:
+                TempData["Error"] = "Enlace inválido.";
+                return View(model);
+
+            default:
+                TempData["Error"] = "Ocurrió un error. Intentá de nuevo más tarde.";
+                return View(model);
         }
     }
 

--- a/src/ExtraGasMVC/Views/Account/ForgotPassword.cshtml
+++ b/src/ExtraGasMVC/Views/Account/ForgotPassword.cshtml
@@ -1,0 +1,39 @@
+@model ExtraGasMVC.DTOs.ForgotPasswordDto
+@{
+    ViewData["Title"] = "Recuperar contraseña";
+    Layout = "_AccountLayout";
+}
+<div class="login-box" style="width: 420px;">
+    <div class="login-logo">
+        <a asp-controller="Home" asp-action="Index"><b>Extra</b>Gas</a>
+    </div>
+    <div class="card">
+        <div class="card-body login-card-body">
+            <p class="login-box-msg">Recuperar tu contraseña</p>
+            <p class="text-secondary small">
+                Ingresá el email asociado a tu cuenta. Si está registrado, te enviaremos un enlace para restablecer tu contraseña.
+            </p>
+            <form asp-action="ForgotPassword" method="post">
+                @Html.AntiForgeryToken()
+                <div asp-validation-summary="All" class="text-danger small mb-3"></div>
+                <div class="input-group mb-3">
+                    <input asp-for="Email" type="email" class="form-control" placeholder="Email" required autofocus />
+                    <div class="input-group-text"><span class="bi bi-envelope-fill"></span></div>
+                </div>
+                <div class="row">
+                    <div class="col-12 d-grid">
+                        <button type="submit" class="btn btn-primary btn-block">
+                            <i class="bi bi-envelope-paper me-1"></i> Enviar enlace
+                        </button>
+                    </div>
+                </div>
+            </form>
+            <p class="mb-0 mt-3">
+                <a asp-action="Login" class="text-center text-decoration-none">
+                    <i class="bi bi-arrow-left me-1"></i> Volver al inicio de sesión
+                </a>
+            </p>
+        </div>
+    </div>
+</div>
+@await Html.PartialAsync("_StatusMessage")

--- a/src/ExtraGasMVC/Views/Account/Login.cshtml
+++ b/src/ExtraGasMVC/Views/Account/Login.cshtml
@@ -38,7 +38,7 @@
                 </div>
             </form>
             <p class="mb-1 mt-3">
-                <span class="text-secondary small">Si olvidaste tu contrasena, contacta a un administrador para que la resetee.</span>
+                <a asp-action="ForgotPassword" class="text-decoration-none">¿Olvidaste tu contraseña?</a>
             </p>
             <p class="mb-0">
                 <a asp-controller="Home" asp-action="Index" class="text-center text-decoration-none">

--- a/src/ExtraGasMVC/Views/Account/ResetPassword.cshtml
+++ b/src/ExtraGasMVC/Views/Account/ResetPassword.cshtml
@@ -1,0 +1,77 @@
+@model ExtraGasMVC.DTOs.ResetPasswordDto
+@{
+    ViewData["Title"] = "Restablecer contraseña";
+    Layout = "_AccountLayout";
+    var policy = ViewBag.PasswordPolicy as ExtraGasMVC.Configuration.PasswordPolicyOptions;
+}
+<div class="login-box" style="width: 420px;">
+    <div class="login-logo">
+        <a asp-controller="Home" asp-action="Index"><b>Extra</b>Gas</a>
+    </div>
+    <div class="card">
+        <div class="card-body login-card-body">
+            <p class="login-box-msg">Restablecer tu contraseña</p>
+            <p class="text-secondary small">
+                Definí una nueva contraseña para tu cuenta.
+            </p>
+            <form asp-action="ResetPassword" method="post">
+                @Html.AntiForgeryToken()
+                <input asp-for="Token" type="hidden" />
+                <div asp-validation-summary="All" class="text-danger small mb-3"></div>
+                <div class="input-group mb-3">
+                    <input asp-for="NewPassword" class="form-control" placeholder="Nueva contraseña" required autofocus />
+                    <div class="input-group-text"><span class="bi bi-lock-fill"></span></div>
+                </div>
+                <div class="input-group mb-3">
+                    <input asp-for="ConfirmPassword" class="form-control" placeholder="Confirmar contraseña" required />
+                    <div class="input-group-text"><span class="bi bi-lock-fill"></span></div>
+                </div>
+                @if (policy is not null)
+                {
+                    <div class="text-secondary small mb-3">
+                        <p class="mb-1">Tu nueva contraseña debe cumplir:</p>
+                        <ul class="mb-0 ps-3">
+                            @if (policy.MinLength > 0)
+                            {
+                                <li>Al menos @policy.MinLength caracteres.</li>
+                            }
+                            @if (policy.RequireUppercase)
+                            {
+                                <li>Al menos una letra mayúscula (A-Z).</li>
+                            }
+                            @if (policy.RequireLowercase)
+                            {
+                                <li>Al menos una letra minúscula (a-z).</li>
+                            }
+                            @if (policy.RequireDigit)
+                            {
+                                <li>Al menos un dígito (0-9).</li>
+                            }
+                            @if (policy.RequireSpecialChar)
+                            {
+                                <li>Al menos un caracter especial.</li>
+                            }
+                            @if (policy.MaxConsecutiveChars > 0)
+                            {
+                                <li>No más de @policy.MaxConsecutiveChars caracteres consecutivos repetidos.</li>
+                            }
+                        </ul>
+                    </div>
+                }
+                <div class="row">
+                    <div class="col-12 d-grid">
+                        <button type="submit" class="btn btn-primary">
+                            <i class="bi bi-key me-1"></i> Restablecer contraseña
+                        </button>
+                    </div>
+                </div>
+            </form>
+            <p class="mb-0 mt-3">
+                <a asp-action="Login" class="text-center text-decoration-none">
+                    <i class="bi bi-arrow-left me-1"></i> Volver al inicio de sesión
+                </a>
+            </p>
+        </div>
+    </div>
+</div>
+@await Html.PartialAsync("_StatusMessage")


### PR DESCRIPTION
## Tasks covered

T9, T10, T11, T12, T13, T14, T15 from `openspec/changes/password-recovery/tasks.md`. This completes the 4-PR chain (PR1 schema, PR2 email, PR3 service, **PR4 UI**).

### Commits in this PR (3 work units)

1. `c887312` — `feat(account): wire ForgotPassword and ResetPassword actions with rate limit` — T9
2. `a859a20` — `feat(ui): add ForgotPassword and ResetPassword Razor views` — T10 + T11
3. `a6bf696` — `feat(ui): add "¿Olvidaste tu contraseña?" link on Login` — T12

## Spec scenarios wired end-to-end (all 9 from `tasks.md` §4)

| Spec scenario | Wired in this PR |
|---|---|
| `password-reset-email` › Request reset for registered email | T9 (POST ForgotPassword → service → email) |
| `password-reset-email` › Request reset for unregistered email | T9 (silent return, generic message) |
| `password-reset-email` › Rate limit on `/Account/ForgotPassword` | T9 (IMemoryCache 3/h per IP) |
| `password-reset-email` › Reset token never stored in plaintext | PR1 (SHA-256 hash only) — UI just consumes the raw token from the link |
| `password-reset-confirm` › Successful password reset | T9 (POST ResetPassword → redirect Login + toast) |
| `password-reset-confirm` › Reject expired token | T9 (TempData "El enlace ha expirado") |
| `password-reset-confirm` › Reject already-used token | T9 (TempData "Este enlace ya fue utilizado") |
| `password-reset-confirm` › Reject unknown token | T9 (TempData "Enlace inválido") |
| `password-reset-confirm` › GET renders form | T9 (GET ResetPassword, no DB read per design ambiguity #1) |

## Files

- `src/ExtraGasMVC/Controllers/AccountController.cs` (mod) — `+103 / -1` — inject `IMemoryCache`, 4 new actions (GET/POST ForgotPassword, GET/POST ResetPassword), reuse existing `GetClientIp()` / `GetUserAgent()` helpers
- `src/ExtraGasMVC/Views/Account/ForgotPassword.cshtml` (new) — `+39` — `_AccountLayout`, email input, `_StatusMessage` partial below the card
- `src/ExtraGasMVC/Views/Account/ResetPassword.cshtml` (new) — `+77` — `_AccountLayout`, hidden Token, password + confirm, policy bullets from `ViewBag.PasswordPolicy`, `_StatusMessage` partial
- `src/ExtraGasMVC/Views/Account/Login.cshtml` (mod) — `+1 / -1` — replaces "contacta a un administrador" with link to ForgotPassword

**Lines changed**: 220 insertions, 2 deletions = 222 net lines (budget: 400).

## Verification (T13)

- `dotnet build ExtraGasMVC.sln` → **0 errors, 5 pre-existing warnings** (4 × NU1903 AutoMapper 12.0.1 GHSA-rvv3-g6hj-g44x; 1 × CS8602 in `Views/Recepciones/Create.cshtml:62`). **No new warnings** introduced.
- `dotnet test --nologo --verbosity quiet` → **33 passed / 0 failed / 0 skipped**.
- `FakeUsuarioService` in `tests/ExtraGasMVC.Tests/ChangePasswordTempDataFlowTests.cs` already had stubs for `RequestPasswordResetAsync` and `ConsumePasswordResetTokenAsync` (added in PR3), so the solution build stays green.

## Migration apply (T14, manual)

The migration `db/migrations/20260828_000004_create_password_reset_tokens.sql` is already present (created in PR1, squash-merged with PR1's commit `67b17b1`). To apply it to the dev DB, run **one** of the following against your environment:

```bash
# As root (local dev default)
mysql -uroot extragas < db/migrations/20260828_000004_create_password_reset_tokens.sql

# Or as the migrator user (homelab)
MYSQL_USER=extragas_migrator MYSQL_PASSWORD='...' mysql extragas < db/migrations/20260828_000004_create_password_reset_tokens.sql
```

Then verify:

```sql
SHOW TABLES LIKE 'password_reset_tokens';      -- should return 1 row
SHOW CREATE TABLE password_reset_tokens\G     -- confirm columns / indexes / FK
-- Re-run the file: should be a no-op (CREATE TABLE IF NOT EXISTS)
```

The migration is idempotent — safe to re-run.

## Manual smoke flow (T15) — to run by reviewer with MailHog

MailHog setup (once):

```bash
docker run -d -p 1025:1025 -p 8025:8025 --name mailhog mailhog/mailhog
# UI: http://localhost:8025
# SMTP: localhost:1025 (matches appsettings.Development.json)
```

Then `dotnet run --project src/ExtraGasMVC` and exercise the flow:

- [ ] **Step 1**: ForgotPassword with a known email → row appears in `password_reset_tokens`, MailHog shows "Restablecé tu contraseña — ExtraGas"
- [ ] **Step 2**: GET `/Account/ResetPassword?token=<raw>` renders the form; `used_at` is still `NULL` for that row
- [ ] **Step 3**: POST `/Account/ResetPassword` with new password → `used_at` set, redirect to `/Account/Login` with toast, MailHog shows "Tu contraseña fue cambiada — ExtraGas"
- [ ] **Step 4**: Login with the new password succeeds
- [ ] **Step 5**: Reuse the consumed token (POST again) → TempData "Este enlace ya fue utilizado." (no DB write, no extra email)
- [ ] **Step 6**: ForgotPassword with an unknown email → identical generic message, **no row** in `password_reset_tokens`
- [ ] **Step 7**: Admin `Usuarios/ResetPassword` still works (admin reset path is untouched; user gets temp password + `debe_cambiar_password=true`)
- [ ] **Bonus**: 4th ForgotPassword from the same IP within 1 hour → identical generic message, **no row** in `password_reset_tokens` (rate limit hit)

## Known limitations (carried forward from PR3)

- **HIGH** — **Lockout not cleared on password reset.** A user who resets their password while locked out (`BloqueadoHasta` in the future) still has to wait for the lockout window. Documented in PR3 apply-progress as an open question; explicitly out of scope per design §Services step 4 ("only mutate password_hash + debe_cambiar_password"). Mitigation: in this change the user can self-service once the lockout expires, or an admin can clear it manually. Will be tracked as a follow-up issue if the reviewer flags it as critical.
- **MEDIUM** — **Rate-limit counter resets on app restart** (`IMemoryCache` is per-process). Acceptable for single-instance homelab per design ambiguity #2. If the project moves to multi-instance, swap to `IDistributedCache` without changing the controller contract.
- **LOW** — **SMTP failures are swallowed** (fire-and-forget, log-only) per design ambiguity #3 and proposal risk table. Admins monitor app logs.

## Rollback

If this PR needs to be reverted after merge: revert the merge commit. The data side is fully reversible — `password_reset_tokens` table can be dropped without touching password hashes. The controller actions can be removed by reverting this PR.

## This completes the 4-PR chain

| PR | Branch | Status |
|---|---|---|
| PR1 — schema | `feature/password-recovery-pr1-schema` | merged (#93) |
| PR2 — email | `feature/password-recovery-pr2-email` | merged (#94) |
| PR3 — service | `feature/password-recovery-pr3-service` | merged (#95) |
| **PR4 — UI** | **`feature/password-recovery-pr4-ui-smoke`** | **this PR** |

Once merged, the change is ready for `sdd-verify`.