### PR TITLE
feat(proveedores): higiene de validacion y tests baseline

### DIFF
--- a/src/ExtraGasMVC/DTOs/ProveedorDto.cs
+++ b/src/ExtraGasMVC/DTOs/ProveedorDto.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using ExtraGasMVC.Extensions;
 
 namespace ExtraGasMVC.DTOs;
 
@@ -34,7 +35,7 @@ public class CreateProveedorDto
 
     [Display(Name = "Razón social")]
     [Required(ErrorMessage = "La razón social es obligatoria.")]
-    [StringLength(200, ErrorMessage = "La razón social no puede superar {1} caracteres.")]
+    [StringLength(150, ErrorMessage = "La razón social no puede superar {1} caracteres.")]
     public string RazonSocial { get; set; } = null!;
 
     [Display(Name = "Nombre de fantasía")]
@@ -42,7 +43,7 @@ public class CreateProveedorDto
 
     [Display(Name = "CUIT")]
     [Required(ErrorMessage = "El CUIT es obligatorio.")]
-    [RegularExpression(@"^[0-9]{11}$", ErrorMessage = "El CUIT debe contener 11 dígitos numéricos.")]
+    [Cuit(ErrorMessage = "El CUIT debe contener 11 dígitos numéricos.")]
     public string Cuit { get; set; } = null!;
 
     [Display(Name = "Teléfono principal")]
@@ -108,7 +109,7 @@ public class UpdateProveedorDto
 
     [Display(Name = "Razón social")]
     [Required(ErrorMessage = "La razón social es obligatoria.")]
-    [StringLength(200, ErrorMessage = "La razón social no puede superar {1} caracteres.")]
+    [StringLength(150, ErrorMessage = "La razón social no puede superar {1} caracteres.")]
     public string RazonSocial { get; set; } = null!;
 
     [Display(Name = "Nombre de fantasía")]
@@ -116,7 +117,7 @@ public class UpdateProveedorDto
 
     [Display(Name = "CUIT")]
     [Required(ErrorMessage = "El CUIT es obligatorio.")]
-    [RegularExpression(@"^[0-9]{11}$", ErrorMessage = "El CUIT debe contener 11 dígitos numéricos.")]
+    [Cuit(ErrorMessage = "El CUIT debe contener 11 dígitos numéricos.")]
     public string Cuit { get; set; } = null!;
 
     [Display(Name = "Teléfono principal")]

--- a/src/ExtraGasMVC/Extensions/CuitAttribute.cs
+++ b/src/ExtraGasMVC/Extensions/CuitAttribute.cs
@@ -1,0 +1,120 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ExtraGasMVC.Extensions;
+
+/// <summary>
+/// Validación de CUIT argentino: combina verificación de formato (11 dígitos
+/// numéricos) y dígito verificador módulo 11, según el algoritmo que usa AFIP
+/// para la clave única de identificación tributaria.
+/// </summary>
+public static class CuitValidator
+{
+    /// <summary>
+    /// Multiplicadores del algoritmo módulo 11 aplicados, en orden, a los
+    /// primeros 10 dígitos del CUIT (de izquierda a derecha).
+    /// </summary>
+    private static readonly int[] Multiplicadores = { 5, 4, 3, 2, 7, 6, 5, 4, 3, 2 };
+
+    /// <summary>
+    /// Calcula el dígito verificador (posición 11) de un CUIT sin DV.
+    /// </summary>
+    /// <param name="cuitSinDv">CUIT de exactamente 10 dígitos numéricos, sin guiones.</param>
+    /// <returns>Dígito verificador (0-9).</returns>
+    /// <exception cref="ArgumentException">Si la entrada no tiene 10 dígitos.</exception>
+    public static int CalcularDigitoVerificador(string cuitSinDv)
+    {
+        if (string.IsNullOrEmpty(cuitSinDv) || cuitSinDv.Length != 10)
+            throw new ArgumentException("El CUIT sin DV debe tener exactamente 10 dígitos.", nameof(cuitSinDv));
+
+        int suma = 0;
+        for (int i = 0; i < 10; i++)
+        {
+            int digito = cuitSinDv[i] - '0';
+            if (digito < 0 || digito > 9)
+                throw new ArgumentException("El CUIT sin DV debe contener solo dígitos numéricos.", nameof(cuitSinDv));
+            suma += digito * Multiplicadores[i];
+        }
+
+        int resto = suma % 11;
+        return resto switch
+        {
+            0 => 0,
+            // AFIP define que para prefijo 20/23/24/25/26/27 con resto 1,
+            // el dígito verificador es 9 (es la convención más usada).
+            1 => 9,
+            _ => 11 - resto
+        };
+    }
+
+    /// <summary>
+    /// Valida un CUIT completo (11 dígitos con DV incluido, sin guiones ni espacios).
+    /// </summary>
+    /// <returns><c>true</c> cuando el formato y el dígito verificador son correctos.</returns>
+    public static bool EsValido(string? cuit)
+    {
+        if (string.IsNullOrWhiteSpace(cuit)) return false;
+        if (cuit.Length != 11) return false;
+
+        for (int i = 0; i < 11; i++)
+        {
+            int digito = cuit[i] - '0';
+            if (digito < 0 || digito > 9) return false;
+        }
+
+        int dv = cuit[10] - '0';
+        int dvCalculado = CalcularDigitoVerificador(cuit.Substring(0, 10));
+        return dv == dvCalculado;
+    }
+
+    /// <summary>
+    /// Genera un CUIT válido a partir de un prefijo (2 dígitos) y un DNI
+    /// (hasta 8 dígitos). Pensado solo para tests y seeds; no para producción
+    /// (en producción el CUIT lo emite AFIP).
+    /// </summary>
+    public static string Generar(int prefijo, long dni)
+    {
+        var prefijoStr = prefijo.ToString("D2");
+        var dniStr = dni.ToString("D8");
+        var sinDv = prefijoStr + dniStr;
+        var dv = CalcularDigitoVerificador(sinDv);
+        return $"{sinDv}{dv}";
+    }
+}
+
+/// <summary>
+/// Atributo de validación para ASP.NET MVC / DataAnnotations: aplica el
+/// algoritmo del CUIT argentino (formato + dígito verificador módulo 11).
+/// Si la cadena tiene un formato inválido, sobrescribe el mensaje con uno
+/// específico de "11 dígitos numéricos"; si el formato es correcto pero el
+/// DV está mal, lo sobrescribe con uno específico de "dígito verificador".
+/// El caso null/empty lo maneja <see cref="RequiredAttribute"/> por separado.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+public sealed class CuitAttribute : ValidationAttribute
+{
+    public override bool IsValid(object? value)
+    {
+        // El atributo NO se encarga del null/empty: RequiredAttribute es el
+        // responsable de obligar la presencia. Aquí solo validamos CUITs
+        // efectivamente presentes.
+        if (value is null) return true;
+        if (value is not string s) return false;
+        if (string.IsNullOrWhiteSpace(s)) return true;
+
+        if (s.Length != 11 || !s.All(char.IsDigit))
+        {
+            ErrorMessage = "El CUIT debe contener 11 dígitos numéricos.";
+            return false;
+        }
+
+        int dv = s[10] - '0';
+        int dvCalculado = CuitValidator.CalcularDigitoVerificador(s.Substring(0, 10));
+        if (dv != dvCalculado)
+        {
+            ErrorMessage = "El CUIT es inválido. Verifique el dígito verificador.";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/ExtraGasMVC/Extensions/ProveedorEditRules.cs
+++ b/src/ExtraGasMVC/Extensions/ProveedorEditRules.cs
@@ -1,0 +1,28 @@
+using ExtraGasMVC.Data.Entities;
+
+namespace ExtraGasMVC.Extensions;
+
+/// <summary>
+/// Reglas de edición de la entidad <see cref="Proveedor"/> centralizadas para
+/// poder testear sin DbContext. Hoy aplica una sola regla: la convención
+/// "doble flag acoplado" del módulo proveedores, donde <c>Activo</c> solo
+/// puede cambiar vía <c>Delete</c>, no vía <c>Edit</c>. Edit debe preservar
+/// el valor de BD para que el estado operacional no se desincronice.
+/// Si en el futuro se agregan más flags protegidos, este es el lugar.
+/// </summary>
+public static class ProveedorEditRules
+{
+    /// <summary>
+    /// Restaura los flags del proveedor que Edit tiene prohibido modificar.
+    /// Llamar DESPUÉS del AutoMapper, sobre la entity ya mergeada con el DTO.
+    /// </summary>
+    /// <param name="entity">Entity post-mapper con los valores del form aplicados.</param>
+    /// <param name="activoOriginal">Valor de <c>Activo</c> leído de la BD antes del mapper.</param>
+    public static void PreservarFlagsNoEditables(Proveedor entity, bool activoOriginal)
+    {
+        // REGLA DURA: el flag Activo solo cambia vía Delete. Si el operador
+        // lo destilda en el form de Edit, la edición silenciosamente no lo
+        // modifica. Para desactivar un proveedor hay que pasar por Delete.
+        entity.Activo = activoOriginal;
+    }
+}

--- a/src/ExtraGasMVC/Services/Implementations/ProveedorService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ProveedorService.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 using ExtraGasMVC.Data.Context;
 using ExtraGasMVC.Data.Entities;
 using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Extensions;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
@@ -101,9 +102,16 @@ public class ProveedorService : IProveedorService
         if (!await IsCuitUniqueAsync(proveedor.Cuit, id, ct))
             throw new InvalidOperationException("El CUIT ingresado ya está registrado.");
 
+        // Snapshot del flag Activo ANTES del AutoMapper: la regla "doble flag
+        // acoplado" prohíbe modificar Activo vía Edit (solo Delete lo cambia).
+        // Si el operador lo manda distinto en el form, lo restauramos sin
+        // lanzar excepción — más amigable que un 400.
+        var activoOriginal = entity.Activo;
+
         _mapper.Map(proveedor, entity);
         entity.UpdatedAt = DateTime.UtcNow;
         entity.UpdatedBy = updatedBy;
+        ProveedorEditRules.PreservarFlagsNoEditables(entity, activoOriginal);
 
         await _context.SaveChangesAsync(ct);
 

--- a/src/ExtraGasMVC/Views/Proveedores/Create.cshtml
+++ b/src/ExtraGasMVC/Views/Proveedores/Create.cshtml
@@ -42,9 +42,15 @@
                 </div>
                 <div class="col-md-3 d-flex align-items-end">
                     <div class="form-check">
-                        <input asp-for="Activo" class="form-check-input" type="checkbox" />
+                        <input asp-for="Activo" class="form-check-input" type="checkbox" disabled checked />
                         <label asp-for="Activo" class="form-check-label"></label>
                     </div>
+                </div>
+                <div class="col-12">
+                    <small class="text-secondary">
+                        <i class="bi bi-info-circle me-1"></i>
+                        Los proveedores nuevos nacen activos. Para desactivarlos, use <strong>Eliminar</strong> desde el listado.
+                    </small>
                 </div>
             </div>
             <h5 class="mt-4">Contacto</h5>

--- a/src/ExtraGasMVC/Views/Proveedores/Edit.cshtml
+++ b/src/ExtraGasMVC/Views/Proveedores/Edit.cshtml
@@ -43,9 +43,15 @@
                 </div>
                 <div class="col-md-3 d-flex align-items-end">
                     <div class="form-check">
-                        <input asp-for="Activo" class="form-check-input" type="checkbox" />
+                        <input asp-for="Activo" class="form-check-input" type="checkbox" disabled />
                         <label asp-for="Activo" class="form-check-label"></label>
                     </div>
+                </div>
+                <div class="col-12">
+                    <small class="text-secondary">
+                        <i class="bi bi-info-circle me-1"></i>
+                        El estado de activación se gestiona desde <strong>Eliminar</strong>; este formulario no lo modifica.
+                    </small>
                 </div>
             </div>
             <h5 class="mt-4">Contacto</h5>

--- a/tests/ExtraGasMVC.Tests/CuitValidatorTests.cs
+++ b/tests/ExtraGasMVC.Tests/CuitValidatorTests.cs
@@ -1,0 +1,200 @@
+using System.ComponentModel.DataAnnotations;
+using ExtraGasMVC.Extensions;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+public class CuitValidatorTests
+{
+    // ---------- CalcularDigitoVerificador ----------
+
+    [Fact]
+    public void CalcularDigitoVerificador_CuitCorto_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => CuitValidator.CalcularDigitoVerificador("123456789"));
+    }
+
+    [Fact]
+    public void CalcularDigitoVerificador_CuitLargo_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => CuitValidator.CalcularDigitoVerificador("123456789012"));
+    }
+
+    [Fact]
+    public void CalcularDigitoVerificador_ConLetras_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => CuitValidator.CalcularDigitoVerificador("12345678a0"));
+    }
+
+    [Fact]
+    public void CalcularDigitoVerificador_ConCeros_RetornaCero()
+    {
+        // prefijo 00 y DNI 00000000 → suma = 0 → resto = 0 → DV = 0
+        int dv = CuitValidator.CalcularDigitoVerificador("0000000000");
+        Assert.Equal(0, dv);
+    }
+
+    // ---------- EsValido ----------
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EsValido_NullOrWhitespace_False(string? input)
+    {
+        Assert.False(CuitValidator.EsValido(input));
+    }
+
+    [Theory]
+    [InlineData("1234567890")]   // 10 dígitos
+    [InlineData("123456789012")] // 12 dígitos
+    [InlineData("20-12345678-9")] // guiones
+    [InlineData("20 12345678 9")] // espacios
+    public void EsValido_FormatoInvalido_False(string input)
+    {
+        Assert.False(CuitValidator.EsValido(input));
+    }
+
+    [Theory]
+    [InlineData("12345678abc")]
+    [InlineData("20.123.456-9")]
+    [InlineData("abcdefghijk")]
+    public void EsValido_ConCaracteresNoNumericos_False(string input)
+    {
+        Assert.False(CuitValidator.EsValido(input));
+    }
+
+    [Fact]
+    public void EsValido_CuitGeneradoConDvCorrecto_True()
+    {
+        var cuit = CuitValidator.Generar(prefijo: 20, dni: 12345678);
+        Assert.True(CuitValidator.EsValido(cuit));
+    }
+
+    [Theory]
+    [InlineData(20)]
+    [InlineData(23)]
+    [InlineData(27)]
+    [InlineData(30)]
+    [InlineData(33)]
+    [InlineData(34)]
+    public void EsValido_VariosPrefijos_True(int prefijo)
+    {
+        var cuit = CuitValidator.Generar(prefijo, dni: 12345678);
+        Assert.True(CuitValidator.EsValido(cuit));
+    }
+
+    [Fact]
+    public void EsValido_DvIncorrecto_False()
+    {
+        var valido = CuitValidator.Generar(prefijo: 20, dni: 12345678);
+        var dvOriginal = valido[10] - '0';
+        var dvAlterado = (dvOriginal + 1) % 10;
+        var cuitAlterado = valido.Substring(0, 10) + dvAlterado;
+
+        Assert.False(CuitValidator.EsValido(cuitAlterado));
+    }
+
+    // ---------- Generar ----------
+
+    [Fact]
+    public void Generar_PrefijoInvalido_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => CuitValidator.Generar(prefijo: 200, dni: 12345678));
+    }
+
+    [Fact]
+    public void Generar_ResultadoTiene11Digitos()
+    {
+        var cuit = CuitValidator.Generar(prefijo: 20, dni: 12345678);
+        Assert.Equal(11, cuit.Length);
+        Assert.True(cuit.All(char.IsDigit));
+    }
+
+    [Fact]
+    public void Generar_ResultadoEsValido()
+    {
+        var cuit = CuitValidator.Generar(prefijo: 30, dni: 76543210);
+        Assert.True(CuitValidator.EsValido(cuit));
+    }
+
+    [Fact]
+    public void Generar_DnisDiferentes_ResultadosDiferentes()
+    {
+        var a = CuitValidator.Generar(prefijo: 20, dni: 10000000);
+        var b = CuitValidator.Generar(prefijo: 20, dni: 10000001);
+        Assert.NotEqual(a, b);
+    }
+
+    // ---------- CuitAttribute (integración con DataAnnotations) ----------
+
+    private sealed class Holder
+    {
+        [Cuit]
+        public string? Cuit { get; set; }
+    }
+
+    [Fact]
+    public void Atributo_Null_NoAgregaError()
+    {
+        var holder = new Holder { Cuit = null };
+        var ctx = new ValidationContext(holder);
+        var results = new List<ValidationResult>();
+        Validator.TryValidateObject(holder, ctx, results, validateAllProperties: true);
+        // [Cuit] no se queja de null (lo cubre [Required]); no hay [Required] acá.
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Atributo_Vacio_NoAgregaError_RequiredEsElResponsable()
+    {
+        // El atributo Cuit solo valida CUITs presentes. El "vacio" lo cubre Required.
+        var attr = new CuitAttribute();
+        Assert.True(attr.IsValid(string.Empty));
+        Assert.True(attr.IsValid("   "));
+    }
+
+    [Fact]
+    public void Atributo_FormatoInvalido_MensajeEspecificoDeFormato()
+    {
+        var attr = new CuitAttribute();
+        Assert.False(attr.IsValid("12345"));
+        Assert.Equal("El CUIT debe contener 11 dígitos numéricos.", attr.ErrorMessage);
+    }
+
+    [Fact]
+    public void Atributo_ConLetras_MensajeDeFormato()
+    {
+        var attr = new CuitAttribute();
+        Assert.False(attr.IsValid("20a12345678"));
+        Assert.Equal("El CUIT debe contener 11 dígitos numéricos.", attr.ErrorMessage);
+    }
+
+    [Fact]
+    public void Atributo_DvIncorrecto_MensajeDeDv()
+    {
+        var attr = new CuitAttribute();
+        var valido = CuitValidator.Generar(prefijo: 20, dni: 12345678);
+        var dvOriginal = valido[10] - '0';
+        var dvAlterado = (dvOriginal + 1) % 10;
+        var cuitAlterado = valido.Substring(0, 10) + dvAlterado;
+
+        Assert.False(attr.IsValid(cuitAlterado));
+        Assert.Equal("El CUIT es inválido. Verifique el dígito verificador.", attr.ErrorMessage);
+    }
+
+    [Fact]
+    public void Atributo_CuitValido_SinError()
+    {
+        var attr = new CuitAttribute();
+        var cuit = CuitValidator.Generar(prefijo: 20, dni: 12345678);
+        Assert.True(attr.IsValid(cuit));
+    }
+
+    [Fact]
+    public void Atributo_NoString_False()
+    {
+        var attr = new CuitAttribute();
+        Assert.False(attr.IsValid(123));
+    }
+}

--- a/tests/ExtraGasMVC.Tests/ProveedorDtoValidationTests.cs
+++ b/tests/ExtraGasMVC.Tests/ProveedorDtoValidationTests.cs
@@ -1,0 +1,203 @@
+using System.ComponentModel.DataAnnotations;
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Extensions;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Tests de DataAnnotations sobre los DTOs del módulo Proveedores.
+/// Cubren las restricciones que el operador puede romper: CUIT con formato
+/// inválido, razón social de más de 150 caracteres (B2), campos requeridos
+/// vacíos, etc. La idea es fijar las reglas y detectar regresiones si alguien
+/// cambia un atributo accidentalmente.
+/// </summary>
+public class ProveedorDtoValidationTests
+{
+    private static IList<ValidationResult> Validar(object dto)
+    {
+        var ctx = new ValidationContext(dto);
+        var results = new List<ValidationResult>();
+        Validator.TryValidateObject(dto, ctx, results, validateAllProperties: true);
+        return results;
+    }
+
+    private static CreateProveedorDto ProveedorValido() => new()
+    {
+        Codigo = "PROV-001",
+        RazonSocial = "Shell Argentina S.A.",
+        NombreFantasia = "Shell",
+        Cuit = CuitValidator.Generar(prefijo: 30, dni: 12345678),
+        TelefonoPrincipal = "1141234567",
+        Email = "shell@example.com",
+        Calle = "Av. Corrientes",
+        Numero = "1234",
+        Ciudad = "CABA",
+        ProvinciaId = 1,
+    };
+
+    // ---------- CreateProveedorDto ----------
+
+    [Fact]
+    public void CreateProveedorDto_ConDatosValidos_NoTieneErrores()
+    {
+        var errors = Validar(ProveedorValido());
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void CreateProveedorDto_SinRazonSocial_TieneErrorDeRequired()
+    {
+        var dto = ProveedorValido();
+        dto.RazonSocial = "";
+
+        var errors = Validar(dto);
+
+        Assert.Contains(errors, e => e.MemberNames.Contains(nameof(CreateProveedorDto.RazonSocial)));
+    }
+
+    [Fact]
+    public void CreateProveedorDto_RazonSocialDeMasDe150Caracteres_TieneErrorDeLength()
+    {
+        var dto = ProveedorValido();
+        dto.RazonSocial = new string('A', 151);
+
+        var errors = Validar(dto);
+
+        Assert.Contains(errors, e =>
+            e.MemberNames.Contains(nameof(CreateProveedorDto.RazonSocial))
+            && e.ErrorMessage!.Contains("150"));
+    }
+
+    [Fact]
+    public void CreateProveedorDto_RazonSocialDe150Caracteres_NoTieneError()
+    {
+        // Borde superior: 150 chars es válido.
+        var dto = ProveedorValido();
+        dto.RazonSocial = new string('A', 150);
+
+        var errors = Validar(dto);
+
+        Assert.DoesNotContain(errors, e => e.MemberNames.Contains(nameof(CreateProveedorDto.RazonSocial)));
+    }
+
+    [Fact]
+    public void CreateProveedorDto_SinCuit_TieneErrorDeRequired()
+    {
+        var dto = ProveedorValido();
+        dto.Cuit = "";
+
+        var errors = Validar(dto);
+
+        Assert.Contains(errors, e => e.MemberNames.Contains(nameof(CreateProveedorDto.Cuit)));
+    }
+
+    [Fact]
+    public void CreateProveedorDto_CuitConFormatoInvalido_TieneErrorDeFormato()
+    {
+        var dto = ProveedorValido();
+        dto.Cuit = "20-12345678-9"; // con guiones
+
+        var errors = Validar(dto);
+
+        Assert.Contains(errors, e =>
+            e.MemberNames.Contains(nameof(CreateProveedorDto.Cuit))
+            && e.ErrorMessage!.Contains("11 dígitos"));
+    }
+
+    [Fact]
+    public void CreateProveedorDto_CuitConDvMal_TieneErrorDeDv()
+    {
+        var dto = ProveedorValido();
+        var cuitValido = CuitValidator.Generar(prefijo: 20, dni: 12345678);
+        var dvOriginal = cuitValido[10] - '0';
+        var dvAlterado = (dvOriginal + 1) % 10;
+        dto.Cuit = cuitValido.Substring(0, 10) + dvAlterado;
+
+        var errors = Validar(dto);
+
+        Assert.Contains(errors, e =>
+            e.MemberNames.Contains(nameof(CreateProveedorDto.Cuit))
+            && e.ErrorMessage!.Contains("dígito verificador"));
+    }
+
+    [Fact]
+    public void CreateProveedorDto_CuitValido_NoTieneErrorDeCuit()
+    {
+        var dto = ProveedorValido();
+        dto.Cuit = CuitValidator.Generar(prefijo: 33, dni: 76543210);
+
+        var errors = Validar(dto);
+
+        Assert.DoesNotContain(errors, e => e.MemberNames.Contains(nameof(CreateProveedorDto.Cuit)));
+    }
+
+    [Fact]
+    public void CreateProveedorDto_EmailInvalido_TieneErrorDeFormato()
+    {
+        var dto = ProveedorValido();
+        dto.Email = "no-es-un-email";
+
+        var errors = Validar(dto);
+
+        Assert.Contains(errors, e => e.MemberNames.Contains(nameof(CreateProveedorDto.Email)));
+    }
+
+    // ---------- UpdateProveedorDto (mismo contrato de validación) ----------
+
+    [Fact]
+    public void UpdateProveedorDto_ConDatosValidos_NoTieneErrores()
+    {
+        var dto = new UpdateProveedorDto
+        {
+            Id = 1,
+            RazonSocial = "YPF S.A.",
+            Cuit = CuitValidator.Generar(prefijo: 30, dni: 87654321),
+        };
+
+        var errors = Validar(dto);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void UpdateProveedorDto_RazonSocialDeMasDe150Caracteres_TieneErrorDeLength()
+    {
+        // Regresión B2: si alguien vuelve a poner [StringLength(200)], este test rompe.
+        var dto = new UpdateProveedorDto
+        {
+            Id = 1,
+            RazonSocial = new string('B', 200),
+            Cuit = CuitValidator.Generar(prefijo: 30, dni: 11111111),
+        };
+
+        var errors = Validar(dto);
+
+        Assert.Contains(errors, e =>
+            e.MemberNames.Contains(nameof(UpdateProveedorDto.RazonSocial))
+            && e.ErrorMessage!.Contains("150"));
+    }
+
+    [Fact]
+    public void UpdateProveedorDto_CuitConDvMal_TieneErrorDeDv()
+    {
+        var cuitValido = CuitValidator.Generar(prefijo: 20, dni: 12345678);
+        var dvOriginal = cuitValido[10] - '0';
+        var dvAlterado = (dvOriginal + 1) % 10;
+        var cuitAlterado = cuitValido.Substring(0, 10) + dvAlterado;
+
+        var dto = new UpdateProveedorDto
+        {
+            Id = 1,
+            RazonSocial = "Proveedor Test",
+            Cuit = cuitAlterado,
+        };
+
+        var errors = Validar(dto);
+
+        Assert.Contains(errors, e =>
+            e.MemberNames.Contains(nameof(UpdateProveedorDto.Cuit))
+            && e.ErrorMessage!.Contains("dígito verificador"));
+    }
+}

--- a/tests/ExtraGasMVC.Tests/ProveedorEditRulesTests.cs
+++ b/tests/ExtraGasMVC.Tests/ProveedorEditRulesTests.cs
@@ -1,0 +1,87 @@
+using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.Extensions;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Tests de la regla "doble flag acoplado" del módulo Proveedores.
+/// Garantizan que <see cref="ProveedorEditRules.PreservarFlagsNoEditables"/>
+/// impone la convención: <c>Activo</c> solo cambia vía Delete, no vía Edit,
+/// evitando la desincronización entre los flags Activo y DeletedAt.
+/// </summary>
+public class ProveedorEditRulesTests
+{
+    [Fact]
+    public void PreservarFlags_ConActivoOriginalTrue_YEntityFalse_LoRestauraATrue()
+    {
+        // Escena: operador edita un proveedor activo y destilda la casilla Activo.
+        // El AutoMapper aplicó el DTO → entity.Activo = false. La regla dura
+        // tiene que restaurar el valor de BD.
+        var entity = new Proveedor
+        {
+            Id = 1,
+            RazonSocial = "Shell",
+            Cuit = "30123456780",
+            Activo = false, // valor que dejó el AutoMapper
+        };
+
+        ProveedorEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true);
+
+        Assert.True(entity.Activo);
+    }
+
+    [Fact]
+    public void PreservarFlags_ConActivoOriginalFalse_YEntityTrue_LoRestauraAFalse()
+    {
+        // Caso inverso: editar un proveedor inactivo y "re-activarlo" desde
+        // el form no debe funcionar. Solo Delete puede hacerlo.
+        var entity = new Proveedor
+        {
+            Id = 1,
+            RazonSocial = "Shell",
+            Cuit = "30123456780",
+            Activo = true,
+        };
+
+        ProveedorEditRules.PreservarFlagsNoEditables(entity, activoOriginal: false);
+
+        Assert.False(entity.Activo);
+    }
+
+    [Fact]
+    public void PreservarFlags_ConMismoValor_NoCambia()
+    {
+        // El caso "feliz": operador edita y deja Activo como estaba.
+        var entity = new Proveedor
+        {
+            Id = 1,
+            RazonSocial = "Shell",
+            Cuit = "30123456780",
+            Activo = true,
+        };
+
+        ProveedorEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true);
+
+        Assert.True(entity.Activo);
+    }
+
+    [Fact]
+    public void PreservarFlags_NoTocaOtrosCampos()
+    {
+        // La regla solo afecta Activo. Verifica que no se carga campos que
+        // el form sí tiene permitido editar (ej. RazonSocial).
+        var entity = new Proveedor
+        {
+            Id = 1,
+            RazonSocial = "Nuevo nombre",
+            Cuit = "30123456780",
+            Activo = true,
+        };
+
+        ProveedorEditRules.PreservarFlagsNoEditables(entity, activoOriginal: false);
+
+        Assert.False(entity.Activo);
+        Assert.Equal("Nuevo nombre", entity.RazonSocial); // quedó como el form lo mandó
+    }
+}

--- a/tests/ExtraGasMVC.Tests/ProveedoresControllerCreateViewBagTests.cs
+++ b/tests/ExtraGasMVC.Tests/ProveedoresControllerCreateViewBagTests.cs
@@ -1,0 +1,181 @@
+using AutoMapper;
+using ExtraGasMVC.Controllers;
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Mappings;
+using ExtraGasMVC.Services.Interfaces;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Tests de regresión del módulo ProveedoresController.
+/// Verifican que las pantallas Create (GET/POST) y Details cargan
+/// <c>ViewBag.Provincias</c> en TODAS las ramas de ejecución. Si alguien
+/// borra un <c>LoadViewBagsAsync(ct)</c> en alguna rama de error del POST,
+/// el dropdown de Provincia en el re-render queda vacío y el operador
+/// no puede editar.
+/// </summary>
+public class ProveedoresControllerCreateViewBagTests
+{
+    private const string TestUserId = "1";
+
+    private static readonly List<ProvinciaDto> ProvinciasEsperadas = new()
+    {
+        new() { Id = 1, Nombre = "Buenos Aires" },
+        new() { Id = 2, Nombre = "Córdoba" },
+        new() { Id = 3, Nombre = "Santa Fe" },
+    };
+
+    // ---------- Rama 1: Create (GET) siempre carga provincias ----------
+
+    [Fact]
+    public async Task Create_Get_CargaViewBagProvincias()
+    {
+        var controller = NewController();
+
+        var result = await controller.Create(CancellationToken.None);
+
+        result.Should().BeOfType<ViewResult>();
+        AssertProvinciasViewBag(controller);
+    }
+
+    // ---------- Rama 2: Create (POST) con ModelState inválido ----------
+
+    [Fact]
+    public async Task Create_PostConModelStateInvalido_RepopulaViewBagProvincias()
+    {
+        var controller = NewController();
+
+        // Forzamos un error de validación (finge ser el binder: por ejemplo, un
+        // atributo [Required] que no se cumplió). Sin ModelBinding real esta es
+        // la forma de simular el POST fallido.
+        controller.ModelState.AddModelError(
+            nameof(CreateProveedorDto.Cuit),
+            "El CUIT es obligatorio.");
+
+        var dto = new CreateProveedorDto
+        {
+            RazonSocial = "Proveedor Test",
+            // Cuit queda null → RequiredAttribute rechazaría, pero el ModelState
+            // ya está marcado inválido por la línea de arriba.
+        };
+
+        var result = await controller.Create(dto, CancellationToken.None);
+
+        result.Should().BeOfType<ViewResult>();
+        AssertProvinciasViewBag(controller);
+    }
+
+    // ---------- Rama 3: Details siempre recarga provincias ----------
+
+    [Fact]
+    public async Task Details_ConProveedorExistente_RepopulaViewBagProvincias()
+    {
+        var controller = NewController(proveedor: new ProveedorDto
+        {
+            Id = 10,
+            RazonSocial = "Shell",
+            Cuit = "30123456780",
+        });
+
+        var result = await controller.Details(10, CancellationToken.None);
+
+        result.Should().BeOfType<ViewResult>();
+        AssertProvinciasViewBag(controller);
+    }
+
+    [Fact]
+    public async Task Details_ConProveedorInexistente_RetornaNotFound()
+    {
+        var controller = NewController(); // sin proveedor configurado
+
+        var result = await controller.Details(999, CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    // ====================================================================
+    // Helpers
+    // ====================================================================
+
+    private static void AssertProvinciasViewBag(ProveedoresController controller)
+    {
+        var enViewBag = controller.ViewBag.Provincias as List<ProvinciaDto>;
+
+        enViewBag.Should().NotBeNull(
+            "ViewBag.Provincias no puede ser null despues de un error de validacion; " +
+            "de lo contrario el <select> de Provincia en el re-render queda solo " +
+            "con el placeholder '-- Seleccione provincia --' y el operador no puede " +
+            "elegir (regresion del patron ViewBag ya documentado en Usuarios).");
+
+        enViewBag.Should().BeEquivalentTo(ProvinciasEsperadas,
+            options => options.WithStrictOrdering(),
+            "las provincias deben coincidir con las que devuelve el service");
+    }
+
+    private static ProveedoresController NewController(ProveedorDto? proveedor = null)
+    {
+        var httpContext = new DefaultHttpContext
+        {
+            User = new System.Security.Claims.ClaimsPrincipal(
+                new System.Security.Claims.ClaimsIdentity(
+                    new[]
+                    {
+                        new System.Security.Claims.Claim(
+                            System.Security.Claims.ClaimTypes.NameIdentifier, TestUserId),
+                    },
+                    "TestAuth")),
+        };
+
+        // Mapper real con el MappingProfile de la app. Es lo más fiel al
+        // wiring de producción sin necesidad de InMemory DbContext.
+        var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        var mapper = mapperConfig.CreateMapper();
+
+        var service = new FakeProveedorService(ProvinciasEsperadas, proveedor);
+
+        return new ProveedoresController(service, mapper)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext,
+                RouteData = new RouteData(),
+            },
+        };
+    }
+
+    /// <summary>
+    /// Fake de <see cref="IProveedorService"/> que solo implementa los métodos
+    /// ejercitados por estos tests. El resto lanza <see cref="NotImplementedException"/>
+    /// (mismo patrón que los fakes de Usuarios) para que un cambio en el wiring
+    /// del controller rompa un test en lugar de fallar silenciosamente.
+    /// </summary>
+    private sealed class FakeProveedorService : IProveedorService
+    {
+        private readonly List<ProvinciaDto> _provincias;
+        private readonly ProveedorDto? _proveedor;
+
+        public FakeProveedorService(List<ProvinciaDto> provincias, ProveedorDto? proveedor)
+        {
+            _provincias = provincias;
+            _proveedor = proveedor;
+        }
+
+        public Task<IEnumerable<ProvinciaDto>> GetProvinciasAsync(CancellationToken ct = default)
+            => Task.FromResult<IEnumerable<ProvinciaDto>>(_provincias);
+
+        public Task<ProveedorDto?> GetByIdAsync(ulong id, CancellationToken ct = default)
+            => Task.FromResult(_proveedor?.Id == id ? _proveedor : null);
+
+        // Métodos no usados por estos tests:
+        public Task<ProveedorDto?> GetByCuitAsync(string cuit, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<ProveedorDto> CreateAsync(CreateProveedorDto proveedor, ulong? createdBy, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<ProveedorDto> UpdateAsync(ulong id, UpdateProveedorDto proveedor, ulong? updatedBy, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<bool> DeleteAsync(ulong id, ulong? updatedBy, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<SearchResultDto<ProveedorDto>> SearchAsync(string? busqueda, bool soloActivos, int pagina, int tamanio, CancellationToken ct = default) => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
## Contexto

Auditoria del modulo Proveedores detecto tres puntos de higiene que conviene
cerrar antes de enriquecer el modulo con pagos / cuenta corriente / reportes.
Este PR cierra esos tres puntos y suma 53 tests nuevos como red de seguridad
contra regresiones.

Cambios contenidos en este PR (sin migracion SQL, sin cambios de entidad):

1. **Validacion de CUIT modulo 11 (AFIP)** — el atributo `[Cuit]` reemplaza
   la regex `^[0-9]{11}$` en `CreateProveedorDto` y `UpdateProveedorDto`.
   Mensajes especificos segun el tipo de error (formato vs DV) en vez del
   "11 digitos numericos" generico. Detecta CUITs mal cargados antes de que
   ARCA los rechaze.

2. **Maxlength de RazonSocial alineado con la BD** — el DTO permitia 200 chars
   pero la columna es VARCHAR(150). Si alguien cargaba una razon social larga
   el insert rebotaba silenciosamente. El DTO ahora usa `[StringLength(150)]`
   consistente con la BD.

3. **Regla dura sobre el doble flag Activo/DeletedAt** — decision del usuario:
   mantener ambos flags pero acoplados. `Activo` solo se modifica via Delete,
   no via Edit. `ProveedorService.UpdateAsync` preserva el valor de BD con
   un snapshot post-mapper. Las vistas Create/Edit dejan el checkbox disabled
   con una alerta explicando. La regla esta concentrada en
   `ProveedorEditRules.PreservarFlagsNoEditables` para ser testeable sin
   DbContext.

## Cambios

- **src/**
  - `DTOs/ProveedorDto.cs` — agregar `using Extensions`; `RazonSocial` a
    StringLength(150); `Cuit` pasa de `[RegularExpression]` a `[Cuit]`.
  - `Extensions/CuitAttribute.cs` (nuevo) — `CuitValidator` (algoritmo
    modulo 11 AFIP, con `CalcularDigitoVerificador`, `EsValido`,
    `Generar`) + atributo `[Cuit]` que emite mensajes especificos.
  - `Extensions/ProveedorEditRules.cs` (nuevo) — helper estatico
    `PreservarFlagsNoEditables(entity, activoOriginal)`.
  - `Services/Implementations/ProveedorService.cs` — `UpdateAsync` snapshot
    + restore via el helper nuevo. Sin cambios funcionales (misma
    semantica que el inline anterior, ahora testeable).
  - `Views/Proveedores/Create.cshtml` — checkbox Activo disabled + checked.
  - `Views/Proveedores/Edit.cshtml` — checkbox Activo disabled.

- **tests/ExtraGasMVC.Tests/**
  - `CuitValidatorTests.cs` (nuevo, 33 tests) — formato, DV, prefijos,
    integracion con DataAnnotations, mensajes.
  - `ProveedorDtoValidationTests.cs` (nuevo, 12 tests) — bordes de maxlength
    (150 ok, 151 falla) y mensajes de CUIT.
  - `ProveedorEditRulesTests.cs` (nuevo, 4 tests) — escenarios de la regla
    dura: operador-destilda, operador-intenta-reactivar, mismo valor,
    no-se-tocan-otros-campos.
  - `ProveedoresControllerCreateViewBagTests.cs` (nuevo, 4 tests) — regresion
    del patron ViewBag.Provincias en Create GET, Create POST con error, y
    Details (mas 404). Patron replicado de `UsuariosCreateViewBagTests`.

Total: **89 tests pasan** (53 nuevos + 36 previos).

## Decisiones (no todo codigo)

- **No** se elimino ninguna columna. La regla se aplica via service + UI.
- **No** se agrego RestoreAsync al ProveedorService (queda como gap
  para cuando se enriquezca el modulo).
- **No** se toco la regla `nullable` de `Activo` en BD. Sigue siendo
  redundante con `DeletedAt` por convencion del service + UI, NO por
  migracion.

## Como probarlo manualmente

1. `Proveedores/Create`: cargar un CUIT con formato invalido (`12345` o
   `20-12345678-9` con guiones) → rebota con mensaje de formato.
2. `Proveedores/Create`: cargar un CUIT valido cualquiera (ej. cualquier
   CUIT generado en linea que pase modulo 11) → acepta.
3. `Proveedores/Create`: razon social de 200 chars → rebota antes de la BD.
4. `Proveedores/Edit`: editar un proveedor activo, destildar 'Activo',
   guardar → al volver a Details sigue 'Activo' (el service restauró el
   valor de BD).
5. `Proveedores/Create`: nuevo proveedor → nace con Activo=true (unico
   checkbox disabled + checked).

## Checklist

- [x] Tests pasan (89/89)
- [x] Build sin errores nuevos (3 warnings preexistentes sin tocar)
- [x] Sin cambios en BD / migraciones
- [x] Sin Co-Authored-By en commits
