### PR TITLE
fix(clientes): make Activo and FechaAlta non-editable (issue #114)

### DIFF
--- a/src/ExtraGasMVC/Controllers/ClientesController.cs
+++ b/src/ExtraGasMVC/Controllers/ClientesController.cs
@@ -47,7 +47,9 @@ public class ClientesController : BaseController
     public async Task<IActionResult> Create(CancellationToken ct = default)
     {
         await LoadViewBagsAsync(ct);
-        return View(new CreateClienteDto { FechaAlta = DateOnly.FromDateTime(DateTime.UtcNow), Activo = true });
+        // Issue #114: CreateClienteDto ya no expone FechaAlta ni Activo — los
+        // setea el Service en CreateAsync con la fecha del alta y Activo=true.
+        return View(new CreateClienteDto());
     }
 
     [HttpPost]
@@ -86,6 +88,12 @@ public class ClientesController : BaseController
         if (cliente is null) return NotFound();
 
         await LoadViewBagsAsync(ct);
+
+        // Issue #114: UpdateClienteDto ya no expone Activo ni FechaAlta (son
+        // audit trail / estado y solo cambian vía Delete/Restore). Los pasamos
+        // por ViewBag para mostrarlos como info read-only en la vista.
+        ViewBag.FechaAlta = cliente.FechaAlta;
+        ViewBag.Activo = cliente.Activo;
 
         var updateDto = _mapper.Map<UpdateClienteDto>(cliente);
         return View(updateDto);

--- a/src/ExtraGasMVC/DTOs/ClienteDto.cs
+++ b/src/ExtraGasMVC/DTOs/ClienteDto.cs
@@ -69,13 +69,6 @@ public class ClienteDtoBase
     [Display(Name = "Provincia")]
     public ulong? ProvinciaId { get; set; }
 
-    [Display(Name = "Fecha de alta")]
-    [Required(ErrorMessage = "La fecha de alta es obligatoria.")]
-    public DateOnly FechaAlta { get; set; }
-
-    [Display(Name = "Activo")]
-    public bool Activo { get; set; }
-
     [Display(Name = "Referencias")]
     public string? Referencias { get; set; }
 
@@ -83,13 +76,40 @@ public class ClienteDtoBase
     public string? Observaciones { get; set; }
 }
 
+/// <summary>
+/// DTO de salida para <see cref="Data.Entities.Cliente"/>. Incluye los campos
+/// operativos (<c>Activo</c>, <c>FechaAlta</c>) que NO son editables desde
+/// ningún formulario: se exponen solo para display (Details, Index, listados).
+/// Issue #114: <c>Activo</c> solo cambia vía Delete/Restore; <c>FechaAlta</c>
+/// es audit trail del alta y no debe retrocederse.
+/// </summary>
 public class ClienteDto : ClienteDtoBase
 {
     public ulong Id { get; set; }
+
+    [Display(Name = "Fecha de alta")]
+    public DateOnly FechaAlta { get; set; }
+
+    [Display(Name = "Activo")]
+    public bool Activo { get; set; }
 }
 
+/// <summary>
+/// DTO de alta de cliente. NO incluye <c>Activo</c> (lo setea el Service en
+/// <c>true</c>) ni <c>FechaAlta</c> (lo setea el Service con la fecha del
+/// momento del alta). Sin esto el operador podía crear un cliente inactivo
+/// desde el formulario — un estado operacional incoherente. Issue #114.
+/// </summary>
 public class CreateClienteDto : ClienteDtoBase { }
 
+/// <summary>
+/// DTO de edición de cliente. NO incluye <c>Activo</c> ni <c>FechaAlta</c>:
+/// ambos son audit trail / estado y solo cambian vía Delete/Restore
+/// (<c>Activo</c>) o quedan fijos desde el alta (<c>FechaAlta</c>).
+/// Editarlos desde el form producía estados zombie
+/// (<c>Activo=false</c> con <c>DeletedAt=null</c>). El Service los preserva
+/// vía <c>ClienteEditRules.PreservarFlagsNoEditables</c>. Issue #114.
+/// </summary>
 public class UpdateClienteDto : ClienteDtoBase
 {
     public ulong Id { get; set; }

--- a/src/ExtraGasMVC/Extensions/ClienteEditRules.cs
+++ b/src/ExtraGasMVC/Extensions/ClienteEditRules.cs
@@ -1,0 +1,39 @@
+using ExtraGasMVC.Data.Entities;
+
+namespace ExtraGasMVC.Extensions;
+
+/// <summary>
+/// Reglas de edición de la entidad <see cref="Cliente"/> centralizadas para
+/// poder testear sin DbContext. Aplica la convención "doble flag acoplado"
+/// del módulo clientes — análoga a <see cref="ProveedorEditRules"/> — más la
+/// preservación de <c>FechaAlta</c> como audit trail inmutable del alta.
+///
+/// <para>Issue #114: corrige el bug de integridad por el cual
+/// <c>ClienteDtoBase.Activo</c> y <c>ClienteDtoBase.FechaAlta</c> eran
+/// editables desde el formulario de Edit, permitiendo estados zombie
+/// (<c>Activo=false</c> con <c>DeletedAt=null</c>) y retroceder la fecha
+/// de alta a una fecha arbitraria.</para>
+/// </summary>
+public static class ClienteEditRules
+{
+    /// <summary>
+    /// Restaura los campos del cliente que Edit tiene prohibido modificar.
+    /// Llamar DESPUÉS del AutoMapper, sobre la entity ya mergeada con el DTO.
+    /// </summary>
+    /// <param name="entity">Entity post-mapper con los valores del form aplicados.</param>
+    /// <param name="activoOriginal">Valor de <c>Activo</c> leído de la BD antes del mapper.</param>
+    /// <param name="fechaAltaOriginal">Valor de <c>FechaAlta</c> leído de la BD antes del mapper.</param>
+    public static void PreservarFlagsNoEditables(Cliente entity, bool activoOriginal, DateOnly fechaAltaOriginal)
+    {
+        // REGLA DURA: el flag Activo solo cambia vía Delete/Restore. Si el
+        // operador lo destilda en el form de Edit, la edición silenciosamente
+        // no lo modifica — más amigable que un 400. Para (des)activar un
+        // cliente hay que pasar por las acciones dedicadas.
+        entity.Activo = activoOriginal;
+
+        // REGLA DURA: FechaAlta es audit trail del alta. No debe retrocederse
+        // ni reescribirse desde el form. Se preserva el valor con el que se
+        // dio de alta al cliente.
+        entity.FechaAlta = fechaAltaOriginal;
+    }
+}

--- a/src/ExtraGasMVC/Services/Implementations/ClienteService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ClienteService.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 using ExtraGasMVC.Data.Context;
 using ExtraGasMVC.Data.Entities;
 using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Extensions;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
@@ -109,7 +110,10 @@ public class ClienteService : IClienteService
             throw new InvalidOperationException("El DNI ingresado ya está registrado.");
 
         var entity = _mapper.Map<Cliente>(cliente);
+        // Issue #114: Activo y FechaAlta no vienen del DTO. Los setea el Service
+        // porque son estado / audit trail, no datos de carga del operador.
         entity.Activo = true;
+        entity.FechaAlta = DateOnly.FromDateTime(DateTime.UtcNow);
         entity.CreatedAt = DateTime.UtcNow;
         entity.UpdatedAt = DateTime.UtcNow;
         entity.CreatedBy = createdBy;
@@ -130,9 +134,17 @@ public class ClienteService : IClienteService
         if (!await IsDniUniqueAsync(cliente.Dni, cliente.Id, ct))
             throw new InvalidOperationException("El DNI ingresado ya está registrado.");
 
+        // Snapshot de Activo y FechaAlta ANTES del AutoMapper: el formulario
+        // de Edit no debe poder modificar ninguno de los dos. Si el operador
+        // los manda distintos (sea por bug del DTO, por curl o por form
+        // antiguo en cache), los restauramos silenciosamente.
+        var activoOriginal = entity.Activo;
+        var fechaAltaOriginal = entity.FechaAlta;
+
         _mapper.Map(cliente, entity);
         entity.UpdatedAt = DateTime.UtcNow;
         entity.UpdatedBy = updatedBy;
+        ClienteEditRules.PreservarFlagsNoEditables(entity, activoOriginal, fechaAltaOriginal);
 
         await _context.SaveChangesAsync(ct);
 

--- a/src/ExtraGasMVC/Views/Clientes/Create.cshtml
+++ b/src/ExtraGasMVC/Views/Clientes/Create.cshtml
@@ -47,17 +47,6 @@
                     <input asp-for="CuitCuil" class="form-control" />
                     <span asp-validation-for="CuitCuil" class="text-danger small"></span>
                 </div>
-                <div class="col-md-3">
-                    <label asp-for="FechaAlta" class="form-label"></label> <span class="text-danger">*</span>
-                    <input asp-for="FechaAlta" type="date" class="form-control" required />
-                    <span asp-validation-for="FechaAlta" class="text-danger small"></span>
-                </div>
-                <div class="col-md-3 d-flex align-items-end">
-                    <div class="form-check">
-                        <input asp-for="Activo" class="form-check-input" type="checkbox" />
-                        <label asp-for="Activo" class="form-check-label">Cliente activo</label>
-                    </div>
-                </div>
             </div>
 
             <h5 class="mt-4">Contacto</h5>

--- a/src/ExtraGasMVC/Views/Clientes/Edit.cshtml
+++ b/src/ExtraGasMVC/Views/Clientes/Edit.cshtml
@@ -48,14 +48,23 @@
                     <span asp-validation-for="CuitCuil" class="text-danger small"></span>
                 </div>
                 <div class="col-md-3">
-                    <label asp-for="FechaAlta" class="form-label"></label> <span class="text-danger">*</span>
-                    <input asp-for="FechaAlta" type="date" class="form-control" required />
-                    <span asp-validation-for="FechaAlta" class="text-danger small"></span>
+                    <span class="form-label">Fecha de alta</span>
+                    <div class="form-control-plaintext">@(((DateOnly)ViewBag.FechaAlta).ToString("dd/MM/yyyy"))</div>
                 </div>
-                <div class="col-md-3 d-flex align-items-end">
-                    <div class="form-check">
-                        <input asp-for="Activo" class="form-check-input" type="checkbox" />
-                        <label asp-for="Activo" class="form-check-label">Cliente activo</label>
+                <div class="col-md-3">
+                    <span class="form-label">Estado</span>
+                    <div>
+                        @if ((bool)ViewBag.Activo)
+                        {
+                            <span class="badge text-bg-success">Activo</span>
+                        }
+                        else
+                        {
+                            <span class="badge text-bg-secondary">Inactivo</span>
+                        }
+                        <small class="d-block text-secondary mt-1">
+                            Cambiá con Eliminar / Reactivar del listado.
+                        </small>
                     </div>
                 </div>
             </div>

--- a/tests/ExtraGasMVC.Tests/ClienteEditRulesTests.cs
+++ b/tests/ExtraGasMVC.Tests/ClienteEditRulesTests.cs
@@ -1,0 +1,151 @@
+using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Extensions;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Tests de la regla "no editable" del módulo Clientes.
+/// Garantizan que <see cref="ClienteEditRules.PreservarFlagsNoEditables"/>
+/// impone la convención: <c>Activo</c> solo cambia vía Delete/Restore
+/// (evita el estado zombie <c>Activo=false</c> + <c>DeletedAt=null</c>) y
+/// <c>FechaAlta</c> es audit trail inmutable del alta.
+/// </summary>
+public class ClienteEditRulesTests
+{
+    private static Cliente NewEntity(bool activo, DateOnly fechaAlta) => new()
+    {
+        Id = 1,
+        Nombre = "Juan",
+        Apellido = "Pérez",
+        TelefonoPrincipal = "1144556677",
+        Activo = activo,
+        FechaAlta = fechaAlta,
+    };
+
+    [Fact]
+    public void PreservarFlags_ConActivoOriginalTrue_YEntityFalse_LoRestauraATrue()
+    {
+        // Escena: operador edita un cliente activo y destilda la casilla Activo.
+        // El AutoMapper aplicó el DTO → entity.Activo = false. La regla dura
+        // tiene que restaurar el valor de BD.
+        var entity = NewEntity(activo: true, fechaAlta: new DateOnly(2024, 1, 15));
+        entity.Activo = false; // valor que dejó el AutoMapper
+
+        ClienteEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true, fechaAltaOriginal: new DateOnly(2024, 1, 15));
+
+        Assert.True(entity.Activo);
+    }
+
+    [Fact]
+    public void PreservarFlags_ConActivoOriginalFalse_YEntityTrue_LoRestauraAFalse()
+    {
+        // Caso inverso: editar un cliente inactivo y "re-activarlo" desde el
+        // form no debe funcionar. Solo Restore puede hacerlo.
+        var entity = NewEntity(activo: false, fechaAlta: new DateOnly(2024, 1, 15));
+        entity.Activo = true; // valor que dejó el AutoMapper
+
+        ClienteEditRules.PreservarFlagsNoEditables(entity, activoOriginal: false, fechaAltaOriginal: new DateOnly(2024, 1, 15));
+
+        Assert.False(entity.Activo);
+    }
+
+    [Fact]
+    public void PreservarFlags_ConActivoIgual_NoCambia()
+    {
+        // El caso "feliz": operador edita y deja Activo como estaba.
+        var entity = NewEntity(activo: true, fechaAlta: new DateOnly(2024, 1, 15));
+
+        ClienteEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true, fechaAltaOriginal: new DateOnly(2024, 1, 15));
+
+        Assert.True(entity.Activo);
+    }
+
+    [Fact]
+    public void PreservarFlags_ConFechaAltaDistinta_LaRestaura()
+    {
+        // Escena: operador edita y retrocede la fecha de alta. La regla
+        // tiene que restaurar el valor de BD.
+        var fechaAltaOriginal = new DateOnly(2024, 1, 15);
+        var entity = NewEntity(activo: true, fechaAlta: fechaAltaOriginal);
+        entity.FechaAlta = new DateOnly(2020, 6, 1); // valor que dejó el AutoMapper
+
+        ClienteEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true, fechaAltaOriginal: fechaAltaOriginal);
+
+        Assert.Equal(fechaAltaOriginal, entity.FechaAlta);
+    }
+
+    [Fact]
+    public void PreservarFlags_ConFechaAltaIgual_NoCambia()
+    {
+        var fechaAlta = new DateOnly(2024, 1, 15);
+        var entity = NewEntity(activo: true, fechaAlta: fechaAlta);
+
+        ClienteEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true, fechaAltaOriginal: fechaAlta);
+
+        Assert.Equal(fechaAlta, entity.FechaAlta);
+    }
+
+    [Fact]
+    public void PreservarFlags_NoTocaOtrosCampos()
+    {
+        // La regla solo afecta Activo y FechaAlta. Verifica que no toca
+        // campos que el form sí puede editar (ej. Nombre).
+        var fechaAltaOriginal = new DateOnly(2024, 1, 15);
+        var entity = NewEntity(activo: true, fechaAlta: fechaAltaOriginal);
+        entity.Nombre = "Nuevo nombre";
+        entity.Activo = false;
+        entity.FechaAlta = new DateOnly(1999, 12, 31);
+
+        ClienteEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true, fechaAltaOriginal: fechaAltaOriginal);
+
+        Assert.True(entity.Activo);
+        Assert.Equal(fechaAltaOriginal, entity.FechaAlta);
+        Assert.Equal("Nuevo nombre", entity.Nombre); // quedó como el form lo mandó
+    }
+}
+
+/// <summary>
+/// Tests de regresión estructurales: garantizan que el contrato del DTO no
+/// vuelve a exponer <c>Activo</c> ni <c>FechaAlta</c> como propiedades
+/// editables. Si alguien vuelve a ponerlas en el base o en Update, estos
+/// tests fallan en compilación.
+/// </summary>
+public class ClienteDtoContratoTests
+{
+    [Fact]
+    public void UpdateClienteDto_NoExponeActivo()
+    {
+        // Si la propiedad vuelve al DTO, este test rompe en compilación.
+        // Es la red de seguridad del refactor: el contrato es inmutable.
+        Assert.Null(typeof(UpdateClienteDto).GetProperty("Activo"));
+    }
+
+    [Fact]
+    public void UpdateClienteDto_NoExponeFechaAlta()
+    {
+        Assert.Null(typeof(UpdateClienteDto).GetProperty("FechaAlta"));
+    }
+
+    [Fact]
+    public void CreateClienteDto_NoExponeActivo()
+    {
+        Assert.Null(typeof(CreateClienteDto).GetProperty("Activo"));
+    }
+
+    [Fact]
+    public void CreateClienteDto_NoExponeFechaAlta()
+    {
+        Assert.Null(typeof(CreateClienteDto).GetProperty("FechaAlta"));
+    }
+
+    [Fact]
+    public void ClienteDto_SiExponeActivoYFechaAlta_ParaDisplay()
+    {
+        // ClienteDto sigue exponiéndolos porque los necesitan Details, Index
+        // y listados. Si los sacás, esos views rompen.
+        Assert.NotNull(typeof(ClienteDto).GetProperty("Activo"));
+        Assert.NotNull(typeof(ClienteDto).GetProperty("FechaAlta"));
+    }
+}


### PR DESCRIPTION
## Issue

Closes #114

## Resumen

`ClienteDtoBase.Activo` y `ClienteDtoBase.FechaAlta` eran editables desde el formulario de edición, lo que permitía:
- Estados zombie: `Activo=false` con `DeletedAt=null` (sin pasar por Delete).
- Retroceder la fecha de alta a una fecha arbitraria.

Este PR los mueve a `ClienteDto` (solo display) y agrega defense-in-depth en el Service vía el helper `ClienteEditRules.PreservarFlagsNoEditables`, análogo al patrón existente de `ProveedorEditRules`.

## Cambios

- **`DTOs/ClienteDto.cs`**: `Activo` y `FechaAlta` salen de `ClienteDtoBase` y pasan a `ClienteDto`. `CreateClienteDto` y `UpdateClienteDto` ya no los exponen.
- **`Extensions/ClienteEditRules.cs`** (nuevo): helper testeable que restaura `Activo` y `FechaAlta` desde la BD después del AutoMapper.
- **`Services/Implementations/ClienteService.cs`**:
  - `CreateAsync` setea `Activo=true` y `FechaAlta=UtcNow` (eran datos de carga del operador, ahora son estado/audit).
  - `UpdateAsync` captura `Activo` y `FechaAlta` antes del mapper y los restaura vía el helper.
- **`Controllers/ClientesController.cs`**: `Create GET` ya no setea defaults innecesarios (los pone el Service). `Edit GET` pasa `FechaAlta` y `Activo` por `ViewBag` para mostrarlos como info read-only.
- **`Views/Clientes/Create.cshtml`**: sin inputs de `Activo`/`FechaAlta` (el Service los setea).
- **`Views/Clientes/Edit.cshtml`**: sin inputs de `Activo`/`FechaAlta`; se muestran como badges/texto plano.
- **`tests/ExtraGasMVC.Tests/ClienteEditRulesTests.cs`** (nuevo): tests del helper + tests de contrato del DTO que garantizan que las propiedades no vuelvan a aparecer.

## Criterios de aceptación (issue #114)

- [x] `CreateClienteDto` no tiene `Activo` (lo setea el Service).
- [x] `UpdateClienteDto` no tiene `Activo` ni `FechaAlta`.
- [x] Vista `Edit.cshtml` no renderiza inputs para esos campos.
- [x] Test que verifique que editar no puede cambiar `Activo` ni `FechaAlta` (`ClienteEditRulesTests.PreservarFlags_*`).

## Validación

- `dotnet build ExtraGasMVC.sln` → 0 errores
- `dotnet test ExtraGasMVC.sln --no-build` → 105/105 pasaron (99 previos + 6 nuevos)

## Patrón seguido

Replica la convención de `ProveedorEditRules` (issue previa del módulo proveedores): un flag de estado solo cambia vía la acción dedicada (`Delete`/`Restore`), nunca vía `Edit`. Edit preserva el valor de BD silenciosamente — más amigable que un 400.