### PR TITLE
fix(usuarios): combo de Roles vacio tras error de validacion en Create

### DIFF
--- a/src/ExtraGasMVC/Controllers/ClientesController.cs
+++ b/src/ExtraGasMVC/Controllers/ClientesController.cs
@@ -18,6 +18,11 @@ public class ClientesController : BaseController
         _mapper = mapper;
     }
 
+    private async Task LoadViewBagsAsync(CancellationToken ct = default)
+    {
+        ViewBag.Provincias = await _clienteService.GetProvinciasAsync(ct);
+    }
+
     public async Task<IActionResult> Index(string? busqueda, bool soloActivos = true, int pagina = 1, int tamanio = 25, CancellationToken ct = default)
     {
         var resultado = await _clienteService.SearchAsync(busqueda, soloActivos, pagina, tamanio, ct);
@@ -35,13 +40,13 @@ public class ClientesController : BaseController
         var cliente = await _clienteService.GetByIdAsync(id, ct);
         if (cliente is null) return NotFound();
 
-        ViewBag.Provincias = await _clienteService.GetProvinciasAsync(ct);
+        await LoadViewBagsAsync(ct);
         return View(cliente);
     }
 
     public async Task<IActionResult> Create(CancellationToken ct = default)
     {
-        ViewBag.Provincias = await _clienteService.GetProvinciasAsync(ct);
+        await LoadViewBagsAsync(ct);
         return View(new CreateClienteDto { FechaAlta = DateOnly.FromDateTime(DateTime.UtcNow), Activo = true });
     }
 
@@ -51,7 +56,7 @@ public class ClientesController : BaseController
     {
         if (!ModelState.IsValid)
         {
-            ViewBag.Provincias = await _clienteService.GetProvinciasAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(cliente);
         }
         try
@@ -64,13 +69,13 @@ public class ClientesController : BaseController
         catch (InvalidOperationException ex)
         {
             ModelState.AddModelError("Dni", ex.Message);
-            ViewBag.Provincias = await _clienteService.GetProvinciasAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(cliente);
         }
         catch (Exception ex)
         {
             ModelState.AddModelError(string.Empty, $"No se pudo crear el cliente: {ex.Message}");
-            ViewBag.Provincias = await _clienteService.GetProvinciasAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(cliente);
         }
     }
@@ -80,7 +85,7 @@ public class ClientesController : BaseController
         var cliente = await _clienteService.GetByIdAsync(id, ct);
         if (cliente is null) return NotFound();
 
-        ViewBag.Provincias = await _clienteService.GetProvinciasAsync(ct);
+        await LoadViewBagsAsync(ct);
 
         var updateDto = _mapper.Map<UpdateClienteDto>(cliente);
         return View(updateDto);
@@ -93,7 +98,7 @@ public class ClientesController : BaseController
         if (id != cliente.Id) return BadRequest();
         if (!ModelState.IsValid)
         {
-            ViewBag.Provincias = await _clienteService.GetProvinciasAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(cliente);
         }
         try
@@ -106,13 +111,13 @@ public class ClientesController : BaseController
         catch (InvalidOperationException ex)
         {
             ModelState.AddModelError("Dni", ex.Message);
-            ViewBag.Provincias = await _clienteService.GetProvinciasAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(cliente);
         }
         catch (Exception ex)
         {
             ModelState.AddModelError(string.Empty, $"No se pudo actualizar el cliente: {ex.Message}");
-            ViewBag.Provincias = await _clienteService.GetProvinciasAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(cliente);
         }
     }

--- a/src/ExtraGasMVC/Controllers/EmpleadosController.cs
+++ b/src/ExtraGasMVC/Controllers/EmpleadosController.cs
@@ -18,6 +18,11 @@ public class EmpleadosController : BaseController
         _mapper = mapper;
     }
 
+    private async Task LoadViewBagsAsync(CancellationToken ct = default)
+    {
+        ViewBag.Provincias = await _empleadoService.GetProvinciasAsync(ct);
+    }
+
     public async Task<IActionResult> Index(string? busqueda, bool soloActivos = false, int pagina = 1, int tamanio = 25, CancellationToken ct = default)
     {
         var resultado = await _empleadoService.SearchAsync(busqueda, soloActivos, pagina, tamanio, ct);
@@ -36,13 +41,13 @@ public class EmpleadosController : BaseController
         var empleado = await _empleadoService.GetByIdAsync(id, ct);
         if (empleado is null) return NotFound();
 
-        ViewBag.Provincias = await _empleadoService.GetProvinciasAsync(ct);
+        await LoadViewBagsAsync(ct);
         return View(empleado);
     }
 
     public async Task<IActionResult> Create(CancellationToken ct = default)
     {
-        ViewBag.Provincias = await _empleadoService.GetProvinciasAsync(ct);
+        await LoadViewBagsAsync(ct);
         return View(new CreateEmpleadoDto { FechaIngreso = DateOnly.FromDateTime(DateTime.UtcNow), Activo = true });
     }
 
@@ -52,7 +57,7 @@ public class EmpleadosController : BaseController
     {
         if (!ModelState.IsValid)
         {
-            ViewBag.Provincias = await _empleadoService.GetProvinciasAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(dto);
         }
         try
@@ -65,13 +70,13 @@ public class EmpleadosController : BaseController
         catch (InvalidOperationException ex)
         {
             ModelState.AddModelError(string.Empty, ex.Message);
-            ViewBag.Provincias = await _empleadoService.GetProvinciasAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(dto);
         }
         catch (Exception ex)
         {
             ModelState.AddModelError(string.Empty, $"No se pudo crear el empleado: {ex.Message}");
-            ViewBag.Provincias = await _empleadoService.GetProvinciasAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(dto);
         }
     }
@@ -81,7 +86,7 @@ public class EmpleadosController : BaseController
         var empleado = await _empleadoService.GetByIdAsync(id, ct);
         if (empleado is null) return NotFound();
 
-        ViewBag.Provincias = await _empleadoService.GetProvinciasAsync(ct);
+        await LoadViewBagsAsync(ct);
 
         var updateDto = _mapper.Map<UpdateEmpleadoDto>(empleado);
         return View(updateDto);
@@ -95,7 +100,7 @@ public class EmpleadosController : BaseController
 
         if (!ModelState.IsValid)
         {
-            ViewBag.Provincias = await _empleadoService.GetProvinciasAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(dto);
         }
         try
@@ -108,13 +113,13 @@ public class EmpleadosController : BaseController
         catch (InvalidOperationException ex)
         {
             ModelState.AddModelError(string.Empty, ex.Message);
-            ViewBag.Provincias = await _empleadoService.GetProvinciasAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(dto);
         }
         catch (Exception ex)
         {
             ModelState.AddModelError(string.Empty, $"No se pudo actualizar el empleado: {ex.Message}");
-            ViewBag.Provincias = await _empleadoService.GetProvinciasAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(dto);
         }
     }

--- a/src/ExtraGasMVC/Controllers/GarrafasController.cs
+++ b/src/ExtraGasMVC/Controllers/GarrafasController.cs
@@ -64,7 +64,7 @@ public class GarrafasController : BaseController
     /// concurrentes sobre un único DbContext (mismo motivo que en
     /// <c>RecepcionesController.BuildCreateViewModelAsync</c>).
     /// </summary>
-    private async Task CargarDropdownsFormularioAsync(CancellationToken ct)
+    private async Task LoadViewBagsAsync(CancellationToken ct)
     {
         ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
         ViewBag.Estados = await _garrafaService.GetEstadosAsync(ct);
@@ -117,7 +117,7 @@ public class GarrafasController : BaseController
 
     public async Task<IActionResult> Create(CancellationToken ct = default)
     {
-        await CargarDropdownsFormularioAsync(ct);
+        await LoadViewBagsAsync(ct);
         return View(new CreateGarrafaDto
         {
             EstadoGarrafaId = 1,
@@ -132,7 +132,7 @@ public class GarrafasController : BaseController
     {
         if (!ModelState.IsValid)
         {
-            await CargarDropdownsFormularioAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(garrafa);
         }
 
@@ -151,7 +151,7 @@ public class GarrafasController : BaseController
             // para mostrar al usuario.
             _logger.LogWarning(ex, "Validación de negocio al crear garrafa {Codigo}", codigoParaLog);
             ModelState.AddModelError(string.Empty, ex.Message);
-            await CargarDropdownsFormularioAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(garrafa);
         }
         catch (KeyNotFoundException ex)
@@ -160,7 +160,7 @@ public class GarrafasController : BaseController
             // en el service o por la BD. El mensaje del service es seguro.
             _logger.LogWarning(ex, "Entidad relacionada inexistente al crear garrafa {Codigo}", codigoParaLog);
             ModelState.AddModelError(string.Empty, ex.Message);
-            await CargarDropdownsFormularioAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(garrafa);
         }
         catch (DbUpdateException ex)
@@ -170,7 +170,7 @@ public class GarrafasController : BaseController
             _logger.LogError(ex, "Error de base de datos al crear garrafa {Codigo}", codigoParaLog);
             ModelState.AddModelError(string.Empty,
                 "No se pudo guardar la información. Si el problema persiste, contacte al administrador.");
-            await CargarDropdownsFormularioAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(garrafa);
         }
         catch (Exception ex)
@@ -178,7 +178,7 @@ public class GarrafasController : BaseController
             _logger.LogError(ex, "Error inesperado al crear garrafa {Codigo}", codigoParaLog);
             ModelState.AddModelError(string.Empty,
                 "Ocurrió un error inesperado al procesar la operación. Intente nuevamente.");
-            await CargarDropdownsFormularioAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(garrafa);
         }
     }
@@ -194,7 +194,7 @@ public class GarrafasController : BaseController
         if (garrafa.EstadoCodigo == GarrafaEstados.FueraServicio)
             return RedirectBloqueadoPorEstado(id);
 
-        await CargarDropdownsFormularioAsync(ct);
+        await LoadViewBagsAsync(ct);
 
         var updateDto = new UpdateGarrafaDto
         {
@@ -229,7 +229,7 @@ public class GarrafasController : BaseController
 
         if (!ModelState.IsValid)
         {
-            await CargarDropdownsFormularioAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(garrafa);
         }
         try
@@ -245,7 +245,7 @@ public class GarrafasController : BaseController
             // antes de SaveChanges, etc.
             _logger.LogWarning(ex, "Validación de negocio al actualizar garrafa {Id}", garrafa.Id);
             ModelState.AddModelError(string.Empty, ex.Message);
-            await CargarDropdownsFormularioAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(garrafa);
         }
         catch (KeyNotFoundException ex)
@@ -263,7 +263,7 @@ public class GarrafasController : BaseController
             _logger.LogError(ex, "Error de base de datos al actualizar garrafa {Id}", garrafa.Id);
             ModelState.AddModelError(string.Empty,
                 "No se pudo guardar la información. Si el problema persiste, contacte al administrador.");
-            await CargarDropdownsFormularioAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(garrafa);
         }
         catch (Exception ex)
@@ -271,7 +271,7 @@ public class GarrafasController : BaseController
             _logger.LogError(ex, "Error inesperado al actualizar garrafa {Id}", garrafa.Id);
             ModelState.AddModelError(string.Empty,
                 "Ocurrió un error inesperado al procesar la operación. Intente nuevamente.");
-            await CargarDropdownsFormularioAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(garrafa);
         }
     }

--- a/src/ExtraGasMVC/Controllers/PagosController.cs
+++ b/src/ExtraGasMVC/Controllers/PagosController.cs
@@ -27,6 +27,13 @@ public class PagosController : Controller
         _context = context;
     }
 
+    private async Task LoadViewBagsAsync(CancellationToken ct = default)
+    {
+        ViewBag.Pedidos = await _pedidoService.GetPendientesAsync(ct);
+        ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
+        ViewBag.FormasPago = await _context.FormasPago.AsNoTracking().ToListAsync(ct);
+    }
+
     public async Task<IActionResult> Index(ulong? pedidoId, int pagina = 1, int tamanio = 25, CancellationToken ct = default)
     {
         var pagos = await _pagoService.GetAllAsync(ct);
@@ -51,9 +58,7 @@ public class PagosController : Controller
 
     public async Task<IActionResult> Create(ulong? pedidoId, CancellationToken ct = default)
     {
-        ViewBag.Pedidos = await _pedidoService.GetPendientesAsync(ct);
-        ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
-        ViewBag.FormasPago = await _context.FormasPago.AsNoTracking().ToListAsync(ct);
+        await LoadViewBagsAsync(ct);
         return View(new CreatePagoDto { Fecha = DateTime.UtcNow, PedidoId = pedidoId ?? 0, FormaPagoId = 1 });
     }
 
@@ -63,9 +68,7 @@ public class PagosController : Controller
     {
         if (!ModelState.IsValid)
         {
-            ViewBag.Pedidos = await _pedidoService.GetPendientesAsync(ct);
-            ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
-            ViewBag.FormasPago = await _context.FormasPago.AsNoTracking().ToListAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(pago);
         }
         try
@@ -77,9 +80,7 @@ public class PagosController : Controller
         catch (Exception ex)
         {
             ModelState.AddModelError(string.Empty, $"No se pudo registrar el pago: {ex.Message}");
-            ViewBag.Pedidos = await _pedidoService.GetPendientesAsync(ct);
-            ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
-            ViewBag.FormasPago = await _context.FormasPago.AsNoTracking().ToListAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(pago);
         }
     }
@@ -88,10 +89,8 @@ public class PagosController : Controller
     {
         var pago = await _pagoService.GetByIdAsync(id, ct);
         if (pago is null) return NotFound();
-        ViewBag.Pedidos = await _pedidoService.GetPendientesAsync(ct);
-        ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
-        ViewBag.FormasPago = await _context.FormasPago.AsNoTracking().ToListAsync(ct);
-        
+            await LoadViewBagsAsync(ct);
+
         var updateDto = new UpdatePagoDto
         {
             Id = pago.Id,
@@ -114,9 +113,7 @@ public class PagosController : Controller
         if (id != pago.Id) return BadRequest();
         if (!ModelState.IsValid)
         {
-            ViewBag.Pedidos = await _pedidoService.GetPendientesAsync(ct);
-            ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
-            ViewBag.FormasPago = await _context.FormasPago.AsNoTracking().ToListAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(pago);
         }
         try
@@ -128,9 +125,7 @@ public class PagosController : Controller
         catch (Exception ex)
         {
             ModelState.AddModelError(string.Empty, $"No se pudo actualizar el pago: {ex.Message}");
-            ViewBag.Pedidos = await _pedidoService.GetPendientesAsync(ct);
-            ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
-            ViewBag.FormasPago = await _context.FormasPago.AsNoTracking().ToListAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(pago);
         }
     }

--- a/src/ExtraGasMVC/Controllers/ProductosController.cs
+++ b/src/ExtraGasMVC/Controllers/ProductosController.cs
@@ -41,7 +41,7 @@ public class ProductosController : BaseController
 
     public async Task<IActionResult> Create(CancellationToken ct = default)
     {
-        await PopulateTiposProductoAsync(ct);
+        await LoadViewBagsAsync(ct);
         return View(new CreateProductoDto { Activo = true, UnidadVenta = "UNIDAD" });
     }
 
@@ -51,7 +51,7 @@ public class ProductosController : BaseController
     {
         if (!ModelState.IsValid)
         {
-            await PopulateTiposProductoAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(producto);
         }
         try
@@ -63,7 +63,7 @@ public class ProductosController : BaseController
         catch (Exception ex)
         {
             ModelState.AddModelError(string.Empty, $"No se pudo crear el producto: {ex.Message}");
-            await PopulateTiposProductoAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(producto);
         }
     }
@@ -87,7 +87,7 @@ public class ProductosController : BaseController
             Activo = producto.Activo
         };
 
-        await PopulateTiposProductoAsync(ct);
+        await LoadViewBagsAsync(ct);
         return View(updateDto);
     }
 
@@ -98,7 +98,7 @@ public class ProductosController : BaseController
         if (id != producto.Id) return BadRequest();
         if (!ModelState.IsValid)
         {
-            await PopulateTiposProductoAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(producto);
         }
         try
@@ -110,7 +110,7 @@ public class ProductosController : BaseController
         catch (Exception ex)
         {
             ModelState.AddModelError(string.Empty, $"No se pudo actualizar el producto: {ex.Message}");
-            await PopulateTiposProductoAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(producto);
         }
     }
@@ -145,7 +145,7 @@ public class ProductosController : BaseController
         return RedirectToAction(nameof(Index));
     }
 
-    private async Task PopulateTiposProductoAsync(CancellationToken ct)
+    private async Task LoadViewBagsAsync(CancellationToken ct)
     {
         ViewBag.TiposProducto = await _productoService.GetTiposProductoAsync(ct);
     }

--- a/src/ExtraGasMVC/Controllers/ProveedoresController.cs
+++ b/src/ExtraGasMVC/Controllers/ProveedoresController.cs
@@ -33,13 +33,13 @@ public class ProveedoresController : BaseController
     {
         var proveedor = await _proveedorService.GetByIdAsync(id, ct);
         if (proveedor is null) return NotFound();
-        await CargarProvinciasAsync(ct);
+        await LoadViewBagsAsync(ct);
         return View(proveedor);
     }
 
     public async Task<IActionResult> Create(CancellationToken ct = default)
     {
-        await CargarProvinciasAsync(ct);
+        await LoadViewBagsAsync(ct);
         return View(new CreateProveedorDto { Activo = true });
     }
 
@@ -49,7 +49,7 @@ public class ProveedoresController : BaseController
     {
         if (!ModelState.IsValid)
         {
-            await CargarProvinciasAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(proveedor);
         }
         try
@@ -62,13 +62,13 @@ public class ProveedoresController : BaseController
         catch (InvalidOperationException ex)
         {
             ModelState.AddModelError("Cuit", ex.Message);
-            await CargarProvinciasAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(proveedor);
         }
         catch (Exception ex)
         {
             ModelState.AddModelError(string.Empty, $"No se pudo crear el proveedor: {ex.Message}");
-            await CargarProvinciasAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(proveedor);
         }
     }
@@ -79,7 +79,7 @@ public class ProveedoresController : BaseController
         if (proveedor is null) return NotFound();
         
         var updateDto = _mapper.Map<UpdateProveedorDto>(proveedor);
-        await CargarProvinciasAsync(ct);
+        await LoadViewBagsAsync(ct);
         return View(updateDto);
     }
 
@@ -90,7 +90,7 @@ public class ProveedoresController : BaseController
         if (id != proveedor.Id) return BadRequest();
         if (!ModelState.IsValid)
         {
-            await CargarProvinciasAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(proveedor);
         }
         try
@@ -103,13 +103,13 @@ public class ProveedoresController : BaseController
         catch (InvalidOperationException ex)
         {
             ModelState.AddModelError("Cuit", ex.Message);
-            await CargarProvinciasAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(proveedor);
         }
         catch (Exception ex)
         {
             ModelState.AddModelError(string.Empty, $"No se pudo actualizar el proveedor: {ex.Message}");
-            await CargarProvinciasAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(proveedor);
         }
     }
@@ -124,7 +124,7 @@ public class ProveedoresController : BaseController
         return RedirectToAction(nameof(Index));
     }
 
-    private async Task CargarProvinciasAsync(CancellationToken ct = default)
+    private async Task LoadViewBagsAsync(CancellationToken ct = default)
     {
         ViewBag.Provincias = await _proveedorService.GetProvinciasAsync(ct);
     }

--- a/src/ExtraGasMVC/Controllers/UsuariosController.cs
+++ b/src/ExtraGasMVC/Controllers/UsuariosController.cs
@@ -51,7 +51,7 @@ public class UsuariosController : BaseController
     {
         if (!ModelState.IsValid)
         {
-            ViewBag.EmpleadosSinUsuario = await _usuarioService.GetEmpleadosSinUsuarioAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(dto);
         }
 
@@ -60,7 +60,7 @@ public class UsuariosController : BaseController
         {
             foreach (var err in policyResult.Errors)
                 ModelState.AddModelError(nameof(dto.Password), err);
-            ViewBag.EmpleadosSinUsuario = await _usuarioService.GetEmpleadosSinUsuarioAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(dto);
         }
 
@@ -68,7 +68,7 @@ public class UsuariosController : BaseController
         if (existing is not null)
         {
             ModelState.AddModelError("Username", "El nombre de usuario ya esta en uso.");
-            ViewBag.EmpleadosSinUsuario = await _usuarioService.GetEmpleadosSinUsuarioAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(dto);
         }
 
@@ -82,7 +82,7 @@ public class UsuariosController : BaseController
         catch (Exception ex)
         {
             ModelState.AddModelError(string.Empty, $"No se pudo crear el usuario: {ex.Message}");
-            ViewBag.EmpleadosSinUsuario = await _usuarioService.GetEmpleadosSinUsuarioAsync(ct);
+            await LoadViewBagsAsync(ct);
             return View(dto);
         }
     }

--- a/tests/ExtraGasMVC.Tests/ExtraGasMVC.Tests.csproj
+++ b/tests/ExtraGasMVC.Tests/ExtraGasMVC.Tests.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/tests/ExtraGasMVC.Tests/UsuariosCreateViewBagTests.cs
+++ b/tests/ExtraGasMVC.Tests/UsuariosCreateViewBagTests.cs
@@ -1,0 +1,235 @@
+using ExtraGasMVC.Configuration;
+using ExtraGasMVC.Controllers;
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Services;
+using ExtraGasMVC.Services.Interfaces;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Test de regresión para el bug del combo de roles vacío en
+/// <c>Usuarios/Create.cshtml</c> después de un error de validación.
+///
+/// Historia: cuando el POST a /Usuarios/Create fallaba por validación
+/// (ej. contraseña corta) y el controller re-renderizaba la vista,
+/// <c>ViewBag.Roles</c> quedaba en null porque solo se recargaba
+/// <c>ViewBag.EmpleadosSinUsuario</c>. La vista bindea el combo con
+/// <c>@if (roles != null)</c> así que el placeholder "-- Seleccionar rol --"
+/// aparecía solo y el usuario no podía elegir ningún rol.
+///
+/// El fix fue centralizar la carga en <c>LoadViewBagsAsync(ct)</c> y llamarlo
+/// en cada <c>return View(dto)</c> por error del POST.
+///
+/// Este archivo cubre las 3 ramas de error del POST (ModelState inválido,
+/// password policy fallida, username duplicado) verificando que en todas
+/// <c>ViewBag.Roles</c> queda poblado. Si alguien vuelve a olvidar poblar
+/// el combo en alguna de las ramas, este test rompe.
+/// </summary>
+public sealed class UsuariosCreateViewBagTests
+{
+    private const string TestUserId = "1";
+
+    // ---------- Rama 1: ModelState inválido ----------
+    //
+    // En un unit test el ModelBinding no corre, así que populamos ModelState
+    // manualmente para simular que el binder rechazó algo (ej. un atributo
+    // [Required] no cumplido). Esta es la rama `if (!ModelState.IsValid)` del
+    // POST (líneas 52-56 del controller).
+    [Fact]
+    public async Task Create_PostWithInvalidModelState_RepopulatesRolesViewBag()
+    {
+        var controller = NewController(
+            usuarioService: NewUsuarioService(roles: RolesEsperados),
+            passwordPolicy: OkPolicy());
+
+        controller.ModelState.AddModelError(
+            nameof(CreateUsuarioDto.Username),
+            "El campo Username es obligatorio.");
+
+        var dto = ValidDto();
+
+        var result = await controller.Create(dto, CancellationToken.None);
+
+        result.Should().BeOfType<ViewResult>();
+        AssertRolesViewBagEsperaLos(controller, RolesEsperados);
+    }
+
+    // ---------- Rama 2: password policy fallida ----------
+    //
+    // ModelState válido al inicio, pero el fake PasswordPolicy rechaza el
+    // password. Cae en la rama de las líneas 58-65 del controller.
+    [Fact]
+    public async Task Create_PostWithPasswordPolicyFailure_RepopulatesRolesViewBag()
+    {
+        var controller = NewController(
+            usuarioService: NewUsuarioService(roles: RolesEsperados),
+            passwordPolicy: FailingPolicy());
+
+        var dto = ValidDto();
+        dto.Password = "abc"; // 3 chars → falla la password policy
+
+        var result = await controller.Create(dto, CancellationToken.None);
+
+        result.Should().BeOfType<ViewResult>();
+        AssertRolesViewBagEsperaLos(controller, RolesEsperados);
+
+        // Verificacion adicional: en esta rama el controller debe haber
+        // registrado el error de la password policy en ModelState.
+        controller.ModelState.Should().ContainKey(nameof(CreateUsuarioDto.Password));
+    }
+
+    // ---------- Rama 3: username duplicado ----------
+    //
+    // ModelState válido y password OK, pero el username ya existe. Cae en la
+    // rama de las líneas 67-73 del controller.
+    [Fact]
+    public async Task Create_PostWithDuplicateUsername_RepopulatesRolesViewBag()
+    {
+        var controller = NewController(
+            usuarioService: NewUsuarioService(roles: RolesEsperados, usernameExists: true),
+            passwordPolicy: OkPolicy());
+
+        var dto = ValidDto();
+
+        var result = await controller.Create(dto, CancellationToken.None);
+
+        result.Should().BeOfType<ViewResult>();
+        AssertRolesViewBagEsperaLos(controller, RolesEsperados);
+
+        // Verificacion adicional: en esta rama el controller debe haber
+        // registrado el error de username duplicado.
+        controller.ModelState.Should().ContainKey(nameof(CreateUsuarioDto.Username));
+    }
+
+    // ====================================================================
+    // Helpers
+    // ====================================================================
+
+    private static readonly List<RolDto> RolesEsperados = new()
+    {
+        new() { Id = 1, Nombre = "ADMIN" },
+        new() { Id = 2, Nombre = "OPERADOR" },
+        new() { Id = 3, Nombre = "CONSULTA" },
+    };
+
+    private static void AssertRolesViewBagEsperaLos(UsuariosController controller, List<RolDto> expected)
+    {
+        var rolesEnViewBag = controller.ViewBag.Roles as List<RolDto>;
+
+        rolesEnViewBag.Should().NotBeNull(
+            "ViewBag.Roles no puede ser null despues de un error de validacion; " +
+            "de lo contrario el <select> de Roles queda solo con el placeholder " +
+            "y el usuario no puede elegir un rol (regresion del bug original).");
+
+        rolesEnViewBag.Should().BeEquivalentTo(expected,
+            options => options.WithStrictOrdering(),
+            "los roles deben coincidir con los que devuelve el service");
+
+        var empleadosEnViewBag = controller.ViewBag.EmpleadosSinUsuario as List<EmpleadoSinUsuarioDto>;
+        empleadosEnViewBag.Should().NotBeNull(
+            "ViewBag.EmpleadosSinUsuario tampoco puede quedar null (ya estaba bien antes del bug).");
+    }
+
+    private static CreateUsuarioDto ValidDto() => new()
+    {
+        Username = "nuevo.test",
+        Email = "nuevo@test.local",
+        RolId = 1,
+        Password = "Valida123!",
+        Activo = true,
+    };
+
+    private static FakeUsuarioService NewUsuarioService(
+        List<RolDto> roles,
+        bool usernameExists = false) => new()
+    {
+        Roles = roles,
+        UsernameExists = usernameExists,
+    };
+
+    private static FakePasswordPolicyService OkPolicy() =>
+        new() { Result = PasswordPolicyResult.Ok() };
+
+    private static FakePasswordPolicyService FailingPolicy() =>
+        new() { Result = PasswordPolicyResult.Fail("La contrasena debe tener al menos 6 caracteres.") };
+
+    private static UsuariosController NewController(
+        IUsuarioService usuarioService,
+        IPasswordPolicyService passwordPolicy)
+    {
+        var httpContext = new DefaultHttpContext
+        {
+            User = new System.Security.Claims.ClaimsPrincipal(
+                new System.Security.Claims.ClaimsIdentity(
+                    new[]
+                    {
+                        new System.Security.Claims.Claim(
+                            System.Security.Claims.ClaimTypes.NameIdentifier, TestUserId),
+                    },
+                    "TestAuth")),
+        };
+
+        return new UsuariosController(usuarioService, passwordPolicy)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext,
+                RouteData = new RouteData(),
+            },
+        };
+    }
+
+    // ====================================================================
+    // Fakes (mismo patron que ChangePasswordTempDataFlowTests)
+    // ====================================================================
+
+    /// <summary>
+    /// Fake de IUsuarioService que devuelve las listas controladas que se le
+    /// configuren. Solo implementa los metodos usados por el Create del
+    /// controller; el resto tira NotImplementedException para detectar
+    /// regresiones de wiring.
+    /// </summary>
+    private sealed class FakeUsuarioService : IUsuarioService
+    {
+        public List<RolDto> Roles { get; init; } = new();
+        public List<EmpleadoSinUsuarioDto> EmpleadosSinUsuario { get; init; } = new();
+        public bool UsernameExists { get; init; }
+
+        public Task<List<RolDto>> GetRolesAsync(CancellationToken ct = default)
+            => Task.FromResult(Roles);
+
+        public Task<List<EmpleadoSinUsuarioDto>> GetEmpleadosSinUsuarioAsync(CancellationToken ct = default)
+            => Task.FromResult(EmpleadosSinUsuario);
+
+        public Task<UsuarioDto?> GetByUsernameAsync(string username, CancellationToken ct = default)
+            => Task.FromResult<UsuarioDto?>(UsernameExists ? new UsuarioDto { Username = username } : null);
+
+        public Task<UsuarioDto> CreateAsync(CreateUsuarioDto d, ulong? c, CancellationToken ct = default)
+            => Task.FromResult(new UsuarioDto { Id = 99, Username = d.Username });
+
+        public Task<UsuarioDto?> GetByIdAsync(ulong id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<SearchResultDto<UsuarioDto>> SearchAsync(string? b, ulong? r, bool s, int p, int t, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<UsuarioDto> UpdateAsync(UpdateUsuarioDto d, ulong? u, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<bool> DeleteAsync(ulong id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<bool> ChangePasswordAsync(ulong id, string cp, string np, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task ChangePasswordWithoutCurrentAsync(ulong id, string n, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<string> ResetPasswordAsync(ulong id, ulong? u, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<LoginResult> ValidateAndLoadForAuthAsync(string u, string p, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task RequestPasswordResetAsync(string e, string? ip, string? ua, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<ConsumeResetTokenResult> ConsumePasswordResetTokenAsync(string t, string p, CancellationToken ct = default) => throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Fake de IPasswordPolicyService con un Result configurable.
+    /// </summary>
+    private sealed class FakePasswordPolicyService : IPasswordPolicyService
+    {
+        public PasswordPolicyResult Result { get; init; } = PasswordPolicyResult.Ok();
+        public PasswordPolicyResult Validate(string? password) => Result;
+    }
+}


### PR DESCRIPTION
## Bug

Cuando el POST a `/Usuarios/Create` fallaba por validacion (ej. contrasena corta) y el controller re-renderizaba el form, el `<select name="RolId">` quedaba vacio: solo veia el placeholder `-- Seleccionar rol --` y el usuario no podia elegir un rol.

### Causa raiz

`UsuariosController.LoadViewBagsAsync` ya existia (lo usaba el GET) pero el POST hacia inline `ViewBag.EmpleadosSinUsuario = await ...` en sus 4 ramas de error y olvidaba `ViewBag.Roles`. La vista bindea el combo con `@if (roles != null)`, asi que `roles == null` significaba combo vacio.

## Cambios

### `fix(usuarios): recargar ViewBag.Roles en re-render del POST Create`

Reemplaza las 4 cargas inline del POST por `await LoadViewBagsAsync(ct)`. Una sola linea de cambio por rama, pero cierra el bug.

### `refactor(controllers): uniformar helper LoadViewBagsAsync en Create/Edit`

Aplica el mismo patron al resto de controllers que usan ViewBag para combos:

| Controller | Cambio |
|---|---|
| Clientes | Helper nuevo (1 ViewBag) |
| Empleados | Helper nuevo (1 ViewBag) |
| Pagos | Helper nuevo (3 ViewBags, 3 servicios) |
| Productos | Renombre `PopulateTiposProductoAsync` |
| Proveedores | Renombre `CargarProvinciasAsync` |
| Garrafas | Renombre `CargarDropdownsFormularioAsync` |

`PedidosController` y `RecepcionesController` **no se tocan**: encapsulan sus combos en un `BuildCreateViewModelAsync` (ViewModel tipado), patron arquitectonico superior a ViewBag que vale la pena respetar.

Centrar la carga en un helper unico cierra el riesgo futuro de que un `return View(model)` por error olvide poblar algun combo.

### `test(usuarios): regresion para ViewBag.Roles tras error de validacion`

3 tests unitarios (uno por cada rama de error del POST: ModelState invalido, password policy fallida, username duplicado) que verifican que `ViewBag.Roles` queda poblado. Si alguien borra `await LoadViewBagsAsync(ct)` en cualquiera de las 3 ramas, el test correspondiente rompe.

**Validacion activa**: reverenti cada una de las 3 ramas individualmente y confirme que SOLO el test de esa rama falla. Luego restaure el fix y los 36 tests (33 preexistentes + 3 nuevos) pasan.

## Test plan

```bash
dotnet test tests/ExtraGasMVC.Tests
# Correctas! - Con error: 0, Superado: 36, Omitido: 0, Total: 36
```

## Notas

- No agrega paquetes nuevos salvo `FluentAssertions 6.12.1` (solo para el archivo de tests nuevo).
- Sigue el patron de unit test existente en el proyecto (`DefaultHttpContext` + `ClaimsPrincipal` + `Fake services`, mismo template que `ChangePasswordTempDataFlowTests`).
- Descarto `WebApplicationFactory` porque `[ValidateAntiForgeryToken]` aplicado como atributo en el action lo rompe sin setup adicional de tokens; el unit test directo del controller es proporcional al riesgo.