### PR TITLE
fix(empleados): make Activo non-editable (replica of #114 pattern)

### DIFF
--- a/src/ExtraGasMVC/Controllers/EmpleadosController.cs
+++ b/src/ExtraGasMVC/Controllers/EmpleadosController.cs
@@ -48,7 +48,10 @@ public class EmpleadosController : BaseController
     public async Task<IActionResult> Create(CancellationToken ct = default)
     {
         await LoadViewBagsAsync(ct);
-        return View(new CreateEmpleadoDto { FechaIngreso = DateOnly.FromDateTime(DateTime.UtcNow), Activo = true });
+        // Issue #114: CreateEmpleadoDto ya no expone Activo — lo setea el
+        // Service en true. FechaIngreso sigue siendo dato del operador
+        // (preinicializado a hoy como UX default).
+        return View(new CreateEmpleadoDto { FechaIngreso = DateOnly.FromDateTime(DateTime.UtcNow) });
     }
 
     [HttpPost]
@@ -87,6 +90,11 @@ public class EmpleadosController : BaseController
         if (empleado is null) return NotFound();
 
         await LoadViewBagsAsync(ct);
+
+        // Issue #114: UpdateEmpleadoDto ya no expone Activo (es estado y
+        // solo cambia vía Delete). Lo pasamos por ViewBag para mostrarlo
+        // como info read-only en la vista.
+        ViewBag.Activo = empleado.Activo;
 
         var updateDto = _mapper.Map<UpdateEmpleadoDto>(empleado);
         return View(updateDto);

--- a/src/ExtraGasMVC/DTOs/EmpleadoDto.cs
+++ b/src/ExtraGasMVC/DTOs/EmpleadoDto.cs
@@ -49,18 +49,41 @@ public class EmpleadoDtoBase
 
     public ulong? UsuarioId { get; set; }
 
-    public bool Activo { get; set; }
-
     public string? Observaciones { get; set; }
 }
 
+/// <summary>
+/// DTO de salida para <see cref="Data.Entities.Empleado"/>. Incluye el campo
+/// operativo <c>Activo</c> que NO es editable desde ningún formulario: se
+/// expone solo para display (Details, Index, listados).
+///
+/// <para>Issue #114 (replicado en Empleados): <c>Activo</c> solo cambia vía
+/// Delete. <c>FechaIngreso</c> sí es editable — es un dato de negocio del
+/// empleado (nullable, lo carga el operador al alta y puede corregirlo
+/// después), a diferencia de <c>Cliente.FechaAlta</c> que es audit trail.</para>
+/// </summary>
 public class EmpleadoDto : EmpleadoDtoBase
 {
     public ulong Id { get; set; }
+
+    [Display(Name = "Activo")]
+    public bool Activo { get; set; }
 }
 
+/// <summary>
+/// DTO de alta de empleado. NO incluye <c>Activo</c> (lo setea el Service en
+/// <c>true</c>). Sin esto el operador podía crear un empleado inactivo desde
+/// el formulario — un estado operacional incoherente. Issue #114.
+/// </summary>
 public class CreateEmpleadoDto : EmpleadoDtoBase { }
 
+/// <summary>
+/// DTO de edición de empleado. NO incluye <c>Activo</c>: es estado y solo
+/// cambia vía Delete. Editarlo desde el form producía estados zombie
+/// (<c>Activo=false</c> con <c>DeletedAt=null</c>). El Service lo preserva
+/// vía <c>EmpleadoEditRules.PreservarFlagsNoEditables</c>. Issue #114.
+/// <c>FechaIngreso</c> sí es editable (dato de negocio).
+/// </summary>
 public class UpdateEmpleadoDto : EmpleadoDtoBase
 {
     public ulong Id { get; set; }

--- a/src/ExtraGasMVC/Extensions/EmpleadoEditRules.cs
+++ b/src/ExtraGasMVC/Extensions/EmpleadoEditRules.cs
@@ -1,0 +1,36 @@
+using ExtraGasMVC.Data.Entities;
+
+namespace ExtraGasMVC.Extensions;
+
+/// <summary>
+/// Reglas de edición de la entidad <see cref="Empleado"/> centralizadas para
+/// poder testear sin DbContext. Aplica la convención "doble flag acoplado"
+/// del módulo empleados — análoga a <see cref="ProveedorEditRules"/> y
+/// <see cref="ClienteEditRules"/>.
+///
+/// <para>A diferencia del helper de Cliente, este NO preserva <c>FechaIngreso</c>:
+/// es un dato de negocio del empleado (lo carga el operador y puede corregirlo),
+/// no audit trail. Solo <c>Activo</c> es estado.</para>
+///
+/// <para>Issue #114 (replicado en Empleados): corrige el bug de integridad por
+/// el cual <c>EmpleadoDtoBase.Activo</c> era editable desde el formulario de
+/// Edit, permitiendo estados zombie (<c>Activo=false</c> con
+/// <c>DeletedAt=null</c>).</para>
+/// </summary>
+public static class EmpleadoEditRules
+{
+    /// <summary>
+    /// Restaura los flags del empleado que Edit tiene prohibido modificar.
+    /// Llamar DESPUÉS del AutoMapper, sobre la entity ya mergeada con el DTO.
+    /// </summary>
+    /// <param name="entity">Entity post-mapper con los valores del form aplicados.</param>
+    /// <param name="activoOriginal">Valor de <c>Activo</c> leído de la BD antes del mapper.</param>
+    public static void PreservarFlagsNoEditables(Empleado entity, bool activoOriginal)
+    {
+        // REGLA DURA: el flag Activo solo cambia vía Delete. Si el operador
+        // lo destilda en el form de Edit, la edición silenciosamente no lo
+        // modifica — más amigable que un 400. Para (des)activar un empleado
+        // hay que pasar por la acción dedicada.
+        entity.Activo = activoOriginal;
+    }
+}

--- a/src/ExtraGasMVC/Services/Implementations/EmpleadoService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/EmpleadoService.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 using ExtraGasMVC.Data.Context;
 using ExtraGasMVC.Data.Entities;
 using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Extensions;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
@@ -73,6 +74,9 @@ public class EmpleadoService : IEmpleadoService
             throw new InvalidOperationException("El DNI ingresado ya está registrado.");
 
         var empleado = _mapper.Map<Empleado>(dto);
+        // Issue #114: Activo no viene del DTO. Lo setea el Service en true
+        // porque es estado, no dato de carga del operador.
+        empleado.Activo = true;
         empleado.CreatedAt = DateTime.UtcNow;
         empleado.UpdatedAt = DateTime.UtcNow;
         empleado.CreatedBy = createdBy;
@@ -93,9 +97,16 @@ public class EmpleadoService : IEmpleadoService
         if (!await IsDniUniqueAsync(dto.Dni, dto.Id, ct))
             throw new InvalidOperationException("El DNI ingresado ya está registrado.");
 
+        // Snapshot de Activo ANTES del AutoMapper: el formulario de Edit no
+        // debe poder modificarlo. Si el operador lo manda distinto (sea por
+        // bug del DTO, por curl o por form antiguo en cache), lo restauramos
+        // silenciosamente. FechaIngreso NO se preserva — es dato de negocio.
+        var activoOriginal = empleado.Activo;
+
         _mapper.Map(dto, empleado);
         empleado.UpdatedAt = DateTime.UtcNow;
         empleado.UpdatedBy = updatedBy;
+        EmpleadoEditRules.PreservarFlagsNoEditables(empleado, activoOriginal);
 
         await _context.SaveChangesAsync(ct);
 

--- a/src/ExtraGasMVC/Views/Empleados/Create.cshtml
+++ b/src/ExtraGasMVC/Views/Empleados/Create.cshtml
@@ -45,12 +45,6 @@
                     <label asp-for="Cuil" class="form-label">CUIL</label>
                     <input asp-for="Cuil" class="form-control" />
                 </div>
-                <div class="col-md-3 d-flex align-items-end">
-                    <div class="form-check">
-                        <input asp-for="Activo" class="form-check-input" type="checkbox" />
-                        <label asp-for="Activo" class="form-check-label">Empleado activo</label>
-                    </div>
-                </div>
             </div>
 
             <h5 class="mt-4">Contacto</h5>

--- a/src/ExtraGasMVC/Views/Empleados/Edit.cshtml
+++ b/src/ExtraGasMVC/Views/Empleados/Edit.cshtml
@@ -46,10 +46,22 @@
                     <label asp-for="Cuil" class="form-label">CUIL</label>
                     <input asp-for="Cuil" class="form-control" />
                 </div>
-                <div class="col-md-3 d-flex align-items-end">
-                    <div class="form-check">
-                        <input asp-for="Activo" class="form-check-input" type="checkbox" />
-                        <label asp-for="Activo" class="form-check-label">Empleado activo</label>
+            </div>
+            <div class="row g-3 mt-1">
+                <div class="col-md-3">
+                    <span class="form-label">Estado</span>
+                    <div>
+                        @if ((bool)ViewBag.Activo)
+                        {
+                            <span class="badge text-bg-success">Activo</span>
+                        }
+                        else
+                        {
+                            <span class="badge text-bg-secondary">Inactivo</span>
+                        }
+                        <small class="d-block text-secondary mt-1">
+                            Cambiá con Eliminar del listado.
+                        </small>
                     </div>
                 </div>
             </div>

--- a/tests/ExtraGasMVC.Tests/EmpleadoEditRulesTests.cs
+++ b/tests/ExtraGasMVC.Tests/EmpleadoEditRulesTests.cs
@@ -1,0 +1,123 @@
+using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Extensions;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Tests de la regla "no editable" del módulo Empleados.
+/// Garantizan que <see cref="EmpleadoEditRules.PreservarFlagsNoEditables"/>
+/// impone la convención: <c>Activo</c> solo cambia vía Delete, evitando el
+/// estado zombie <c>Activo=false</c> + <c>DeletedAt=null</c>.
+///
+/// <para>A diferencia de Cliente, <c>FechaIngreso</c> NO se preserva — es
+/// dato de negocio del empleado (editable).</para>
+/// </summary>
+public class EmpleadoEditRulesTests
+{
+    private static Empleado NewEntity(bool activo) => new()
+    {
+        Id = 1,
+        Nombre = "Juan",
+        Apellido = "Pérez",
+        Activo = activo,
+    };
+
+    [Fact]
+    public void PreservarFlags_ConActivoOriginalTrue_YEntityFalse_LoRestauraATrue()
+    {
+        var entity = NewEntity(activo: true);
+        entity.Activo = false; // valor que dejó el AutoMapper
+
+        EmpleadoEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true);
+
+        Assert.True(entity.Activo);
+    }
+
+    [Fact]
+    public void PreservarFlags_ConActivoOriginalFalse_YEntityTrue_LoRestauraAFalse()
+    {
+        var entity = NewEntity(activo: false);
+        entity.Activo = true; // valor que dejó el AutoMapper
+
+        EmpleadoEditRules.PreservarFlagsNoEditables(entity, activoOriginal: false);
+
+        Assert.False(entity.Activo);
+    }
+
+    [Fact]
+    public void PreservarFlags_ConActivoIgual_NoCambia()
+    {
+        var entity = NewEntity(activo: true);
+
+        EmpleadoEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true);
+
+        Assert.True(entity.Activo);
+    }
+
+    [Fact]
+    public void PreservarFlags_NoTocaFechaIngreso_DatoDeNegocio()
+    {
+        // A diferencia de Cliente, FechaIngreso es dato del empleado y debe
+        // poder ser editado libremente desde el form.
+        var entity = NewEntity(activo: true);
+        entity.FechaIngreso = new DateOnly(2024, 6, 1);
+        entity.FechaIngreso = new DateOnly(2025, 1, 15); // operador corrigió la fecha
+
+        EmpleadoEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true);
+
+        Assert.Equal(new DateOnly(2025, 1, 15), entity.FechaIngreso);
+    }
+
+    [Fact]
+    public void PreservarFlags_NoTocaOtrosCampos()
+    {
+        // La regla solo afecta Activo. Verifica que no toca campos que el
+        // form sí puede editar (ej. Nombre).
+        var entity = NewEntity(activo: true);
+        entity.Nombre = "Nuevo nombre";
+        entity.Activo = false;
+
+        EmpleadoEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true);
+
+        Assert.True(entity.Activo);
+        Assert.Equal("Nuevo nombre", entity.Nombre); // quedó como el form lo mandó
+    }
+}
+
+/// <summary>
+/// Tests de regresión estructurales: garantizan que el contrato del DTO no
+/// vuelve a exponer <c>Activo</c> como propiedad editable. Si alguien la
+/// vuelve a poner, estos tests fallan en compilación.
+/// </summary>
+public class EmpleadoDtoContratoTests
+{
+    [Fact]
+    public void UpdateEmpleadoDto_NoExponeActivo()
+    {
+        Assert.Null(typeof(UpdateEmpleadoDto).GetProperty("Activo"));
+    }
+
+    [Fact]
+    public void CreateEmpleadoDto_NoExponeActivo()
+    {
+        Assert.Null(typeof(CreateEmpleadoDto).GetProperty("Activo"));
+    }
+
+    [Fact]
+    public void EmpleadoDto_SiExponeActivo_ParaDisplay()
+    {
+        // EmpleadoDto sigue exponiéndolo porque Details/Index lo necesitan.
+        Assert.NotNull(typeof(EmpleadoDto).GetProperty("Activo"));
+    }
+
+    [Fact]
+    public void EmpleadoDtoBase_MantieneFechaIngreso_PorqueEsDatoDeNegocio()
+    {
+        // A diferencia de Cliente (donde FechaAlta es audit trail y salió del
+        // base), FechaIngreso sigue siendo editable: el operador lo carga al
+        // alta y puede corregirlo. Por eso queda en EmpleadoDtoBase.
+        Assert.NotNull(typeof(EmpleadoDtoBase).GetProperty("FechaIngreso"));
+    }
+}


### PR DESCRIPTION
## Contexto

Mismo bug que #114 / PR #119, pero en el módulo Empleados.

`EmpleadoDtoBase.Activo` era editable desde el formulario de Edit, permitiendo estados zombie (`Activo=false` con `DeletedAt=null`). Además, el `CreateAsync` ni siquiera forzaba `Activo=true` — si el operador destildaba el checkbox al dar de alta, el empleado quedaba inactivo desde el inicio. **Esto es peor que en Cliente**.

## Diferencia clave con Cliente

`EmpleadoDtoBase.FechaIngreso` se mantiene editable — es **dato de negocio** del empleado (nullable, lo carga el operador al alta y puede corregirlo), no audit trail del sistema. Solo `Activo` se bloquea.

## Cambios

- **`DTOs/EmpleadoDto.cs`**: `Activo` sale de `EmpleadoDtoBase` y pasa a `EmpleadoDto` (solo display). `CreateEmpleadoDto` y `UpdateEmpleadoDto` ya no lo exponen.
- **`Extensions/EmpleadoEditRules.cs`** (nuevo): helper testeable análogo a `ClienteEditRules`. Solo preserva `Activo` (no `FechaIngreso`).
- **`Services/Implementations/EmpleadoService.cs`**:
  - `CreateAsync` ahora setea `Activo=true` (antes el operador podía crearlo inactivo).
  - `UpdateAsync` captura `Activo` antes del mapper y lo restaura vía el helper.
- **`Controllers/EmpleadosController.cs`**: `Edit GET` pasa `Activo` por `ViewBag` para mostrarlo como info read-only.
- **`Views/Empleados/Create.cshtml`**: sin checkbox de `Activo`.
- **`Views/Empleados/Edit.cshtml`**: badge read-only en lugar de checkbox.
- **`tests/ExtraGasMVC.Tests/EmpleadoEditRulesTests.cs`** (nuevo): 9 tests (helper + contrato del DTO + invariante "FechaIngreso sigue editable").

## Validación

- `dotnet build ExtraGasMVC.sln` → 0 errores
- `dotnet test ExtraGasMVC.sln --no-build` → 103/103 pasaron (94 base + 9 nuevos)

## Relación con #119

PR hermano de #119. Ambos aplican el mismo patrón a módulos diferentes. Se podrían merge-ear en cualquier orden — los helpers (`ClienteEditRules` / `EmpleadoEditRules`) viven en clases separadas para no generar una dependencia cruzada entre módulos.

## Módulos restantes a revisar

Vale la pena auditar el resto de los DTOs (`ProductoDto`, `ProveedorDto`, `UsuarioDto`, etc.) por si tienen el mismo patrón. `Proveedor` ya tiene `ProveedorEditRules`, así que ese está cubierto.