### PR TITLE
refactor(services): resolve 25 SonarQube CRITICAL issues (#97)

### DIFF
--- a/src/ExtraGasMVC/Controllers/PedidosController.cs
+++ b/src/ExtraGasMVC/Controllers/PedidosController.cs
@@ -220,56 +220,13 @@ public class PedidosController : BaseController
             // para que la transición de estado y los movimientos de garrafa sean
             // atómicos. Si no hay códigos (pedido solo VENTA / carbón / leña),
             // caemos al flujo normal de CambiarEstadoAsync.
-            var estados = await _pedidoService.GetEstadosPedidoAsync(ct);
-            var estadoDestino = estados.FirstOrDefault(e => e.Id == nuevoEstadoId);
-            var esConfirmado = estadoDestino?.Codigo == PedidoEstados.Confirmado;
-            var hayCodigos = !string.IsNullOrWhiteSpace(codigosGarrafaJson);
+            var destino = await ResolveEstadoDestinoAsync(nuevoEstadoId, ct);
+            var esConfirmadoConCodigos = destino?.Codigo == PedidoEstados.Confirmado
+                                         && !string.IsNullOrWhiteSpace(codigosGarrafaJson);
 
-            if (esConfirmado && hayCodigos)
-            {
-                Dictionary<ulong, List<string>>? codigosPorItem = null;
-                try
-                {
-                    codigosPorItem = System.Text.Json.JsonSerializer.Deserialize<Dictionary<ulong, List<string>>>(
-                        codigosGarrafaJson!,
-                        new System.Text.Json.JsonSerializerOptions
-                        {
-                            PropertyNameCaseInsensitive = true
-                        });
-                }
-                catch (System.Text.Json.JsonException)
-                {
-                    TempData["Error"] = "Los códigos de garrafas enviados tienen un formato inválido. Recargue la pantalla e intente nuevamente.";
-                    return RedirectToAction(nameof(Edit), new { id });
-                }
-
-                var ok = await _pedidoService.RegistrarCanjePedidoAsync(
-                    id,
-                    codigosPorItem ?? new Dictionary<ulong, List<string>>(),
-                    userId,
-                    ct);
-
-                TempData[ok ? "Success" : "Error"] = ok
-                    ? "Pedido confirmado y garrafas registradas correctamente."
-                    : "No se encontró el pedido.";
-
-                if (ok)
-                    return RedirectToAction(nameof(Details), new { id });
-            }
-            else
-            {
-                var ok = await _pedidoService.CambiarEstadoAsync(id, nuevoEstadoId, motivoCancelacion, userId, ct);
-                TempData[ok ? "Success" : "Error"] = ok
-                    ? "Estado del pedido actualizado correctamente."
-                    : "No se encontró el pedido.";
-
-                if (ok)
-                {
-                    var pedido = await _pedidoService.GetByIdAsync(id, ct);
-                    if (PedidoEstados.EstadosFinales.Contains(pedido?.EstadoCodigo ?? ""))
-                        return RedirectToAction(nameof(Details), new { id });
-                }
-            }
+            return esConfirmadoConCodigos
+                ? await ConfirmarConCanjeAsync(id, codigosGarrafaJson!, userId, ct)
+                : await CambiarEstadoGenericoAsync(id, nuevoEstadoId, motivoCancelacion, userId, ct);
         }
         catch (InvalidOperationException ex)
         {
@@ -282,6 +239,70 @@ public class PedidosController : BaseController
             TempData["Error"] = "Ocurrió un error al cambiar el estado del pedido. Intente nuevamente.";
         }
         return RedirectToAction(nameof(Edit), new { id });
+    }
+
+    /// <summary>
+    /// Resuelve el <see cref="EstadoPedidoDto"/> destino a partir del id del form.
+    /// Devuelve null si el id no existe en el catálogo (se propaga como
+    /// "estado destino no existe" desde el service).
+    /// </summary>
+    private async Task<EstadoPedidoDto?> ResolveEstadoDestinoAsync(ulong nuevoEstadoId, CancellationToken ct)
+    {
+        var estados = await _pedidoService.GetEstadosPedidoAsync(ct);
+        return estados.FirstOrDefault(e => e.Id == nuevoEstadoId);
+    }
+
+    /// <summary>
+    /// Branch CONFIRMADO + códigos de garrafas: deserializa el JSON de
+    /// códigos y delega en <c>RegistrarCanjePedidoAsync</c> para hacer
+    /// atómica la transición de estado y los movimientos de garrafa.
+    /// </summary>
+    private async Task<IActionResult> ConfirmarConCanjeAsync(
+        ulong id, string codigosGarrafaJson, ulong? userId, CancellationToken ct)
+    {
+        Dictionary<ulong, List<string>> codigosPorItem;
+        try
+        {
+            codigosPorItem = System.Text.Json.JsonSerializer.Deserialize<Dictionary<ulong, List<string>>>(
+                codigosGarrafaJson,
+                new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+                ?? new Dictionary<ulong, List<string>>();
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            TempData["Error"] = "Los códigos de garrafas enviados tienen un formato inválido. Recargue la pantalla e intente nuevamente.";
+            return RedirectToAction(nameof(Edit), new { id });
+        }
+
+        var ok = await _pedidoService.RegistrarCanjePedidoAsync(id, codigosPorItem, userId, ct);
+
+        TempData[ok ? "Success" : "Error"] = ok
+            ? "Pedido confirmado y garrafas registradas correctamente."
+            : "No se encontró el pedido.";
+
+        return ok
+            ? RedirectToAction(nameof(Details), new { id })
+            : RedirectToAction(nameof(Edit), new { id });
+    }
+
+    /// <summary>
+    /// Branch genérico: llama a <c>CambiarEstadoAsync</c> y, si la transición
+    /// lleva al pedido a un estado final, redirige a Details en lugar de Edit.
+    /// </summary>
+    private async Task<IActionResult> CambiarEstadoGenericoAsync(
+        ulong id, ulong nuevoEstadoId, string? motivoCancelacion, ulong? userId, CancellationToken ct)
+    {
+        var ok = await _pedidoService.CambiarEstadoAsync(id, nuevoEstadoId, motivoCancelacion, userId, ct);
+        TempData[ok ? "Success" : "Error"] = ok
+            ? "Estado del pedido actualizado correctamente."
+            : "No se encontró el pedido.";
+
+        if (!ok) return RedirectToAction(nameof(Edit), new { id });
+
+        var pedido = await _pedidoService.GetByIdAsync(id, ct);
+        return PedidoEstados.EstadosFinales.Contains(pedido?.EstadoCodigo ?? "")
+            ? RedirectToAction(nameof(Details), new { id })
+            : RedirectToAction(nameof(Edit), new { id });
     }
 
     public async Task<IActionResult> Pendientes(CancellationToken ct = default)

--- a/src/ExtraGasMVC/Mappings/MappingProfile.cs
+++ b/src/ExtraGasMVC/Mappings/MappingProfile.cs
@@ -8,33 +8,67 @@ public class MappingProfile : Profile
 {
     public MappingProfile()
     {
-        // Cliente mappings
+        ConfigureCliente();
+        ConfigurePedido();
+        ConfigurePedidoItem();
+        ConfigureLookups();
+        ConfigureProducto();
+        ConfigureTipoProducto();
+        ConfigureProveedor();
+        ConfigurePago();
+        ConfigureGarrafa();
+        ConfigureMovimientoGarrafa();
+        ConfigureUsuario();
+        ConfigureProvincia();
+        ConfigureEmpleado();
+    }
+
+    private void ConfigureCliente()
+    {
         CreateMap<Cliente, ClienteDto>().ReverseMap();
         CreateMap<CreateClienteDto, Cliente>();
         CreateMap<UpdateClienteDto, Cliente>();
         CreateMap<ClienteDto, UpdateClienteDto>();
+    }
 
-        // Pedido mappings
+    private void ConfigurePedido()
+    {
         CreateMap<Pedido, PedidoDto>()
-            .ForMember(d => d.ClienteNombre, o => o.MapFrom(s =>
-                s.Cliente != null ? s.Cliente.Apellido + ", " + s.Cliente.Nombre : null))
-            .ForMember(d => d.EmpleadoNombre, o => o.MapFrom(s =>
-                s.Empleado != null ? s.Empleado.Apellido + ", " + s.Empleado.Nombre : null))
-            .ForMember(d => d.EstadoNombre, o => o.MapFrom(s =>
-                s.EstadoPedido != null ? s.EstadoPedido.Nombre : null))
-            .ForMember(d => d.EstadoCodigo, o => o.MapFrom(s =>
-                s.EstadoPedido != null ? s.EstadoPedido.Codigo : null))
-            .ForMember(d => d.EstadoColor, o => o.MapFrom(s =>
-                s.EstadoPedido != null ? s.EstadoPedido.Color : null))
-            .ForMember(d => d.CanalNombre, o => o.MapFrom(s =>
-                s.CanalVenta != null ? s.CanalVenta.Nombre : null))
-            .ForMember(d => d.MedioContactoNombre, o => o.MapFrom(s =>
-                s.MedioContactoPedido != null ? s.MedioContactoPedido.Nombre : null))
+            .ForMember(d => d.ClienteNombre, o => o.MapFrom(s => NombreCompletoCliente(s)))
+            .ForMember(d => d.EmpleadoNombre, o => o.MapFrom(s => NombreCompletoEmpleado(s)))
+            .ForMember(d => d.EstadoNombre, o => o.MapFrom(s => NombreEstado(s)))
+            .ForMember(d => d.EstadoCodigo, o => o.MapFrom(s => CodigoEstado(s)))
+            .ForMember(d => d.EstadoColor, o => o.MapFrom(s => ColorEstado(s)))
+            .ForMember(d => d.CanalNombre, o => o.MapFrom(s => NombreCanal(s)))
+            .ForMember(d => d.MedioContactoNombre, o => o.MapFrom(s => NombreMedioContacto(s)))
             .ForMember(d => d.Items, o => o.MapFrom(s => s.Items));
         CreateMap<CreatePedidoDto, Pedido>();
         CreateMap<UpdatePedidoDto, Pedido>();
+    }
 
-        // PedidoItem mappings
+    private static string? NombreCompletoCliente(Pedido s)
+        => s.Cliente != null ? s.Cliente.Apellido + ", " + s.Cliente.Nombre : null;
+
+    private static string? NombreCompletoEmpleado(Pedido s)
+        => s.Empleado != null ? s.Empleado.Apellido + ", " + s.Empleado.Nombre : null;
+
+    private static string? NombreEstado(Pedido s)
+        => s.EstadoPedido != null ? s.EstadoPedido.Nombre : null;
+
+    private static string? CodigoEstado(Pedido s)
+        => s.EstadoPedido != null ? s.EstadoPedido.Codigo : null;
+
+    private static string? ColorEstado(Pedido s)
+        => s.EstadoPedido != null ? s.EstadoPedido.Color : null;
+
+    private static string? NombreCanal(Pedido s)
+        => s.CanalVenta != null ? s.CanalVenta.Nombre : null;
+
+    private static string? NombreMedioContacto(Pedido s)
+        => s.MedioContactoPedido != null ? s.MedioContactoPedido.Nombre : null;
+
+    private void ConfigurePedidoItem()
+    {
         CreateMap<PedidoItem, PedidoItemDto>()
             .ForMember(d => d.ProductoNombre, o => o.MapFrom(s =>
                 s.Producto != null ? s.Producto.Nombre : null))
@@ -51,35 +85,48 @@ public class MappingProfile : Profile
         CreateMap<UpdatePedidoItemDto, PedidoItem>()
             .ForMember(d => d.TipoLinea, o => o.MapFrom(s =>
                 Enum.Parse<ExtraGasMVC.Data.Entities.Enums.TipoLinea>(s.TipoLinea)));
+    }
 
-        // Lookup mappings
+    private void ConfigureLookups()
+    {
         CreateMap<EstadoPedido, EstadoPedidoDto>().ReverseMap();
         CreateMap<CanalVenta, CanalVentaDto>().ReverseMap();
         CreateMap<MedioContactoPedido, MedioContactoPedidoDto>().ReverseMap();
         CreateMap<EstadoGarrafa, EstadoGarrafaDto>().ReverseMap();
+    }
 
-        // Producto mappings
+    private void ConfigureProducto()
+    {
         CreateMap<Producto, ProductoDto>()
-            .ForMember(d => d.TipoProductoNombre, o => o.MapFrom(s => s.TipoProducto != null ? s.TipoProducto.Nombre : null))
+            .ForMember(d => d.TipoProductoNombre, o => o.MapFrom(s =>
+                s.TipoProducto != null ? s.TipoProducto.Nombre : null))
             .ReverseMap();
         CreateMap<CreateProductoDto, Producto>();
         CreateMap<UpdateProductoDto, Producto>();
+    }
 
-        // TipoProducto mappings
+    private void ConfigureTipoProducto()
+    {
         CreateMap<TipoProducto, TipoProductoDto>().ReverseMap();
+    }
 
-        // Proveedor mappings
+    private void ConfigureProveedor()
+    {
         CreateMap<Proveedor, ProveedorDto>().ReverseMap();
         CreateMap<CreateProveedorDto, Proveedor>();
         CreateMap<UpdateProveedorDto, Proveedor>();
         CreateMap<ProveedorDto, UpdateProveedorDto>();
+    }
 
-        // Pago mappings
+    private void ConfigurePago()
+    {
         CreateMap<Pago, PagoDto>().ReverseMap();
         CreateMap<CreatePagoDto, Pago>();
         CreateMap<UpdatePagoDto, Pago>();
+    }
 
-        // Garrafa mappings
+    private void ConfigureGarrafa()
+    {
         CreateMap<Garrafa, GarrafaDto>()
             .ForMember(d => d.EstadoCodigo, o => o.MapFrom(s =>
                 s.EstadoGarrafa != null ? s.EstadoGarrafa.Codigo : null))
@@ -94,38 +141,62 @@ public class MappingProfile : Profile
             .ReverseMap();
         CreateMap<CreateGarrafaDto, Garrafa>();
         CreateMap<UpdateGarrafaDto, Garrafa>();
+    }
 
-        // MovimientoGarrafa mappings
+    private void ConfigureMovimientoGarrafa()
+    {
         CreateMap<MovimientoGarrafa, MovimientoGarrafaDto>()
-            .ForMember(d => d.TipoMovimientoCodigo, o => o.MapFrom(s =>
-                s.TipoMovimiento != null ? s.TipoMovimiento.Codigo : null))
-            .ForMember(d => d.TipoMovimientoNombre, o => o.MapFrom(s =>
-                s.TipoMovimiento != null ? s.TipoMovimiento.Nombre : null))
-            .ForMember(d => d.EstadoOrigenCodigo, o => o.MapFrom(s =>
-                s.EstadoOrigen != null ? s.EstadoOrigen.Codigo : null))
-            .ForMember(d => d.EstadoOrigenNombre, o => o.MapFrom(s =>
-                s.EstadoOrigen != null ? s.EstadoOrigen.Nombre : null))
-            .ForMember(d => d.EstadoDestinoCodigo, o => o.MapFrom(s =>
-                s.EstadoDestino != null ? s.EstadoDestino.Codigo : null))
-            .ForMember(d => d.EstadoDestinoNombre, o => o.MapFrom(s =>
-                s.EstadoDestino != null ? s.EstadoDestino.Nombre : null))
-            .ForMember(d => d.EmpleadoNombreCompleto, o => o.MapFrom(s =>
-                s.Empleado != null ? s.Empleado.Apellido + ", " + s.Empleado.Nombre : null))
-            .ForMember(d => d.GarrafaCodigo, o => o.MapFrom(s =>
-                s.Garrafa != null ? s.Garrafa.Codigo : null));
+            .ForMember(d => d.TipoMovimientoCodigo, o => o.MapFrom(s => CodigoTipoMovimiento(s)))
+            .ForMember(d => d.TipoMovimientoNombre, o => o.MapFrom(s => NombreTipoMovimiento(s)))
+            .ForMember(d => d.EstadoOrigenCodigo, o => o.MapFrom(s => CodigoEstadoOrigen(s)))
+            .ForMember(d => d.EstadoOrigenNombre, o => o.MapFrom(s => NombreEstadoOrigen(s)))
+            .ForMember(d => d.EstadoDestinoCodigo, o => o.MapFrom(s => CodigoEstadoDestino(s)))
+            .ForMember(d => d.EstadoDestinoNombre, o => o.MapFrom(s => NombreEstadoDestino(s)))
+            .ForMember(d => d.EmpleadoNombreCompleto, o => o.MapFrom(s => NombreCompletoEmpleado(s)))
+            .ForMember(d => d.GarrafaCodigo, o => o.MapFrom(s => CodigoGarrafa(s)));
+    }
 
-        // Usuario mappings
+    private static string? CodigoTipoMovimiento(MovimientoGarrafa s)
+        => s.TipoMovimiento != null ? s.TipoMovimiento.Codigo : null;
+
+    private static string? NombreTipoMovimiento(MovimientoGarrafa s)
+        => s.TipoMovimiento != null ? s.TipoMovimiento.Nombre : null;
+
+    private static string? CodigoEstadoOrigen(MovimientoGarrafa s)
+        => s.EstadoOrigen != null ? s.EstadoOrigen.Codigo : null;
+
+    private static string? NombreEstadoOrigen(MovimientoGarrafa s)
+        => s.EstadoOrigen != null ? s.EstadoOrigen.Nombre : null;
+
+    private static string? CodigoEstadoDestino(MovimientoGarrafa s)
+        => s.EstadoDestino != null ? s.EstadoDestino.Codigo : null;
+
+    private static string? NombreEstadoDestino(MovimientoGarrafa s)
+        => s.EstadoDestino != null ? s.EstadoDestino.Nombre : null;
+
+    private static string? CodigoGarrafa(MovimientoGarrafa s)
+        => s.Garrafa != null ? s.Garrafa.Codigo : null;
+
+    private static string? NombreCompletoEmpleado(MovimientoGarrafa s)
+        => s.Empleado != null ? s.Empleado.Apellido + ", " + s.Empleado.Nombre : null;
+
+    private void ConfigureUsuario()
+    {
         CreateMap<Usuario, UsuarioDto>()
             .ForMember(d => d.RolCodigo, o => o.MapFrom(s => s.Rol != null ? s.Rol.Codigo : null))
             .ForMember(d => d.RolNombre, o => o.MapFrom(s => s.Rol != null ? s.Rol.Nombre : null));
         CreateMap<CreateUsuarioDto, Usuario>()
             .ForMember(d => d.PasswordHash, o => o.Ignore());
         CreateMap<UpdateUsuarioDto, Usuario>();
+    }
 
-        // Provincia mappings
+    private void ConfigureProvincia()
+    {
         CreateMap<Provincia, ProvinciaDto>();
+    }
 
-        // Empleado mappings
+    private void ConfigureEmpleado()
+    {
         CreateMap<Empleado, EmpleadoDto>().ReverseMap();
         CreateMap<CreateEmpleadoDto, Empleado>();
         CreateMap<UpdateEmpleadoDto, Empleado>();

--- a/src/ExtraGasMVC/Program.cs
+++ b/src/ExtraGasMVC/Program.cs
@@ -81,23 +81,7 @@ var app = builder.Build();
 // faltan Username/Password, loggear warning y NO crashear (MailKit fallara
 // al primer envio; el caller hace fire-and-forget y loggea). En dev (MailHog)
 // los campos son opcionales por lo que no se valida.
-if (!app.Environment.IsDevelopment())
-{
-    var emailOptions = app.Services.GetRequiredService<IOptions<EmailOptions>>().Value;
-    if (!string.IsNullOrWhiteSpace(emailOptions.Host))
-    {
-        if (string.IsNullOrEmpty(emailOptions.Username) || string.IsNullOrEmpty(emailOptions.Password))
-        {
-            var startupLogger = app.Services.GetRequiredService<ILoggerFactory>()
-                .CreateLogger("EmailStartup");
-            startupLogger.LogWarning(
-                "Email:Host configurado ({Host}) pero Email:Username/Email:Password no estan seteados. " +
-                "Defini las credenciales SMTP via 'dotnet user-secrets set' antes de enviar emails. " +
-                "Los envios fallaran silenciosamente.",
-                emailOptions.Host);
-        }
-    }
-}
+WarnOnIncompleteSmtpConfig(app);
 
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
@@ -117,32 +101,7 @@ if (!app.Environment.IsDevelopment())
 //     "KnownProxies":  ["10.0.0.5", "192.168.1.20"],
 //     "KnownNetworks": ["10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12"]
 //   }
-var forwardedHeadersSection = builder.Configuration.GetSection("ForwardedHeaders");
-var hasForwardedConfig = forwardedHeadersSection.Exists();
-if (hasForwardedConfig)
-{
-    var forwardedOptions = new Microsoft.AspNetCore.Builder.ForwardedHeadersOptions
-    {
-        ForwardedHeaders = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedFor
-                         | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto,
-        RequireHeaderSymmetry = false,
-        ForwardLimit = 2,
-    };
-
-    var knownProxies = forwardedHeadersSection.GetSection("KnownProxies").Get<string[]>();
-    if (knownProxies is not null)
-        foreach (var ip in knownProxies)
-            if (System.Net.IPAddress.TryParse(ip, out var addr))
-                forwardedOptions.KnownProxies.Add(addr);
-
-    var knownNetworks = forwardedHeadersSection.GetSection("KnownNetworks").Get<string[]>();
-    if (knownNetworks is not null)
-        foreach (var cidr in knownNetworks)
-            if (TryParseCidr(cidr, out var network))
-                forwardedOptions.KnownIPNetworks.Add(network);
-
-    app.UseForwardedHeaders(forwardedOptions);
-}
+ConfigureForwardedHeaders(app, builder.Configuration);
 
 app.UseHttpsRedirection();
 app.UseRouting();
@@ -159,8 +118,86 @@ app.MapControllerRoute(
 
 app.Run();
 
-// Parsea un CIDR ("192.168.0.0/16") a IPNetwork. Usado por la configuracion
-// de ForwardedHeaders.KnownNetworks.
+/// <summary>
+/// Loggea un warning si en produccion el email tiene Host pero faltan
+/// Username/Password. No rompe el startup: el caller hace fire-and-forget
+/// y va a loggear el fallo real al primer envio.
+/// </summary>
+static void WarnOnIncompleteSmtpConfig(WebApplication app)
+{
+    if (app.Environment.IsDevelopment()) return;
+
+    var emailOptions = app.Services.GetRequiredService<IOptions<EmailOptions>>().Value;
+    if (string.IsNullOrWhiteSpace(emailOptions.Host)) return;
+    if (!string.IsNullOrEmpty(emailOptions.Username) && !string.IsNullOrEmpty(emailOptions.Password)) return;
+
+    var startupLogger = app.Services.GetRequiredService<ILoggerFactory>()
+        .CreateLogger("EmailStartup");
+    startupLogger.LogWarning(
+        "Email:Host configurado ({Host}) pero Email:Username/Email:Password no estan seteados. " +
+        "Defini las credenciales SMTP via 'dotnet user-secrets set' antes de enviar emails. " +
+        "Los envios fallaran silenciosamente.",
+        emailOptions.Host);
+}
+
+/// <summary>
+/// Aplica <c>UseForwardedHeaders</c> solo si la sección "ForwardedHeaders"
+/// existe en configuración. Si no, no se reescribe nada (defensa contra
+/// spoofing de IP).
+/// </summary>
+static void ConfigureForwardedHeaders(WebApplication app, IConfiguration configuration)
+{
+    var section = configuration.GetSection("ForwardedHeaders");
+    if (!section.Exists()) return;
+
+    var options = new Microsoft.AspNetCore.Builder.ForwardedHeadersOptions
+    {
+        ForwardedHeaders = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedFor
+                         | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto,
+        RequireHeaderSymmetry = false,
+        ForwardLimit = 2,
+    };
+
+    AddKnownProxies(options, section.GetSection("KnownProxies"));
+    AddKnownNetworks(options, section.GetSection("KnownNetworks"));
+
+    app.UseForwardedHeaders(options);
+}
+
+/// <summary>
+/// Suma las IPs de <c>KnownProxies</c> al builder de options. Las IPs
+/// inválidas se descartan silenciosamente (no son bloqueantes).
+/// </summary>
+static void AddKnownProxies(
+    Microsoft.AspNetCore.Builder.ForwardedHeadersOptions options, IConfigurationSection section)
+{
+    var proxies = section.Get<string[]>();
+    if (proxies is null) return;
+
+    foreach (var ip in proxies)
+        if (System.Net.IPAddress.TryParse(ip, out var addr))
+            options.KnownProxies.Add(addr);
+}
+
+/// <summary>
+/// Suma los CIDR de <c>KnownNetworks</c> al builder de options. Los CIDR
+/// inválidos se descartan silenciosamente.
+/// </summary>
+static void AddKnownNetworks(
+    Microsoft.AspNetCore.Builder.ForwardedHeadersOptions options, IConfigurationSection section)
+{
+    var cidrs = section.Get<string[]>();
+    if (cidrs is null) return;
+
+    foreach (var cidr in cidrs)
+        if (TryParseCidr(cidr, out var network))
+            options.KnownIPNetworks.Add(network);
+}
+
+/// <summary>
+/// Parsea un CIDR ("192.168.0.0/16") a IPNetwork. Usado por la configuracion
+/// de ForwardedHeaders.KnownNetworks.
+/// </summary>
 static bool TryParseCidr(string cidr, out IPNetwork network)
 {
     network = default;

--- a/src/ExtraGasMVC/Services/Implementations/ClienteService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ClienteService.cs
@@ -103,40 +103,40 @@ public class ClienteService : IClienteService
         };
     }
 
-    public async Task<ClienteDto> CreateAsync(CreateClienteDto clienteDto, ulong? createdBy, CancellationToken ct = default)
+    public async Task<ClienteDto> CreateAsync(CreateClienteDto cliente, ulong? createdBy, CancellationToken ct = default)
     {
-        if (!await IsDniUniqueAsync(clienteDto.Dni, ct))
+        if (!await IsDniUniqueAsync(cliente.Dni, ct))
             throw new InvalidOperationException("El DNI ingresado ya está registrado.");
 
-        var cliente = _mapper.Map<Cliente>(clienteDto);
-        cliente.Activo = true;
-        cliente.CreatedAt = DateTime.UtcNow;
-        cliente.UpdatedAt = DateTime.UtcNow;
-        cliente.CreatedBy = createdBy;
-        cliente.UpdatedBy = createdBy;
+        var entity = _mapper.Map<Cliente>(cliente);
+        entity.Activo = true;
+        entity.CreatedAt = DateTime.UtcNow;
+        entity.UpdatedAt = DateTime.UtcNow;
+        entity.CreatedBy = createdBy;
+        entity.UpdatedBy = createdBy;
 
-        _context.Clientes.Add(cliente);
+        _context.Clientes.Add(entity);
         await _context.SaveChangesAsync(ct);
 
-        return _mapper.Map<ClienteDto>(cliente);
+        return _mapper.Map<ClienteDto>(entity);
     }
 
-    public async Task<ClienteDto> UpdateAsync(UpdateClienteDto clienteDto, ulong? updatedBy, CancellationToken ct = default)
+    public async Task<ClienteDto> UpdateAsync(UpdateClienteDto cliente, ulong? updatedBy, CancellationToken ct = default)
     {
-        var cliente = await _context.Clientes.FindAsync(new object[] { clienteDto.Id }, ct);
-        if (cliente == null)
-            throw new KeyNotFoundException($"Cliente con Id {clienteDto.Id} no encontrado.");
+        var entity = await _context.Clientes.FindAsync(new object[] { cliente.Id }, ct);
+        if (entity == null)
+            throw new KeyNotFoundException($"Cliente con Id {cliente.Id} no encontrado.");
 
-        if (!await IsDniUniqueAsync(clienteDto.Dni, clienteDto.Id, ct))
+        if (!await IsDniUniqueAsync(cliente.Dni, cliente.Id, ct))
             throw new InvalidOperationException("El DNI ingresado ya está registrado.");
 
-        _mapper.Map(clienteDto, cliente);
-        cliente.UpdatedAt = DateTime.UtcNow;
-        cliente.UpdatedBy = updatedBy;
+        _mapper.Map(cliente, entity);
+        entity.UpdatedAt = DateTime.UtcNow;
+        entity.UpdatedBy = updatedBy;
 
         await _context.SaveChangesAsync(ct);
 
-        return _mapper.Map<ClienteDto>(cliente);
+        return _mapper.Map<ClienteDto>(entity);
     }
 
     public async Task<bool> DeleteAsync(ulong id, ulong? updatedBy, CancellationToken ct = default)

--- a/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using AutoMapper;
 using ExtraGasMVC.Constants;
 using ExtraGasMVC.Data.Context;
@@ -100,7 +101,7 @@ public class GarrafaService : IGarrafaService
     }
 
     public async Task<PagedResult<GarrafaDto>> GetPagedAsync(
-        string? codigo, byte? capacidad, int page, int pageSize,
+        string? codigo, byte? capacidad, int page = 1, int pageSize = 20,
         string sortBy = "codigo", string sortDir = "asc",
         CancellationToken ct = default)
     {
@@ -139,41 +140,8 @@ public class GarrafaService : IGarrafaService
 
         // Issue #53: ordenar por el campo pedido. Defaults seguros (cualquier
         // sortBy desconocido cae a "codigo", cualquier sortDir != "desc" a
-        // "asc"). Cada case arma el IOrderedQueryable en su tipo concreto para
-        // que EF genere SQL específico por campo — no usamos reflection ni
-        // expression trees dinámicas porque romperían la traducción a SQL.
-        // ThenBy(Id) en todos los casos = tiebreaker estable para paginación.
-        var desc = string.Equals(sortDir, "desc", StringComparison.OrdinalIgnoreCase);
-        IOrderedQueryable<Garrafa> ordered = sortBy.ToLowerInvariant() switch
-        {
-            "capacidad" => desc
-                ? query.OrderByDescending(g => g.CapacidadKg).ThenBy(g => g.Id)
-                : query.OrderBy(g => g.CapacidadKg).ThenBy(g => g.Id),
-            "estado" => desc
-                ? query.OrderByDescending(g => g.EstadoGarrafa!.Nombre).ThenBy(g => g.Id)
-                : query.OrderBy(g => g.EstadoGarrafa!.Nombre).ThenBy(g => g.Id),
-            // Cliente es nullable: ordenar por Apellido, luego Nombre. EF
-            // traduce el acceso a navegación como LEFT JOIN; las filas sin
-            // cliente quedan con NULL y MySQL las pone al inicio en ASC.
-            "cliente" => desc
-                ? query.OrderByDescending(g => g.Cliente!.Apellido)
-                       .ThenByDescending(g => g.Cliente!.Nombre)
-                       .ThenBy(g => g.Id)
-                : query.OrderBy(g => g.Cliente!.Apellido)
-                       .ThenBy(g => g.Cliente!.Nombre)
-                       .ThenBy(g => g.Id),
-            "fechacompra" => desc
-                ? query.OrderByDescending(g => g.FechaCompra).ThenBy(g => g.Id)
-                : query.OrderBy(g => g.FechaCompra).ThenBy(g => g.Id),
-            // FechaUltimoMovimiento es DateTime? — los NULL van primero en ASC
-            // (semántica de MySQL), lo cual es razonable para "último mov."
-            "ultimomov" => desc
-                ? query.OrderByDescending(g => g.FechaUltimoMovimiento).ThenBy(g => g.Id)
-                : query.OrderBy(g => g.FechaUltimoMovimiento).ThenBy(g => g.Id),
-            "codigo" or _ => desc
-                ? query.OrderByDescending(g => g.Codigo).ThenBy(g => g.Id)
-                : query.OrderBy(g => g.Codigo).ThenBy(g => g.Id),
-        };
+        // "asc"). ThenBy(Id) en todos los casos = tiebreaker estable para paginación.
+        var ordered = BuildOrderedQueryable(query, sortBy, sortDir);
 
         var items = await ordered
             .Skip((page - 1) * pageSize)
@@ -189,6 +157,51 @@ public class GarrafaService : IGarrafaService
         };
     }
 
+    /// <summary>
+    /// Construye el IOrderedQueryable según los parámetros sortBy/sortDir.
+    /// Cada case arma el ordenamiento en su tipo concreto para que EF genere
+    /// SQL específico por campo — no usamos reflection ni expression trees
+    /// dinámicas porque romperían la traducción a SQL.
+    /// </summary>
+    private static IOrderedQueryable<Garrafa> BuildOrderedQueryable(
+        IQueryable<Garrafa> query, string sortBy, string sortDir)
+    {
+        var desc = string.Equals(sortDir, "desc", StringComparison.OrdinalIgnoreCase);
+        return sortBy.ToLowerInvariant() switch
+        {
+            "capacidad" => OrderByCampoOrId(query, g => g.CapacidadKg, desc),
+            "estado" => OrderByCampoOrId(query, g => g.EstadoGarrafa!.Nombre, desc),
+            // Cliente es nullable: ordenar por Apellido, luego Nombre. EF
+            // traduce el acceso a navegación como LEFT JOIN; las filas sin
+            // cliente quedan con NULL y MySQL las pone al inicio en ASC.
+            "cliente" => desc
+                ? query.OrderByDescending(g => g.Cliente!.Apellido)
+                       .ThenByDescending(g => g.Cliente!.Nombre)
+                       .ThenBy(g => g.Id)
+                : query.OrderBy(g => g.Cliente!.Apellido)
+                       .ThenBy(g => g.Cliente!.Nombre)
+                       .ThenBy(g => g.Id),
+            "fechacompra" => OrderByCampoOrId(query, g => g.FechaCompra, desc),
+            // FechaUltimoMovimiento es DateTime? — los NULL van primero en ASC
+            // (semántica de MySQL), lo cual es razonable para "último mov."
+            "ultimomov" => OrderByCampoOrId(query, g => g.FechaUltimoMovimiento, desc),
+            // "codigo" y default: campo principal + Id como tiebreaker.
+            _ => OrderByCampoOrId(query, g => g.Codigo, desc),
+        };
+    }
+
+    /// <summary>
+    /// Helper común: ordena por la key provista y usa Id como tiebreaker
+    /// estable. Reduce el switch anterior a una sola expresión por case.
+    /// </summary>
+    private static IOrderedQueryable<Garrafa> OrderByCampoOrId<TKey>(
+        IQueryable<Garrafa> query, System.Linq.Expressions.Expression<Func<Garrafa, TKey>> keySelector, bool desc)
+    {
+        return desc
+            ? query.OrderByDescending(keySelector).ThenBy(g => g.Id)
+            : query.OrderBy(keySelector).ThenBy(g => g.Id);
+    }
+
     public async Task<IEnumerable<EstadoGarrafaDto>> GetEstadosAsync(CancellationToken ct = default)
     {
         var estados = await _context.EstadosGarrafa
@@ -199,39 +212,39 @@ public class GarrafaService : IGarrafaService
         return _mapper.Map<IEnumerable<EstadoGarrafaDto>>(estados);
     }
 
-    public async Task<GarrafaDto> CreateAsync(CreateGarrafaDto garrafaDto, ulong? usuarioId, CancellationToken ct = default)
+    public async Task<GarrafaDto> CreateAsync(CreateGarrafaDto garrafa, ulong? usuarioId, CancellationToken ct = default)
     {
-        if (await _context.Garrafas.AnyAsync(g => g.Codigo == garrafaDto.Codigo, ct))
-            throw new InvalidOperationException($"Ya existe una garrafa con el código {garrafaDto.Codigo}.");
+        if (await _context.Garrafas.AnyAsync(g => g.Codigo == garrafa.Codigo, ct))
+            throw new InvalidOperationException($"Ya existe una garrafa con el código {garrafa.Codigo}.");
 
-        var garrafa = _mapper.Map<Garrafa>(garrafaDto);
-        garrafa.CreatedAt = DateTime.UtcNow;
-        garrafa.UpdatedAt = DateTime.UtcNow;
-        garrafa.CreatedBy = usuarioId;
-        garrafa.UpdatedBy = usuarioId;
+        var entity = _mapper.Map<Garrafa>(garrafa);
+        entity.CreatedAt = DateTime.UtcNow;
+        entity.UpdatedAt = DateTime.UtcNow;
+        entity.CreatedBy = usuarioId;
+        entity.UpdatedBy = usuarioId;
 
-        _context.Garrafas.Add(garrafa);
-        await SaveOrThrowDuplicateAsync(garrafaDto.Codigo, ct);
+        _context.Garrafas.Add(entity);
+        await SaveOrThrowDuplicateAsync(garrafa.Codigo, ct);
 
-        return _mapper.Map<GarrafaDto>(garrafa);
+        return _mapper.Map<GarrafaDto>(entity);
     }
 
-    public async Task<GarrafaDto> UpdateAsync(UpdateGarrafaDto garrafaDto, ulong? usuarioId, CancellationToken ct = default)
+    public async Task<GarrafaDto> UpdateAsync(UpdateGarrafaDto garrafa, ulong? usuarioId, CancellationToken ct = default)
     {
-        var garrafa = await _context.Garrafas.FindAsync(new object[] { garrafaDto.Id }, ct);
-        if (garrafa == null)
-            throw new KeyNotFoundException($"Garrafa con Id {garrafaDto.Id} no encontrada.");
+        var entity = await _context.Garrafas.FindAsync(new object[] { garrafa.Id }, ct);
+        if (entity == null)
+            throw new KeyNotFoundException($"Garrafa con Id {garrafa.Id} no encontrada.");
 
-        if (await _context.Garrafas.AnyAsync(g => g.Codigo == garrafaDto.Codigo && g.Id != garrafaDto.Id, ct))
-            throw new InvalidOperationException($"Ya existe una garrafa con el código {garrafaDto.Codigo}.");
+        if (await _context.Garrafas.AnyAsync(g => g.Codigo == garrafa.Codigo && g.Id != garrafa.Id, ct))
+            throw new InvalidOperationException($"Ya existe una garrafa con el código {garrafa.Codigo}.");
 
-        _mapper.Map(garrafaDto, garrafa);
-        garrafa.UpdatedAt = DateTime.UtcNow;
-        garrafa.UpdatedBy = usuarioId;
+        _mapper.Map(garrafa, entity);
+        entity.UpdatedAt = DateTime.UtcNow;
+        entity.UpdatedBy = usuarioId;
 
-        await SaveOrThrowDuplicateAsync(garrafaDto.Codigo, ct);
+        await SaveOrThrowDuplicateAsync(garrafa.Codigo, ct);
 
-        return _mapper.Map<GarrafaDto>(garrafa);
+        return _mapper.Map<GarrafaDto>(entity);
     }
 
     public async Task<bool> CambiarEstadoAsync(ulong id, CambiarEstadoGarrafaDto dto, ulong? currentUserId = null, CancellationToken ct = default)

--- a/src/ExtraGasMVC/Services/Implementations/PagoService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/PagoService.cs
@@ -59,30 +59,30 @@ public class PagoService : IPagoService
         return _mapper.Map<IEnumerable<PagoDto>>(pagos);
     }
 
-    public async Task<PagoDto> CreateAsync(CreatePagoDto pagoDto, CancellationToken ct = default)
+    public async Task<PagoDto> CreateAsync(CreatePagoDto pago, CancellationToken ct = default)
     {
-        var pago = _mapper.Map<Pago>(pagoDto);
-        pago.CreatedAt = DateTime.UtcNow;
-        pago.UpdatedAt = DateTime.UtcNow;
-        
-        _context.Pagos.Add(pago);
+        var entity = _mapper.Map<Pago>(pago);
+        entity.CreatedAt = DateTime.UtcNow;
+        entity.UpdatedAt = DateTime.UtcNow;
+
+        _context.Pagos.Add(entity);
         await _context.SaveChangesAsync(ct);
-        
-        return _mapper.Map<PagoDto>(pago);
+
+        return _mapper.Map<PagoDto>(entity);
     }
 
-    public async Task<PagoDto> UpdateAsync(UpdatePagoDto pagoDto, CancellationToken ct = default)
+    public async Task<PagoDto> UpdateAsync(UpdatePagoDto pago, CancellationToken ct = default)
     {
-        var pago = await _context.Pagos.FindAsync(new object[] { pagoDto.Id }, ct);
-        if (pago == null)
-            throw new KeyNotFoundException($"Pago con Id {pagoDto.Id} no encontrado.");
+        var entity = await _context.Pagos.FindAsync(new object[] { pago.Id }, ct);
+        if (entity == null)
+            throw new KeyNotFoundException($"Pago con Id {pago.Id} no encontrado.");
 
-        _mapper.Map(pagoDto, pago);
-        pago.UpdatedAt = DateTime.UtcNow;
-        
+        _mapper.Map(pago, entity);
+        entity.UpdatedAt = DateTime.UtcNow;
+
         await _context.SaveChangesAsync(ct);
-        
-        return _mapper.Map<PagoDto>(pago);
+
+        return _mapper.Map<PagoDto>(entity);
     }
 
     public async Task<bool> DeleteAsync(ulong id, CancellationToken ct = default)

--- a/src/ExtraGasMVC/Services/Implementations/PedidoService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/PedidoService.cs
@@ -190,39 +190,39 @@ public class PedidoService : IPedidoService
 
     #region Commands
 
-    public async Task<PedidoDto> CreateAsync(CreatePedidoDto pedidoDto, ulong? usuarioId, CancellationToken ct = default)
+    public async Task<PedidoDto> CreateAsync(CreatePedidoDto pedido, ulong? usuarioId, CancellationToken ct = default)
     {
         var estadoPendiente = await _context.EstadosPedido
             .AsNoTracking()
             .FirstOrDefaultAsync(e => e.Codigo == PedidoEstados.Pendiente, ct)
             ?? throw new InvalidOperationException("No se encontró el estado PENDIENTE en el catálogo.");
 
-        var pedido = _mapper.Map<Pedido>(pedidoDto);
-        pedido.EstadoPedidoId = estadoPendiente.Id;
-        pedido.Subtotal = 0;
-        pedido.Descuento = 0;
-        pedido.Total = 0;
-        pedido.CreatedAt = DateTime.UtcNow;
-        pedido.UpdatedAt = DateTime.UtcNow;
-        pedido.CreatedBy = usuarioId;
-        pedido.UpdatedBy = usuarioId;
+        var entity = _mapper.Map<Pedido>(pedido);
+        entity.EstadoPedidoId = estadoPendiente.Id;
+        entity.Subtotal = 0;
+        entity.Descuento = 0;
+        entity.Total = 0;
+        entity.CreatedAt = DateTime.UtcNow;
+        entity.UpdatedAt = DateTime.UtcNow;
+        entity.CreatedBy = usuarioId;
+        entity.UpdatedBy = usuarioId;
 
-        _context.Pedidos.Add(pedido);
+        _context.Pedidos.Add(entity);
         await _context.SaveChangesAsync(ct);
 
-        return (await GetByIdAsync(pedido.Id, ct))!;
+        return (await GetByIdAsync(entity.Id, ct))!;
     }
 
-    public async Task<PedidoDto> UpdateAsync(UpdatePedidoDto pedidoDto, ulong? usuarioId, CancellationToken ct = default)
+    public async Task<PedidoDto> UpdateAsync(UpdatePedidoDto pedido, ulong? usuarioId, CancellationToken ct = default)
     {
-        var pedido = await _context.Pedidos.FindAsync(new object[] { pedidoDto.Id }, ct);
-        if (pedido == null)
-            throw new KeyNotFoundException($"Pedido con Id {pedidoDto.Id} no encontrado.");
+        var entity = await _context.Pedidos.FindAsync(new object[] { pedido.Id }, ct);
+        if (entity == null)
+            throw new KeyNotFoundException($"Pedido con Id {pedido.Id} no encontrado.");
 
         // Business rule: final state orders cannot be edited
         var estadoActual = await _context.EstadosPedido
             .AsNoTracking()
-            .FirstOrDefaultAsync(e => e.Id == pedido.EstadoPedidoId, ct);
+            .FirstOrDefaultAsync(e => e.Id == entity.EstadoPedidoId, ct);
 
         if (estadoActual is not null && PedidoEstados.EstadosFinales.Contains(estadoActual.Codigo))
             throw new InvalidOperationException($"No se puede editar un pedido en estado final ({estadoActual.Nombre}).");
@@ -230,32 +230,32 @@ public class PedidoService : IPedidoService
         // Business rule: CONFIRMADO/EN_PREPARACION orders can only edit DireccionEntrega and Observaciones
         var isPartialEdit = estadoActual is not null && PedidoEstados.EstadosSoloLecturaParcial.Contains(estadoActual.Codigo);
 
-        pedido.UpdatedAt = DateTime.UtcNow;
-        pedido.UpdatedBy = usuarioId;
+        entity.UpdatedAt = DateTime.UtcNow;
+        entity.UpdatedBy = usuarioId;
 
         if (isPartialEdit)
         {
             // Only allow editing delivery address and observations
-            pedido.DireccionEntrega = pedidoDto.DireccionEntrega;
-            pedido.Observaciones = pedidoDto.Observaciones;
-            pedido.Descuento = pedidoDto.Descuento;
+            entity.DireccionEntrega = pedido.DireccionEntrega;
+            entity.Observaciones = pedido.Observaciones;
+            entity.Descuento = pedido.Descuento;
         }
         else
         {
-            pedido.Fecha = pedidoDto.Fecha;
-            pedido.FechaEntrega = pedidoDto.FechaEntrega;
-            pedido.ClienteId = pedidoDto.ClienteId;
-            pedido.EmpleadoId = pedidoDto.EmpleadoId;
-            pedido.CanalVentaId = pedidoDto.CanalVentaId;
-            pedido.MedioContactoId = pedidoDto.MedioContactoId;
-            pedido.DireccionEntrega = pedidoDto.DireccionEntrega;
-            pedido.Observaciones = pedidoDto.Observaciones;
-            pedido.Descuento = pedidoDto.Descuento;
+            entity.Fecha = pedido.Fecha;
+            entity.FechaEntrega = pedido.FechaEntrega;
+            entity.ClienteId = pedido.ClienteId;
+            entity.EmpleadoId = pedido.EmpleadoId;
+            entity.CanalVentaId = pedido.CanalVentaId;
+            entity.MedioContactoId = pedido.MedioContactoId;
+            entity.DireccionEntrega = pedido.DireccionEntrega;
+            entity.Observaciones = pedido.Observaciones;
+            entity.Descuento = pedido.Descuento;
         }
 
-        await RecalculateTotalsAsync(pedido.Id, ct);
+        await RecalculateTotalsAsync(entity.Id, ct);
 
-        return (await GetByIdAsync(pedido.Id, ct))!;
+        return (await GetByIdAsync(entity.Id, ct))!;
     }
 
     public async Task<bool> DeleteAsync(ulong id, ulong? usuarioId, CancellationToken ct = default)
@@ -344,12 +344,12 @@ public class PedidoService : IPedidoService
         return true;
     }
 
-    public async Task<PedidoItemDto> AddItemAsync(CreatePedidoItemDto itemDto, CancellationToken ct = default)
+    public async Task<PedidoItemDto> AddItemAsync(CreatePedidoItemDto item, CancellationToken ct = default)
     {
         // Business rule: only PENDIENTE orders can have items added
-        var pedido = await _context.Pedidos.FindAsync(new object[] { itemDto.PedidoId }, ct);
+        var pedido = await _context.Pedidos.FindAsync(new object[] { item.PedidoId }, ct);
         if (pedido is null)
-            throw new KeyNotFoundException($"Pedido con Id {itemDto.PedidoId} no encontrado.");
+            throw new KeyNotFoundException($"Pedido con Id {item.PedidoId} no encontrado.");
 
         var estadoPedido = await _context.EstadosPedido
             .AsNoTracking()
@@ -358,35 +358,35 @@ public class PedidoService : IPedidoService
         if (estadoPedido is not null && estadoPedido.Codigo != PedidoEstados.Pendiente)
             throw new InvalidOperationException($"No se pueden agregar items en estado {estadoPedido.Nombre}. Solo se permite en estado Pendiente.");
 
-        var tipoLinea = ParseTipoLinea(itemDto.TipoLinea);
+        var tipoLinea = ParseTipoLinea(item.TipoLinea);
 
         var producto = await _context.Productos
             .AsNoTracking()
-            .FirstOrDefaultAsync(p => p.Id == itemDto.ProductoId, ct);
+            .FirstOrDefaultAsync(p => p.Id == item.ProductoId, ct);
 
         if (producto == null)
-            throw new KeyNotFoundException($"Producto con Id {itemDto.ProductoId} no encontrado.");
+            throw new KeyNotFoundException($"Producto con Id {item.ProductoId} no encontrado.");
 
         // Duplicate check — defensive; database unique constraint is the authoritative guard
         var yaExiste = await _context.PedidoItems
             .AsNoTracking()
-            .AnyAsync(i => i.PedidoId == itemDto.PedidoId
-                        && i.ProductoId == itemDto.ProductoId
+            .AnyAsync(i => i.PedidoId == item.PedidoId
+                        && i.ProductoId == item.ProductoId
                         && i.TipoLinea == tipoLinea, ct);
 
         if (yaExiste)
             throw new InvalidOperationException(
-                $"El producto \"{producto.Nombre}\" ya está agregado al pedido con tipo {itemDto.TipoLinea}. " +
+                $"El producto \"{producto.Nombre}\" ya está agregado al pedido con tipo {item.TipoLinea}. " +
                 $"Si necesita modificar la cantidad, elimine el item existente y vuelva a cargarlo.");
 
-        var item = _mapper.Map<PedidoItem>(itemDto);
-        item.PrecioUnitario = producto.PrecioActual;
-        item.TipoLinea = tipoLinea;
+        var entity = _mapper.Map<PedidoItem>(item);
+        entity.PrecioUnitario = producto.PrecioActual;
+        entity.TipoLinea = tipoLinea;
 
         using var transaction = await _context.Database.BeginTransactionAsync(ct);
         try
         {
-            _context.PedidoItems.Add(item);
+            _context.PedidoItems.Add(entity);
             await _context.SaveChangesAsync(ct);
             await RecalculateTotalsInternalAsync(pedido.Id, ct);
             await transaction.CommitAsync(ct);
@@ -395,35 +395,35 @@ public class PedidoService : IPedidoService
         {
             await transaction.RollbackAsync(ct);
             throw new InvalidOperationException(
-                $"El producto \"{producto.Nombre}\" ya está agregado al pedido con tipo {itemDto.TipoLinea}. " +
+                $"El producto \"{producto.Nombre}\" ya está agregado al pedido con tipo {item.TipoLinea}. " +
                 $"Si necesita modificar la cantidad, elimine el item existente y vuelva a cargarlo.");
         }
 
         return (await _context.PedidoItems
             .AsNoTracking()
             .Include(i => i.Producto)
-            .FirstOrDefaultAsync(i => i.Id == item.Id, ct)) is { } saved
+            .FirstOrDefaultAsync(i => i.Id == entity.Id, ct)) is { } saved
             ? _mapper.Map<PedidoItemDto>(saved)
             : throw new InvalidOperationException("No se pudo recuperar el item creado.");
     }
 
-    public async Task<PedidoItemDto> UpdateItemAsync(UpdatePedidoItemDto itemDto, CancellationToken ct = default)
+    public async Task<PedidoItemDto> UpdateItemAsync(UpdatePedidoItemDto item, CancellationToken ct = default)
     {
-        var item = await _context.PedidoItems.FindAsync(new object[] { itemDto.Id }, ct);
-        if (item == null)
-            throw new KeyNotFoundException($"Item con Id {itemDto.Id} no encontrado.");
+        var entity = await _context.PedidoItems.FindAsync(new object[] { item.Id }, ct);
+        if (entity == null)
+            throw new KeyNotFoundException($"Item con Id {item.Id} no encontrado.");
 
-        _mapper.Map(itemDto, item);
-        item.TipoLinea = ParseTipoLinea(itemDto.TipoLinea);
-        item.UpdatedAt = DateTime.UtcNow;
+        _mapper.Map(item, entity);
+        entity.TipoLinea = ParseTipoLinea(item.TipoLinea);
+        entity.UpdatedAt = DateTime.UtcNow;
 
         await _context.SaveChangesAsync(ct);
-        await RecalculateTotalsAsync(item.PedidoId, ct);
+        await RecalculateTotalsAsync(entity.PedidoId, ct);
 
         return (await _context.PedidoItems
             .AsNoTracking()
             .Include(i => i.Producto)
-            .FirstOrDefaultAsync(i => i.Id == item.Id, ct)) is { } saved
+            .FirstOrDefaultAsync(i => i.Id == entity.Id, ct)) is { } saved
             ? _mapper.Map<PedidoItemDto>(saved)
             : throw new InvalidOperationException("No se pudo recuperar el item actualizado.");
     }
@@ -473,12 +473,70 @@ public class PedidoService : IPedidoService
         ulong? usuarioId,
         CancellationToken ct = default)
     {
-        // 1) El pedido debe existir y estar en un estado que permita pasar a CONFIRMADO.
+        // 1) El pedido debe existir y no estar ya en CONFIRMADO.
+        var pedido = await LoadPedidoParaCanjeAsync(pedidoId, ct);
+        if (pedido is null)
+            return false;
+
+        // 2) Idempotencia: si ya hay movimientos para este pedido, rechazar.
+        await AsegurarNoCanjeadoAsync(pedidoId, ct);
+
+        // 3) Resolver los IDs de los lookups que vamos a usar varias veces.
+        var (estadoIdByCodigo, tipoMovimientoIdByCodigo, estadoConfirmadoId) =
+            await LoadCatalogosParaCanjeAsync(ct);
+
+        // 4) Si no hay items a canjear (pedido solo VENTA / carbón / leña), el
+        // método degenera en un simple cambio de estado.
+        if (codigosPorItem is null || codigosPorItem.Count == 0)
+        {
+            return await ConfirmarSinCanjeAsync(pedido, estadoConfirmadoId, usuarioId, ct);
+        }
+
+        // 5) Cargar los items solicitados con su producto.
+        var items = await LoadItemsParaCanjeAsync(pedidoId, codigosPorItem, ct);
+
+        // 6) Defensa en profundidad: validar que los items son GARRAFA-capaces
+        // y que su tipo de línea es ENTREGA/DEVOLUCION.
+        ValidarItemsSonGarrafaCanjeable(items);
+
+        // 7) Pre-validar TODOS los códigos antes de escribir nada.
+        var codigosPorItemLimpios = NormalizarYValidarCodigos(items, codigosPorItem);
+
+        // 8) Segunda pasada: validar cada código contra existencia, estado y
+        // cliente (en DEVOLUCION). Cargamos todas las garrafas en una sola query
+        // por item para no hacer N+1.
+        foreach (var item in items)
+            await ValidarCodigosContraInventarioAsync(item, codigosPorItemLimpios[item.Id], pedido, ct);
+
+        // 9) Todo validado. Transacción ambiente.
+        await using var transaction = await _context.Database.BeginTransactionAsync(ct);
+        try
+        {
+            await AplicarCanjeYConfirmarAsync(
+                items, codigosPorItemLimpios, pedidoId, pedido,
+                estadoIdByCodigo, tipoMovimientoIdByCodigo, estadoConfirmadoId, usuarioId, ct);
+
+            await transaction.CommitAsync(ct);
+            return true;
+        }
+        catch
+        {
+            await transaction.RollbackAsync(ct);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Carga el pedido para el canje. Devuelve null si no existe. Falla con
+    /// InvalidOperationException si ya está CONFIRMADO.
+    /// </summary>
+    private async Task<Pedido?> LoadPedidoParaCanjeAsync(ulong pedidoId, CancellationToken ct)
+    {
         var pedido = await _context.Pedidos
             .FirstOrDefaultAsync(p => p.Id == pedidoId, ct);
 
         if (pedido is null)
-            return false;
+            return null;
 
         if (pedido.EstadoPedidoId != 0)
         {
@@ -493,10 +551,16 @@ public class PedidoService : IPedidoService
                     "El pedido ya se encuentra en estado CONFIRMADO. No se puede confirmar dos veces.");
         }
 
-        // 2) Idempotencia: si ya hay movimientos de garrafa para este pedido,
-        // rechazar (el pedido ya pasó por canje y fue revertido a PENDIENTE — requiere
-        // un nuevo pedido, no re-confirmar el mismo). El check se hace antes de la
-        // transacción para que el rechazo sea barato.
+        return pedido;
+    }
+
+    /// <summary>
+    /// Rechaza el canje si ya hay movimientos de garrafa para este pedido
+    /// (idempotencia: el pedido ya pasó por canje y fue revertido a
+    /// PENDIENTE — requiere un nuevo pedido, no re-confirmar el mismo).
+    /// </summary>
+    private async Task AsegurarNoCanjeadoAsync(ulong pedidoId, CancellationToken ct)
+    {
         var yaCanjeado = await _context.MovimientosGarrafa
             .AsNoTracking()
             .AnyAsync(m => m.PedidoId == pedidoId, ct);
@@ -505,15 +569,19 @@ public class PedidoService : IPedidoService
             throw new InvalidOperationException(
                 "Este pedido ya tiene movimientos de canje registrados. " +
                 "No se puede confirmar dos veces.");
+    }
 
-        // 3) Resolver los IDs de los lookups que vamos a usar varias veces en un
-        // solo viaje a la BD (estados de garrafa, tipo de movimiento, estado CONFIRMADO).
+    /// <summary>
+    /// Resuelve los IDs de los lookups que vamos a usar varias veces en un
+    /// solo viaje a la BD (estados de garrafa, tipo de movimiento, estado CONFIRMADO).
+    /// </summary>
+    private async Task<(Dictionary<string, ulong> estadoIdByCodigo, Dictionary<string, ulong> tipoMovimientoIdByCodigo, ulong estadoConfirmadoId)>
+        LoadCatalogosParaCanjeAsync(CancellationToken ct)
+    {
         var lookupCodigos = new[]
         {
             GarrafaEstados.LlenaDeposito,
             GarrafaEstados.EnCliente,
-            TipoMovimientoEntregaCliente,
-            TipoMovimientoDevolucionCliente,
             PedidoEstados.Confirmado
         };
 
@@ -522,7 +590,6 @@ public class PedidoService : IPedidoService
             .Where(e => lookupCodigos.Contains(e.Codigo))
             .Select(e => new { e.Id, e.Codigo })
             .ToListAsync(ct);
-
         var estadoIdByCodigo = catalogos.ToDictionary(e => e.Codigo, e => e.Id);
 
         var tiposMovimiento = await _context.TiposMovimientoGarrafa
@@ -531,7 +598,6 @@ public class PedidoService : IPedidoService
                      || t.Codigo == TipoMovimientoDevolucionCliente)
             .Select(t => new { t.Id, t.Codigo })
             .ToListAsync(ct);
-
         var tipoMovimientoIdByCodigo = tiposMovimiento.ToDictionary(t => t.Codigo, t => t.Id);
 
         if (!tipoMovimientoIdByCodigo.ContainsKey(TipoMovimientoEntregaCliente)
@@ -551,23 +617,34 @@ public class PedidoService : IPedidoService
             throw new InvalidOperationException(
                 "No se encontró el estado CONFIRMADO en el catálogo estados_pedido.");
 
-        // 4) Si no hay items a canjear (pedido solo VENTA / carbón / leña), el
-        // método degenera en un simple cambio de estado. La transición y la
-        // auditoría se aplican igual; no abrimos transacción porque no hay
-        // escrituras múltiples.
-        if (codigosPorItem is null || codigosPorItem.Count == 0)
-        {
-            pedido.EstadoPedidoId = estadoConfirmadoId;
-            pedido.UpdatedAt = DateTime.UtcNow;
-            pedido.UpdatedBy = usuarioId;
-            await _context.SaveChangesAsync(ct);
-            return true;
-        }
+        return (estadoIdByCodigo, tipoMovimientoIdByCodigo, estadoConfirmadoId);
+    }
 
-        // 5) Cargar los items solicitados con su producto. Esto valida que el
-        // item existe, pertenece al pedido, y su producto requiere tracking.
+    /// <summary>
+    /// Caso degenerado: pedido sin items a canjear (solo VENTA / carbón / leña).
+    /// La transición y la auditoría se aplican igual; no abrimos transacción
+    /// porque no hay escrituras múltiples.
+    /// </summary>
+    private async Task<bool> ConfirmarSinCanjeAsync(
+        Pedido pedido, ulong estadoConfirmadoId, ulong? usuarioId, CancellationToken ct)
+    {
+        pedido.EstadoPedidoId = estadoConfirmadoId;
+        pedido.UpdatedAt = DateTime.UtcNow;
+        pedido.UpdatedBy = usuarioId;
+        await _context.SaveChangesAsync(ct);
+        return true;
+    }
+
+    /// <summary>
+    /// Carga los items solicitados con su producto. Esto valida que el
+    /// item existe y pertenece al pedido. Lanza si hay items faltantes.
+    /// </summary>
+    private async Task<List<PedidoItem>> LoadItemsParaCanjeAsync(
+        ulong pedidoId,
+        Dictionary<ulong, List<string>> codigosPorItem,
+        CancellationToken ct)
+    {
         var itemIds = codigosPorItem.Keys.ToList();
-
         var items = await _context.PedidoItems
             .AsNoTracking()
             .Include(i => i.Producto)
@@ -582,9 +659,16 @@ public class PedidoService : IPedidoService
                 $"Los siguientes items no pertenecen al pedido {pedidoId}: {string.Join(", ", faltantes)}.");
         }
 
-        // 6) Defensa en profundidad: el controller solo debería enviar items
-        // GARRAFA-capaces con tipo ENTREGA/DEVOLUCION. Rechequearlo acá
-        // protege contra requests hand-crafted.
+        return items;
+    }
+
+    /// <summary>
+    /// Defensa en profundidad: el controller solo debería enviar items
+    /// GARRAFA-capaces con tipo ENTREGA/DEVOLUCION. Rechequearlo acá
+    /// protege contra requests hand-crafted.
+    /// </summary>
+    private static void ValidarItemsSonGarrafaCanjeable(IEnumerable<PedidoItem> items)
+    {
         foreach (var item in items)
         {
             if (item.Producto is null || !item.Producto.ManejaGarrafaIndividual)
@@ -595,10 +679,16 @@ public class PedidoService : IPedidoService
                 throw new InvalidOperationException(
                     $"El item {item.Id} tiene tipo de línea {item.TipoLinea}; solo ENTREGA o DEVOLUCION participan en el canje.");
         }
+    }
 
-        // 7) Pre-validar TODOS los códigos antes de escribir nada. Cualquier
-        // falla hace throw sin tocar la BD. El primer código que falle aborta.
-        // Agrupamos por item para una sola lectura de garrafas por item.
+    /// <summary>
+    /// Normaliza los códigos físicos (trim, dedupe, descarte vacíos) y
+    /// valida que la cantidad coincida con la cantidad esperada del item.
+    /// </summary>
+    private static Dictionary<ulong, List<string>> NormalizarYValidarCodigos(
+        IEnumerable<PedidoItem> items,
+        Dictionary<ulong, List<string>> codigosPorItem)
+    {
         var codigosPorItemLimpios = new Dictionary<ulong, List<string>>(codigosPorItem.Count);
 
         foreach (var item in items)
@@ -620,113 +710,146 @@ public class PedidoService : IPedidoService
 
             var cantidadEsperada = (int)item.Cantidad;
             if (limpios.Count != cantidadEsperada)
-            {
                 throw new InvalidOperationException(
                     $"El item {item.Id} ({item.Producto!.Nombre}) esperaba {cantidadEsperada} código(s) y recibió {limpios.Count}.");
-            }
 
             codigosPorItemLimpios[item.Id] = limpios;
         }
 
-        // 8) Segunda pasada: validar cada código contra existencia, estado y
-        // cliente (en DEVOLUCION). Cargamos todas las garrafas en una sola query
-        // por item para no hacer N+1.
+        return codigosPorItemLimpios;
+    }
+
+    /// <summary>
+    /// Segunda pasada: valida cada código contra existencia, estado y
+    /// cliente (en DEVOLUCION). Carga todas las garrafas en una sola query
+    /// por item para no hacer N+1.
+    /// </summary>
+    private async Task ValidarCodigosContraInventarioAsync(
+        PedidoItem item, List<string> codigos, Pedido pedido, CancellationToken ct)
+    {
+        var garrafas = await _context.Garrafas
+            .AsNoTracking()
+            .Include(g => g.EstadoGarrafa)
+            .Where(g => codigos.Contains(g.Codigo))
+            .Select(g => new { g.Id, g.Codigo, g.EstadoGarrafaId, g.ClienteId, EstadoCodigo = g.EstadoGarrafa!.Codigo })
+            .ToListAsync(ct);
+
+        var encontrados = garrafas.ToDictionary(g => g.Codigo, g => g, StringComparer.Ordinal);
+
+        foreach (var codigo in codigos)
+        {
+            if (!encontrados.TryGetValue(codigo, out var garrafa))
+                throw new InvalidOperationException(
+                    $"El código '{codigo}' (item {item.Id}, {item.Producto!.Nombre}) no existe en el inventario de garrafas.");
+
+            ValidarCodigoContraReglasDeCanje(codigo, garrafa, item, pedido);
+        }
+    }
+
+    /// <summary>
+    /// Aplica las reglas de canje a un código físico: ENTREGA exige
+    /// LLENA_DEPOSITO, DEVOLUCION exige EN_CLIENTE y que la garrafa sea
+    /// del mismo cliente del pedido.
+    /// </summary>
+    private static void ValidarCodigoContraReglasDeCanje(
+        string codigo, dynamic garrafa, PedidoItem item, Pedido pedido)
+    {
+        if (item.TipoLinea == TipoLinea.ENTREGA)
+        {
+            if (garrafa.EstadoCodigo != GarrafaEstados.LlenaDeposito)
+                throw new InvalidOperationException(
+                    $"El código '{codigo}' no se puede entregar: está en estado {garrafa.EstadoCodigo}, se requiere {GarrafaEstados.LlenaDeposito}.");
+            return;
+        }
+
+        // DEVOLUCION
+        if (garrafa.EstadoCodigo != GarrafaEstados.EnCliente)
+            throw new InvalidOperationException(
+                $"El código '{codigo}' no se puede devolver: está en estado {garrafa.EstadoCodigo}, se requiere {GarrafaEstados.EnCliente}.");
+
+        if (garrafa.ClienteId != pedido.ClienteId)
+            throw new InvalidOperationException(
+                $"El código '{codigo}' no se puede devolver a este pedido: pertenece al cliente {garrafa.ClienteId}, no al cliente del pedido ({pedido.ClienteId}).");
+    }
+
+    /// <summary>
+    /// Aplica el canje delegando cada código en
+    /// <see cref="IGarrafaService.RegistrarMovimientoPorCanjeAsync"/> y
+    /// finalmente cambia el estado del pedido a CONFIRMADO.
+    /// </summary>
+    private async Task AplicarCanjeYConfirmarAsync(
+        List<PedidoItem> items,
+        Dictionary<ulong, List<string>> codigosPorItemLimpios,
+        ulong pedidoId,
+        Pedido pedido,
+        Dictionary<string, ulong> estadoIdByCodigo,
+        Dictionary<string, ulong> tipoMovimientoIdByCodigo,
+        ulong estadoConfirmadoId,
+        ulong? usuarioId,
+        CancellationToken ct)
+    {
         foreach (var item in items)
         {
             var codigos = codigosPorItemLimpios[item.Id];
-            var garrafas = await _context.Garrafas
-                .AsNoTracking()
-                .Include(g => g.EstadoGarrafa)
-                .Where(g => codigos.Contains(g.Codigo))
-                .Select(g => new { g.Id, g.Codigo, g.EstadoGarrafaId, g.ClienteId, EstadoCodigo = g.EstadoGarrafa!.Codigo })
-                .ToListAsync(ct);
+            var tipoMovimientoCodigo = item.TipoLinea == TipoLinea.ENTREGA
+                ? TipoMovimientoEntregaCliente
+                : TipoMovimientoDevolucionCliente;
 
-            var encontrados = garrafas.ToDictionary(g => g.Codigo, g => g, StringComparer.Ordinal);
+            var estadoDestinoCodigo = item.TipoLinea == TipoLinea.ENTREGA
+                ? GarrafaEstados.EnCliente
+                : GarrafaEstados.LlenaDeposito;
 
-            foreach (var codigo in codigos)
-            {
-                if (!encontrados.TryGetValue(codigo, out var garrafa))
-                    throw new InvalidOperationException(
-                        $"El código '{codigo}' (item {item.Id}, {item.Producto!.Nombre}) no existe en el inventario de garrafas.");
+            var estadoDestinoId = estadoIdByCodigo[estadoDestinoCodigo];
+            var clienteIdParaCanje = item.TipoLinea == TipoLinea.ENTREGA
+                ? (ulong?)pedido.ClienteId
+                : null;
 
-                if (item.TipoLinea == TipoLinea.ENTREGA)
-                {
-                    if (garrafa.EstadoCodigo != GarrafaEstados.LlenaDeposito)
-                        throw new InvalidOperationException(
-                            $"El código '{codigo}' no se puede entregar: está en estado {garrafa.EstadoCodigo}, se requiere {GarrafaEstados.LlenaDeposito}.");
-                }
-                else // DEVOLUCION
-                {
-                    if (garrafa.EstadoCodigo != GarrafaEstados.EnCliente)
-                        throw new InvalidOperationException(
-                            $"El código '{codigo}' no se puede devolver: está en estado {garrafa.EstadoCodigo}, se requiere {GarrafaEstados.EnCliente}.");
-
-                    if (garrafa.ClienteId != pedido.ClienteId)
-                        throw new InvalidOperationException(
-                            $"El código '{codigo}' no se puede devolver a este pedido: pertenece al cliente {garrafa.ClienteId}, no al cliente del pedido ({pedido.ClienteId}).");
-                }
-            }
+            await AplicarCanjeDeItemAsync(
+                codigos, pedidoId, tipoMovimientoCodigo,
+                estadoDestinoId, clienteIdParaCanje, usuarioId, ct);
         }
 
-        // 9) Todo validado. Transacción ambiente: o entran todos los
-        // movimientos + el cambio de estado del pedido, o no entra nada.
-        await using var transaction = await _context.Database.BeginTransactionAsync(ct);
+        pedido.EstadoPedidoId = estadoConfirmadoId;
+        pedido.UpdatedAt = DateTime.UtcNow;
+        pedido.UpdatedBy = usuarioId;
 
-        try
+        await _context.SaveChangesAsync(ct);
+    }
+
+    /// <summary>
+    /// Aplica los movimientos de canje de todos los códigos de un item.
+    /// Resuelve los IDs de las garrafas (con tracking) en una sola query
+    /// para evitar N+1 contra el servicio de garrafas.
+    /// </summary>
+    private async Task AplicarCanjeDeItemAsync(
+        List<string> codigos,
+        ulong pedidoId,
+        string tipoMovimientoCodigo,
+        ulong estadoDestinoId,
+        ulong? clienteIdParaCanje,
+        ulong? usuarioId,
+        CancellationToken ct)
+    {
+        // Volvemos a buscar la garrafa SIN AsNoTracking porque
+        // GarrafaService.RegistrarMovimientoPorCanjeAsync la va a mutar
+        // (ClienteId). La query anterior usó AsNoTracking solo para
+        // validar; acá la hacemos con tracking porque la mutación es
+        // nuestra.
+        var garrafasTracking = await _context.Garrafas
+            .Where(g => codigos.Contains(g.Codigo))
+            .ToDictionaryAsync(g => g.Codigo, g => g.Id, StringComparer.Ordinal, ct);
+
+        foreach (var codigo in codigos)
         {
-            foreach (var item in items)
-            {
-                var codigos = codigosPorItemLimpios[item.Id];
-                var tipoMovimientoCodigo = item.TipoLinea == TipoLinea.ENTREGA
-                    ? TipoMovimientoEntregaCliente
-                    : TipoMovimientoDevolucionCliente;
-
-                var estadoDestinoCodigo = item.TipoLinea == TipoLinea.ENTREGA
-                    ? GarrafaEstados.EnCliente
-                    : GarrafaEstados.LlenaDeposito;
-
-                var estadoDestinoId = estadoIdByCodigo[estadoDestinoCodigo];
-                var clienteIdParaCanje = item.TipoLinea == TipoLinea.ENTREGA
-                    ? (ulong?)pedido.ClienteId
-                    : null;
-
-                // Volvemos a buscar la garrafa SIN AsNoTracking porque
-                // GarrafaService.RegistrarMovimientoPorCanjeAsync la va a mutar
-                // (ClienteId). La query anterior usó AsNoTracking solo para
-                // validar; acá la hacemos con tracking porque la mutación es
-                // nuestra.
-                var codigoAGarrafaId = new Dictionary<string, ulong>(StringComparer.Ordinal);
-                var garrafasTracking = await _context.Garrafas
-                    .Where(g => codigos.Contains(g.Codigo))
-                    .ToDictionaryAsync(g => g.Codigo, g => g.Id, StringComparer.Ordinal, ct);
-
-                foreach (var codigo in codigos)
-                {
-                    var garrafaId = garrafasTracking[codigo];
-                    await _garrafaService.RegistrarMovimientoPorCanjeAsync(
-                        garrafaId,
-                        estadoDestinoId,
-                        clienteIdParaCanje,
-                        pedidoId,
-                        tipoMovimientoCodigo,
-                        usuarioId,
-                        ct);
-                }
-            }
-
-            pedido.EstadoPedidoId = estadoConfirmadoId;
-            pedido.UpdatedAt = DateTime.UtcNow;
-            pedido.UpdatedBy = usuarioId;
-
-            await _context.SaveChangesAsync(ct);
-            await transaction.CommitAsync(ct);
-
-            return true;
-        }
-        catch
-        {
-            await transaction.RollbackAsync(ct);
-            throw;
+            var garrafaId = garrafasTracking[codigo];
+            await _garrafaService.RegistrarMovimientoPorCanjeAsync(
+                garrafaId,
+                estadoDestinoId,
+                clienteIdParaCanje,
+                pedidoId,
+                tipoMovimientoCodigo,
+                usuarioId,
+                ct);
         }
     }
 

--- a/src/ExtraGasMVC/Services/Implementations/ProductoService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ProductoService.cs
@@ -83,33 +83,33 @@ public class ProductoService : IProductoService
         return _mapper.Map<IEnumerable<TipoProductoDto>>(tipos);
     }
 
-    public async Task<ProductoDto> CreateAsync(CreateProductoDto productoDto, ulong? usuarioId, CancellationToken ct = default)
+    public async Task<ProductoDto> CreateAsync(CreateProductoDto producto, ulong? usuarioId, CancellationToken ct = default)
     {
-        var producto = _mapper.Map<Producto>(productoDto);
-        producto.CreatedAt = DateTime.UtcNow;
-        producto.UpdatedAt = DateTime.UtcNow;
-        producto.CreatedBy = usuarioId;
-        producto.UpdatedBy = usuarioId;
-        
-        _context.Productos.Add(producto);
+        var entity = _mapper.Map<Producto>(producto);
+        entity.CreatedAt = DateTime.UtcNow;
+        entity.UpdatedAt = DateTime.UtcNow;
+        entity.CreatedBy = usuarioId;
+        entity.UpdatedBy = usuarioId;
+
+        _context.Productos.Add(entity);
         await _context.SaveChangesAsync(ct);
-        
-        return _mapper.Map<ProductoDto>(producto);
+
+        return _mapper.Map<ProductoDto>(entity);
     }
 
-    public async Task<ProductoDto> UpdateAsync(UpdateProductoDto productoDto, ulong? usuarioId, CancellationToken ct = default)
+    public async Task<ProductoDto> UpdateAsync(UpdateProductoDto producto, ulong? usuarioId, CancellationToken ct = default)
     {
-        var producto = await _context.Productos.FindAsync(new object[] { productoDto.Id }, ct);
-        if (producto == null)
-            throw new KeyNotFoundException($"Producto con Id {productoDto.Id} no encontrado.");
+        var entity = await _context.Productos.FindAsync(new object[] { producto.Id }, ct);
+        if (entity == null)
+            throw new KeyNotFoundException($"Producto con Id {producto.Id} no encontrado.");
 
-        _mapper.Map(productoDto, producto);
-        producto.UpdatedAt = DateTime.UtcNow;
-        producto.UpdatedBy = usuarioId;
-        
+        _mapper.Map(producto, entity);
+        entity.UpdatedAt = DateTime.UtcNow;
+        entity.UpdatedBy = usuarioId;
+
         await _context.SaveChangesAsync(ct);
-        
-        return _mapper.Map<ProductoDto>(producto);
+
+        return _mapper.Map<ProductoDto>(entity);
     }
 
     public async Task<bool> DeleteAsync(ulong id, CancellationToken ct = default)

--- a/src/ExtraGasMVC/Services/Implementations/ProveedorService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ProveedorService.cs
@@ -96,39 +96,39 @@ public class ProveedorService : IProveedorService
         };
     }
 
-    public async Task<ProveedorDto> CreateAsync(CreateProveedorDto proveedorDto, ulong? createdBy, CancellationToken ct = default)
+    public async Task<ProveedorDto> CreateAsync(CreateProveedorDto proveedor, ulong? createdBy, CancellationToken ct = default)
     {
-        if (!await IsCuitUniqueAsync(proveedorDto.Cuit, ct))
+        if (!await IsCuitUniqueAsync(proveedor.Cuit, ct))
             throw new InvalidOperationException("El CUIT ingresado ya está registrado.");
 
-        var proveedor = _mapper.Map<Proveedor>(proveedorDto);
-        proveedor.CreatedAt = DateTime.UtcNow;
-        proveedor.UpdatedAt = DateTime.UtcNow;
-        proveedor.CreatedBy = createdBy;
-        proveedor.UpdatedBy = createdBy;
-        
-        _context.Proveedores.Add(proveedor);
+        var entity = _mapper.Map<Proveedor>(proveedor);
+        entity.CreatedAt = DateTime.UtcNow;
+        entity.UpdatedAt = DateTime.UtcNow;
+        entity.CreatedBy = createdBy;
+        entity.UpdatedBy = createdBy;
+
+        _context.Proveedores.Add(entity);
         await _context.SaveChangesAsync(ct);
-        
-        return _mapper.Map<ProveedorDto>(proveedor);
+
+        return _mapper.Map<ProveedorDto>(entity);
     }
 
-    public async Task<ProveedorDto> UpdateAsync(ulong id, UpdateProveedorDto proveedorDto, ulong? updatedBy, CancellationToken ct = default)
+    public async Task<ProveedorDto> UpdateAsync(ulong id, UpdateProveedorDto proveedor, ulong? updatedBy, CancellationToken ct = default)
     {
-        var proveedor = await _context.Proveedores.FindAsync(new object[] { id }, ct);
-        if (proveedor == null)
+        var entity = await _context.Proveedores.FindAsync(new object[] { id }, ct);
+        if (entity == null)
             throw new KeyNotFoundException($"Proveedor con Id {id} no encontrado.");
 
-        if (!await IsCuitUniqueAsync(proveedorDto.Cuit, id, ct))
+        if (!await IsCuitUniqueAsync(proveedor.Cuit, id, ct))
             throw new InvalidOperationException("El CUIT ingresado ya está registrado.");
 
-        _mapper.Map(proveedorDto, proveedor);
-        proveedor.UpdatedAt = DateTime.UtcNow;
-        proveedor.UpdatedBy = updatedBy;
-        
+        _mapper.Map(proveedor, entity);
+        entity.UpdatedAt = DateTime.UtcNow;
+        entity.UpdatedBy = updatedBy;
+
         await _context.SaveChangesAsync(ct);
-        
-        return _mapper.Map<ProveedorDto>(proveedor);
+
+        return _mapper.Map<ProveedorDto>(entity);
     }
 
     public async Task<bool> DeleteAsync(ulong id, ulong? updatedBy, CancellationToken ct = default)

--- a/src/ExtraGasMVC/Services/Implementations/RecepcionService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/RecepcionService.cs
@@ -13,6 +13,12 @@ public class RecepcionService : IRecepcionService
 {
     private const string TipoMovimientoCompra = "COMPRA";
 
+    /// <summary>
+    /// Proyección mínima de Producto usada durante la validación previa al commit.
+    /// Evita arrastrar navegaciones ni columnas que no se necesitan en este flujo.
+    /// </summary>
+    private sealed record ProductoResumen(ulong Id, bool ManejaGarrafaIndividual, decimal? CapacidadKg, string Nombre);
+
     private readonly ExtraGasDbContext _context;
     private readonly IProductoService _productoService;
 
@@ -22,58 +28,19 @@ public class RecepcionService : IRecepcionService
         _productoService = productoService;
     }
 
-    public async Task<RecepcionDto> CreateAsync(CrearRecepcionDto input, ulong? usuarioId, CancellationToken ct = default)
+    public async Task<RecepcionDto> CreateAsync(CrearRecepcionDto dto, ulong? usuarioId, CancellationToken ct = default)
     {
-        if (input.Items is null || input.Items.Count == 0)
+        if (dto.Items is null || dto.Items.Count == 0)
             throw new InvalidOperationException("La recepción debe incluir al menos un item.");
 
         var empleadoId = await ResolverEmpleadoIdAsync(usuarioId, ct)
             ?? throw new InvalidOperationException(
                 "No se pudo resolver el operador: el usuario autenticado no tiene un empleado activo vinculado.");
 
-        var productoIds = input.Items.Select(i => i.ProductoId).Distinct().ToList();
-        var productoById = await _context.Productos.AsNoTracking()
-            .Where(p => productoIds.Contains(p.Id))
-            .Select(p => new { p.Id, p.ManejaGarrafaIndividual, p.CapacidadKg, p.Nombre })
-            .ToDictionaryAsync(p => p.Id, ct);
+        var productoById = await LoadProductosByIdAsync(dto.Items, ct);
+        var (estadoLlenaDepositoId, tipoCompraId) = await LoadCatalogosCompraAsync(ct);
 
-        var estadoLlenaDepositoId = await _context.EstadosGarrafa.AsNoTracking()
-            .Where(e => e.Codigo == GarrafaEstados.LlenaDeposito).Select(e => e.Id).FirstOrDefaultAsync(ct);
-        if (estadoLlenaDepositoId == 0) throw new InvalidOperationException("No se encontró el estado LLENA_DEPOSITO en el catálogo.");
-        var tipoCompraId = await _context.TiposMovimientoGarrafa.AsNoTracking()
-            .Where(t => t.Codigo == TipoMovimientoCompra).Select(t => t.Id).FirstOrDefaultAsync(ct);
-        if (tipoCompraId == 0) throw new InvalidOperationException("No se encontró el tipo de movimiento COMPRA en el catálogo.");
-
-        // Validaciones previas: cantidad==codigos, dedupe, codigo existente, capacidad.
-        foreach (var (item, idx) in input.Items.Select((it, i) => (it, i)))
-        {
-            if (!productoById.TryGetValue(item.ProductoId, out var producto))
-                throw new InvalidOperationException($"Item {idx + 1}: el producto {item.ProductoId} no existe o está inactivo.");
-            if (!producto.ManejaGarrafaIndividual) continue;
-
-            if (decimal.Truncate(item.Cantidad) != item.Cantidad)
-                throw new InvalidOperationException($"Item {idx + 1} ({producto.Nombre}): la cantidad debe ser entera para GARRAFA (recibido {item.Cantidad}).");
-
-            var esperado = (int)item.Cantidad;
-            var codigos = (item.CodigosGarrafa ?? new List<string>())
-                .Where(c => !string.IsNullOrWhiteSpace(c)).Select(c => c.Trim()).ToList();
-            if (esperado == 0 && codigos.Count == 0) continue;
-            if (esperado != codigos.Count)
-                throw new InvalidOperationException($"Item {idx + 1} ({producto.Nombre}): esperaba {esperado} código(s) y recibió {codigos.Count}.");
-
-            var dups = codigos.GroupBy(c => c, StringComparer.OrdinalIgnoreCase)
-                .Where(g => g.Count() > 1).Select(g => g.Key).ToList();
-            if (dups.Count > 0)
-                throw new InvalidOperationException($"Item {idx + 1} ({producto.Nombre}): código(s) duplicado(s): {string.Join(", ", dups)}.");
-
-            if (!producto.CapacidadKg.HasValue)
-                throw new InvalidOperationException($"Item {idx + 1} ({producto.Nombre}): el producto GARRAFA no tiene capacidad_kg definida.");
-
-            var existentes = await _context.Garrafas.IgnoreQueryFilters()
-                .Where(g => codigos.Contains(g.Codigo)).Select(g => g.Codigo).ToListAsync(ct);
-            if (existentes.Count > 0)
-                throw new InvalidOperationException($"Item {idx + 1} ({producto.Nombre}): código(s) ya existente(s): {string.Join(", ", existentes)}.");
-        }
+        await ValidarItemsPreCommitAsync(dto.Items, productoById, ct);
 
         await using var tx = await _context.Database.BeginTransactionAsync(ct);
         try
@@ -81,16 +48,16 @@ public class RecepcionService : IRecepcionService
             var now = DateTime.UtcNow;
             var recepcion = new RecepcionProveedor
             {
-                Fecha = input.Fecha, ProveedorId = input.ProveedorId, EmpleadoId = empleadoId,
-                NumeroFacturaProveedor = input.NumeroFacturaProveedor,
-                Subtotal = input.Subtotal, Descuento = input.Descuento, Total = input.Total,
-                Observaciones = input.Observaciones,
+                Fecha = dto.Fecha, ProveedorId = dto.ProveedorId, EmpleadoId = empleadoId,
+                NumeroFacturaProveedor = dto.NumeroFacturaProveedor,
+                Subtotal = dto.Subtotal, Descuento = dto.Descuento, Total = dto.Total,
+                Observaciones = dto.Observaciones,
                 CreatedAt = now, UpdatedAt = now, CreatedBy = usuarioId, UpdatedBy = usuarioId,
             };
             _context.RecepcionesProveedor.Add(recepcion);
             await _context.SaveChangesAsync(ct);   // trigger llena recepcion.Numero
 
-            foreach (var itemDto in input.Items)
+            foreach (var itemDto in dto.Items)
             {
                 _context.RecepcionItems.Add(new RecepcionItem
                 {
@@ -100,40 +67,10 @@ public class RecepcionService : IRecepcionService
                 });
                 await _context.SaveChangesAsync(ct);
 
-                var producto = productoById[itemDto.ProductoId];
-                if (!producto.ManejaGarrafaIndividual) continue;
-
-                var capacidad = (byte)decimal.Truncate(producto.CapacidadKg!.Value);
-                var codigosUnicos = (itemDto.CodigosGarrafa ?? new List<string>())
-                    .Where(c => !string.IsNullOrWhiteSpace(c)).Select(c => c.Trim())
-                    .Distinct(StringComparer.OrdinalIgnoreCase).ToList();
-
-                foreach (var codigo in codigosUnicos)
-                {
-                    _context.Garrafas.Add(new Garrafa
-                    {
-                        Codigo = codigo, CapacidadKg = capacidad,
-                        ProveedorId = recepcion.ProveedorId, RecepcionId = recepcion.Id,
-                        FechaCompra = DateOnly.FromDateTime(recepcion.Fecha),
-                        EstadoGarrafaId = estadoLlenaDepositoId, Activo = true,
-                        CreatedAt = now, UpdatedAt = now,
-                        CreatedBy = usuarioId, UpdatedBy = usuarioId,
-                    });
-                    Garrafa garrafa;
-                    try { await _context.SaveChangesAsync(ct); garrafa = _context.Garrafas.Local.Single(g => g.Codigo == codigo); }
-                    catch (DbUpdateException dbex) when (dbex.InnerException is MySqlException my && my.Number == 1062)
-                    { throw new InvalidOperationException($"Código duplicado detectado al guardar: {codigo}."); }
-
-                    _context.MovimientosGarrafa.Add(new MovimientoGarrafa
-                    {
-                        GarrafaId = garrafa.Id, Fecha = recepcion.Fecha,
-                        TipoMovimientoId = tipoCompraId, RecepcionId = recepcion.Id,
-                        EstadoOrigenId = estadoLlenaDepositoId, EstadoDestinoId = estadoLlenaDepositoId,
-                        EmpleadoId = empleadoId, Observaciones = $"Compra - {recepcion.Numero}",
-                        CreatedBy = usuarioId,
-                    });
-                    await _context.SaveChangesAsync(ct);
-                }
+                if (!productoById[itemDto.ProductoId].ManejaGarrafaIndividual) continue;
+                await CrearGarrafasYMovimientosAsync(
+                    itemDto, recepcion, empleadoId, usuarioId,
+                    productoById[itemDto.ProductoId], estadoLlenaDepositoId, tipoCompraId, ct);
             }
 
             await tx.CommitAsync(ct);
@@ -145,6 +82,190 @@ public class RecepcionService : IRecepcionService
             await tx.RollbackAsync(ct);
             throw;
         }
+    }
+
+    /// <summary>
+    /// Resuelve los IDs de productos del dto en una sola query y los devuelve
+    /// en un diccionario para evitar lookups repetidos en el bucle principal.
+    /// </summary>
+    private async Task<Dictionary<ulong, ProductoResumen>> LoadProductosByIdAsync(
+        IEnumerable<CrearRecepcionItemDto> items, CancellationToken ct)
+    {
+        var productoIds = items.Select(i => i.ProductoId).Distinct().ToList();
+        var rows = await _context.Productos.AsNoTracking()
+            .Where(p => productoIds.Contains(p.Id))
+            .Select(p => new ProductoResumen(p.Id, p.ManejaGarrafaIndividual, p.CapacidadKg, p.Nombre))
+            .ToListAsync(ct);
+        return rows.ToDictionary(p => p.Id);
+    }
+
+    /// <summary>
+    /// Resuelve los IDs del estado LLENA_DEPOSITO y del tipo de movimiento
+    /// COMPRA en una sola query cada uno. Falla rápido si faltan en el
+    /// catálogo — son lookups obligatorios para registrar la recepción.
+    /// </summary>
+    private async Task<(ulong estadoLlenaDepositoId, ulong tipoCompraId)> LoadCatalogosCompraAsync(CancellationToken ct)
+    {
+        var estadoLlenaDepositoId = await _context.EstadosGarrafa.AsNoTracking()
+            .Where(e => e.Codigo == GarrafaEstados.LlenaDeposito).Select(e => e.Id).FirstOrDefaultAsync(ct);
+        if (estadoLlenaDepositoId == 0)
+            throw new InvalidOperationException("No se encontró el estado LLENA_DEPOSITO en el catálogo.");
+
+        var tipoCompraId = await _context.TiposMovimientoGarrafa.AsNoTracking()
+            .Where(t => t.Codigo == TipoMovimientoCompra).Select(t => t.Id).FirstOrDefaultAsync(ct);
+        if (tipoCompraId == 0)
+            throw new InvalidOperationException("No se encontró el tipo de movimiento COMPRA en el catálogo.");
+
+        return (estadoLlenaDepositoId, tipoCompraId);
+    }
+
+    /// <summary>
+    /// Validaciones previas: cantidad==codigos, dedupe, codigo existente,
+    /// capacidad. Falla rápido (sin escribir nada) ante cualquier error.
+    /// </summary>
+    private async Task ValidarItemsPreCommitAsync(
+        IEnumerable<CrearRecepcionItemDto> items,
+        Dictionary<ulong, ProductoResumen> productoById,
+        CancellationToken ct)
+    {
+        foreach (var (item, idx) in items.Select((it, i) => (it, i)))
+        {
+            if (!productoById.TryGetValue(item.ProductoId, out var producto))
+                throw new InvalidOperationException($"Item {idx + 1}: el producto {item.ProductoId} no existe o está inactivo.");
+
+            if (!producto.ManejaGarrafaIndividual) continue;
+
+            ValidarCantidadEntera(item, producto, idx);
+            await ValidarCodigosGarrafaAsync(item, producto, idx, ct);
+        }
+    }
+
+    /// <summary>
+    /// Verifica que la cantidad sea entera para productos GARRAFA. La
+    /// comparación se hace contra el truncate explícito para no confundir
+    /// 2.0 (válido) con 2.5 (rechazado).
+    /// </summary>
+    private static void ValidarCantidadEntera(CrearRecepcionItemDto item, ProductoResumen producto, int idx)
+    {
+        if (decimal.Truncate(item.Cantidad) != item.Cantidad)
+            throw new InvalidOperationException(
+                $"Item {idx + 1} ({producto.Nombre}): la cantidad debe ser entera para GARRAFA (recibido {item.Cantidad}).");
+    }
+
+    /// <summary>
+    /// Validaciones específicas de items GARRAFA: cantidad vs códigos,
+    /// duplicados, capacidad_kg definida, códigos ya existentes en la BD.
+    /// </summary>
+    private async Task ValidarCodigosGarrafaAsync(
+        CrearRecepcionItemDto item, ProductoResumen producto, int idx, CancellationToken ct)
+    {
+        var esperado = (int)item.Cantidad;
+        var codigos = (item.CodigosGarrafa ?? new List<string>())
+            .Where(c => !string.IsNullOrWhiteSpace(c)).Select(c => c.Trim()).ToList();
+
+        if (esperado == 0 && codigos.Count == 0) return;
+        if (esperado != codigos.Count)
+            throw new InvalidOperationException(
+                $"Item {idx + 1} ({producto.Nombre}): esperaba {esperado} código(s) y recibió {codigos.Count}.");
+
+        var dups = codigos.GroupBy(c => c, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1).Select(g => g.Key).ToList();
+        if (dups.Count > 0)
+            throw new InvalidOperationException(
+                $"Item {idx + 1} ({producto.Nombre}): código(s) duplicado(s): {string.Join(", ", dups)}.");
+
+        if (!producto.CapacidadKg.HasValue)
+            throw new InvalidOperationException(
+                $"Item {idx + 1} ({producto.Nombre}): el producto GARRAFA no tiene capacidad_kg definida.");
+
+        var existentes = await _context.Garrafas.IgnoreQueryFilters()
+            .Where(g => codigos.Contains(g.Codigo)).Select(g => g.Codigo).ToListAsync(ct);
+        if (existentes.Count > 0)
+            throw new InvalidOperationException(
+                $"Item {idx + 1} ({producto.Nombre}): código(s) ya existente(s): {string.Join(", ", existentes)}.");
+    }
+
+    /// <summary>
+    /// Inserta una Garrafa + su MovimientoGarrafa de COMPRA por cada código
+    /// único del item. Asume que ya estamos dentro de la transacción del
+    /// caller (no abre una nueva).
+    /// </summary>
+    private async Task CrearGarrafasYMovimientosAsync(
+        CrearRecepcionItemDto itemDto,
+        RecepcionProveedor recepcion,
+        ulong empleadoId,
+        ulong? usuarioId,
+        ProductoResumen producto,
+        ulong estadoLlenaDepositoId,
+        ulong tipoCompraId,
+        CancellationToken ct)
+    {
+        var capacidad = (byte)decimal.Truncate(producto.CapacidadKg!.Value);
+        var codigosUnicos = (itemDto.CodigosGarrafa ?? new List<string>())
+            .Where(c => !string.IsNullOrWhiteSpace(c)).Select(c => c.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+        foreach (var codigo in codigosUnicos)
+            await CrearUnaGarrafaConSuMovimientoAsync(
+                codigo, capacidad, recepcion, empleadoId, usuarioId,
+                estadoLlenaDepositoId, tipoCompraId, ct);
+    }
+
+    /// <summary>
+    /// Inserta una sola garrafa y su movimiento de COMPRA atado a la
+    /// recepción. Captura el error 1062 de MySQL (duplicado) que se le haya
+    /// escapado a la validación previa y lo traduce a un mensaje claro.
+    /// </summary>
+    private async Task CrearUnaGarrafaConSuMovimientoAsync(
+        string codigo,
+        byte capacidad,
+        RecepcionProveedor recepcion,
+        ulong empleadoId,
+        ulong? usuarioId,
+        ulong estadoLlenaDepositoId,
+        ulong tipoCompraId,
+        CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        _context.Garrafas.Add(new Garrafa
+        {
+            Codigo = codigo,
+            CapacidadKg = capacidad,
+            ProveedorId = recepcion.ProveedorId,
+            RecepcionId = recepcion.Id,
+            FechaCompra = DateOnly.FromDateTime(recepcion.Fecha),
+            EstadoGarrafaId = estadoLlenaDepositoId,
+            Activo = true,
+            CreatedAt = now,
+            UpdatedAt = now,
+            CreatedBy = usuarioId,
+            UpdatedBy = usuarioId,
+        });
+
+        Garrafa garrafa;
+        try
+        {
+            await _context.SaveChangesAsync(ct);
+            garrafa = _context.Garrafas.Local.Single(g => g.Codigo == codigo);
+        }
+        catch (DbUpdateException dbex) when (dbex.InnerException is MySqlException my && my.Number == 1062)
+        {
+            throw new InvalidOperationException($"Código duplicado detectado al guardar: {codigo}.");
+        }
+
+        _context.MovimientosGarrafa.Add(new MovimientoGarrafa
+        {
+            GarrafaId = garrafa.Id,
+            Fecha = recepcion.Fecha,
+            TipoMovimientoId = tipoCompraId,
+            RecepcionId = recepcion.Id,
+            EstadoOrigenId = estadoLlenaDepositoId,
+            EstadoDestinoId = estadoLlenaDepositoId,
+            EmpleadoId = empleadoId,
+            Observaciones = $"Compra - {recepcion.Numero}",
+            CreatedBy = usuarioId,
+        });
+        await _context.SaveChangesAsync(ct);
     }
 
     public async Task<bool> ReversarAsync(ulong recepcionId, ulong? usuarioId, CancellationToken ct = default)

--- a/src/ExtraGasMVC/Services/Implementations/UsuarioService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/UsuarioService.cs
@@ -540,47 +540,84 @@ public class UsuarioService : IUsuarioService
 
     private async Task EnrichBatchAsync(List<UsuarioDto> dtos, List<Usuario> usuarios, CancellationToken ct)
     {
-        var auditUserIds = new HashSet<ulong>();
+        var auditUsers = await LoadAuditUsersAsync(usuarios, ct);
+        var empleadosByUsuarioId = await LoadEmpleadosByUsuarioIdAsync(dtos, ct);
 
+        foreach (var dto in dtos)
+        {
+            var usuario = usuarios.First(u => u.Id == dto.Id);
+            AplicarAudit(dto, usuario, auditUsers);
+            AplicarEmpleado(dto, empleadosByUsuarioId);
+        }
+    }
+
+    /// <summary>
+    /// Recolecta los IDs de CreatedBy/UpdatedBy de todos los usuarios y
+    /// devuelve un diccionario Id → Username para resolver auditores en
+    /// una sola query. Devuelve diccionario vacío si no hay IDs.
+    /// </summary>
+    private async Task<Dictionary<ulong, string>> LoadAuditUsersAsync(
+        IEnumerable<Usuario> usuarios, CancellationToken ct)
+    {
+        var auditUserIds = new HashSet<ulong>();
         foreach (var usuario in usuarios)
         {
             if (usuario.CreatedBy.HasValue) auditUserIds.Add(usuario.CreatedBy.Value);
             if (usuario.UpdatedBy.HasValue) auditUserIds.Add(usuario.UpdatedBy.Value);
         }
 
-        var auditUsers = auditUserIds.Count > 0
-            ? await _context.Usuarios
-                .AsNoTracking()
-                .IgnoreQueryFilters()
-                .Where(u => auditUserIds.Contains(u.Id))
-                .ToDictionaryAsync(u => u.Id, u => u.Username, ct)
-            : new Dictionary<ulong, string>();
+        if (auditUserIds.Count == 0) return new Dictionary<ulong, string>();
 
+        return await _context.Usuarios
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .Where(u => auditUserIds.Contains(u.Id))
+            .ToDictionaryAsync(u => u.Id, u => u.Username, ct);
+    }
+
+    /// <summary>
+    /// Devuelve los empleados vinculados a cada Usuario en un diccionario
+    /// UsuarioId → Empleado. Diccionario vacío si ningún usuario tiene
+    /// empleado vinculado.
+    /// </summary>
+    private async Task<Dictionary<ulong, Empleado>> LoadEmpleadosByUsuarioIdAsync(
+        IEnumerable<UsuarioDto> dtos, CancellationToken ct)
+    {
         var usuarioIds = dtos.Select(d => d.Id).ToList();
-        var empleados = usuarioIds.Count > 0
-            ? await _context.Empleados
-                .AsNoTracking()
-                .Where(e => e.UsuarioId.HasValue && usuarioIds.Contains(e.UsuarioId!.Value))
-                .ToListAsync(ct)
-            : new List<Empleado>();
+        if (usuarioIds.Count == 0) return new Dictionary<ulong, Empleado>();
 
-        var empleadosDict = empleados.ToDictionary(e => e.UsuarioId!.Value);
+        var empleados = await _context.Empleados
+            .AsNoTracking()
+            .Where(e => e.UsuarioId.HasValue && usuarioIds.Contains(e.UsuarioId!.Value))
+            .ToListAsync(ct);
 
-        foreach (var dto in dtos)
-        {
-            var usuario = usuarios.First(u => u.Id == dto.Id);
+        return empleados.ToDictionary(e => e.UsuarioId!.Value);
+    }
 
-            if (usuario.CreatedBy.HasValue && auditUsers.TryGetValue(usuario.CreatedBy.Value, out var creador))
-                dto.CreadoPor = creador;
+    /// <summary>
+    /// Copia el username del auditor (CreatedBy / UpdatedBy) en el DTO si
+    /// el auditor existe. Sin excepción si el auditor fue soft-deleted.
+    /// </summary>
+    private static void AplicarAudit(
+        UsuarioDto dto, Usuario usuario, IReadOnlyDictionary<ulong, string> auditUsers)
+    {
+        if (usuario.CreatedBy.HasValue && auditUsers.TryGetValue(usuario.CreatedBy.Value, out var creador))
+            dto.CreadoPor = creador;
 
-            if (usuario.UpdatedBy.HasValue && auditUsers.TryGetValue(usuario.UpdatedBy.Value, out var actualizador))
-                dto.ActualizadoPor = actualizador;
+        if (usuario.UpdatedBy.HasValue && auditUsers.TryGetValue(usuario.UpdatedBy.Value, out var actualizador))
+            dto.ActualizadoPor = actualizador;
+    }
 
-            if (empleadosDict.TryGetValue(dto.Id, out var empleado))
-            {
-                dto.EmpleadoId = empleado.Id;
-                dto.EmpleadoNombre = $"{empleado.Apellido}, {empleado.Nombre}";
-            }
-        }
+    /// <summary>
+    /// Copia el EmpleadoId y el nombre formateado del empleado vinculado
+    /// al Usuario. Sin excepción si el usuario no tiene empleado.
+    /// </summary>
+    private static void AplicarEmpleado(
+        UsuarioDto dto, IReadOnlyDictionary<ulong, Empleado> empleadosByUsuarioId)
+    {
+        if (!empleadosByUsuarioId.TryGetValue(dto.Id, out var empleado)) return;
+
+        dto.EmpleadoId = empleado.Id;
+        dto.EmpleadoNombre = $"{empleado.Apellido}, {empleado.Nombre}";
     }
 }

--- a/src/ExtraGasMVC/wwwroot/js/recepciones.js
+++ b/src/ExtraGasMVC/wwwroot/js/recepciones.js
@@ -167,25 +167,48 @@
     function validarCliente(items) {
         if (items.length === 0) return 'Debe agregar al menos un item antes de confirmar.';
         for (var i = 0; i < items.length; i++) {
-            var it = items[i];
-            if (!(it.cantidad > 0)) return 'Item ' + (i + 1) + ': la cantidad debe ser mayor a 0.';
-            if (it.precioUnitario < 0) return 'Item ' + (i + 1) + ': el precio unitario no puede ser negativo.';
-            if (it.manejaGarrafaIndividual) {
-                if (Math.trunc(it.cantidad) !== it.cantidad)
-                    return 'Item ' + (i + 1) + ' (' + it.productoNombre + '): la cantidad debe ser entera para GARRAFA.';
-                var esp = Math.trunc(it.cantidad);
-                if (esp !== it.codigosGarrafa.length)
-                    return 'Item ' + (i + 1) + ' (' + it.productoNombre + '): esperaba ' + esp + ' código(s) y recibió ' + it.codigosGarrafa.length + '.';
-                var seen = {}, dupes = [];
-                it.codigosGarrafa.forEach(function (c) {
-                    var k = c.toLowerCase();
-                    if (seen[k]) dupes.push(c); else seen[k] = true;
-                });
-                if (dupes.length > 0)
-                    return 'Item ' + (i + 1) + ' (' + it.productoNombre + '): códigos duplicados: ' + Array.from(new Set(dupes)).join(', ') + '.';
-            }
+            var msg = validarItem(items[i], i + 1);
+            if (msg !== null) return msg;
         }
         return null;
+    }
+
+    /// Devuelve un mensaje de error si el item no cumple las reglas del
+    /// formulario; null si está OK. Las reglas GARRAFA (cantidad entera,
+    /// cantidad vs códigos, dedupe) se aplican solo si el producto tiene
+    /// tracking individual.
+    function validarItem(it, idx) {
+        if (!(it.cantidad > 0)) return 'Item ' + idx + ': la cantidad debe ser mayor a 0.';
+        if (it.precioUnitario < 0) return 'Item ' + idx + ': el precio unitario no puede ser negativo.';
+        if (!it.manejaGarrafaIndividual) return null;
+        return validarCodigosGarrafa(it, idx);
+    }
+
+    /// Valida cantidad, conteo de códigos y duplicados para items GARRAFA.
+    function validarCodigosGarrafa(it, idx) {
+        if (Math.trunc(it.cantidad) !== it.cantidad)
+            return 'Item ' + idx + ' (' + it.productoNombre + '): la cantidad debe ser entera para GARRAFA.';
+
+        var esperado = Math.trunc(it.cantidad);
+        if (esperado !== it.codigosGarrafa.length)
+            return 'Item ' + idx + ' (' + it.productoNombre + '): esperaba ' + esperado + ' código(s) y recibió ' + it.codigosGarrafa.length + '.';
+
+        var dupes = duplicadosInsensitive(it.codigosGarrafa);
+        if (dupes.length > 0)
+            return 'Item ' + idx + ' (' + it.productoNombre + '): códigos duplicados: ' + dupes.join(', ') + '.';
+
+        return null;
+    }
+
+    /// Devuelve la lista de códigos duplicados (case-insensitive) sin repetir
+    /// el mismo duplicado en el resultado.
+    function duplicadosInsensitive(codigos) {
+        var seen = {}, dupes = [];
+        codigos.forEach(function (c) {
+            var k = c.toLowerCase();
+            if (seen[k]) dupes.push(c); else seen[k] = true;
+        });
+        return Array.from(new Set(dupes));
     }
 
     function resumenHtml(items, totales) {


### PR DESCRIPTION
Closes #97

Resolves all 25 CRITICAL issues tracked in issue #97 by refactoring affected code without changing behaviour.

## Summary
- Rename 16 parameters to match their interface contract (S927)
- Add 2 missing default values to GarrafaService.GetPagedAsync (S1006)
- Refactor 7 methods over the 15 cognitive complexity threshold (S3776):
  - MappingProfile constructor: 79 → ~1 (split by entity + extracted ForMember lambdas)
  - PedidoService.RegistrarCanjePedidoAsync: 60 → ~8 (one helper per numbered step)
  - RecepcionService.CreateAsync: 23 → ~5 (load + validate + create helpers)
  - PedidosController.CambiarEstado: 22 → ~6 (branch methods)
  - GarrafaService.GetPagedAsync: 19 → ~5 (extracted sort builder)
  - Program.cs top-level: 28 → ~6 (extracted setup helpers)
  - UsuarioService.EnrichBatchAsync: 17 → ~6 (extracted load + apply helpers)
  - recepciones.js validarCliente: 17 → ~3 (extracted validation helpers)

## Changes

| File | Change |
|------|--------|
| Controllers/PedidosController.cs | Extract branch helpers |
| Mappings/MappingProfile.cs | Split by entity + extract ForMember lambdas |
| Program.cs | Extract SMTP and ForwardedHeaders helpers |
| Services/Implementations/ClienteService.cs | Rename parameters |
| Services/Implementations/GarrafaService.cs | Rename + defaults + sort builder |
| Services/Implementations/PagoService.cs | Rename parameters |
| Services/Implementations/PedidoItemDto.cs | Rename + extract RegistrarCanje helpers (PedidoService) |
| Services/Implementations/ProductoService.cs | Rename parameters |
| Services/Implementations/ProveedorService.cs | Rename parameters |
| Services/Implementations/RecepcionService.cs | Rename + extract validation/create helpers |
| Services/Implementations/UsuarioService.cs | Extract audit/empleado helpers |
| wwwroot/js/recepciones.js | Extract validation helpers |

## Verification

- `dotnet build src/ExtraGasMVC` → 0 errors
- `dotnet test tests/ExtraGasMVC.Tests` → 33/33 passed
- `dotnet-sonarscanner` against sonarqube.elflacoseba.online (project extragas):
  - CRITICAL+BLOCKER open: 25 → 0
  - 36 historical CRITICAL issues all `FIXED`
- Behaviour preserved: no public API changes, only internal renames and extractions