### PR TITLE
fix(productos): make Activo non-editable + refactor Delete to use DeleteAsync

### DIFF
--- a/src/ExtraGasMVC/Controllers/ProductosController.cs
+++ b/src/ExtraGasMVC/Controllers/ProductosController.cs
@@ -42,7 +42,9 @@ public class ProductosController : BaseController
     public async Task<IActionResult> Create(CancellationToken ct = default)
     {
         await LoadViewBagsAsync(ct);
-        return View(new CreateProductoDto { Activo = true, UnidadVenta = "UNIDAD" });
+        // Issue #114: CreateProductoDto ya no expone Activo — lo setea el
+        // Service en true. UnidadVenta queda como default de UI.
+        return View(new CreateProductoDto { UnidadVenta = "UNIDAD" });
     }
 
     [HttpPost]
@@ -84,8 +86,12 @@ public class ProductosController : BaseController
             UnidadVenta = producto.UnidadVenta,
             PrecioActual = producto.PrecioActual,
             ManejaGarrafaIndividual = producto.ManejaGarrafaIndividual,
-            Activo = producto.Activo
         };
+
+        // Issue #114: UpdateProductoDto ya no expone Activo (es estado y
+        // solo cambia vía Delete). Lo pasamos por ViewBag para mostrarlo
+        // como info read-only en la vista.
+        ViewBag.Activo = producto.Activo;
 
         await LoadViewBagsAsync(ct);
         return View(updateDto);
@@ -119,29 +125,15 @@ public class ProductosController : BaseController
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Delete(ulong id, CancellationToken ct = default)
     {
-        var producto = await _productoService.GetByIdAsync(id, ct);
-        if (producto is null)
-        {
-            TempData["Error"] = "No se encontró el producto.";
-            return RedirectToAction(nameof(Index));
-        }
-        
-        var updateDto = new UpdateProductoDto
-        {
-            Id = producto.Id,
-            Codigo = producto.Codigo,
-            Nombre = producto.Nombre,
-            Descripcion = producto.Descripcion,
-            TipoProductoId = producto.TipoProductoId,
-            CapacidadKg = producto.CapacidadKg,
-            UnidadVenta = producto.UnidadVenta,
-            PrecioActual = producto.PrecioActual,
-            ManejaGarrafaIndividual = producto.ManejaGarrafaIndividual,
-            Activo = false
-        };
-        
-        await _productoService.UpdateAsync(updateDto, GetCurrentUserId(), ct);
-        TempData["Success"] = "Producto desactivado.";
+        // Issue #114: antes este Delete implementaba soft-delete a mano vía
+        // UpdateAsync con Activo=false — un anti-patrón que dependía de que
+        // Activo fuera editable. Con el fix, el soft-delete se delega al
+        // Service (DeleteAsync), que setea DeletedAt + Activo=false en una
+        // sola operación consistente con el resto de los módulos.
+        var ok = await _productoService.DeleteAsync(id, ct);
+        TempData[ok ? "Success" : "Error"] = ok
+            ? "Producto desactivado correctamente."
+            : "No se encontró el producto.";
         return RedirectToAction(nameof(Index));
     }
 

--- a/src/ExtraGasMVC/DTOs/ProductoDto.cs
+++ b/src/ExtraGasMVC/DTOs/ProductoDto.cs
@@ -2,6 +2,15 @@ using System.ComponentModel.DataAnnotations;
 
 namespace ExtraGasMVC.DTOs;
 
+/// <summary>
+/// DTO de salida para <see cref="Data.Entities.Producto"/>. Incluye el campo
+/// operativo <c>Activo</c> que NO es editable desde ningún formulario: se
+/// expone solo para display (Details, Index, listados).
+///
+/// <para>Issue #114 (replicado en Productos): <c>Activo</c> solo cambia vía
+/// Delete. <c>ManejaGarrafaIndividual</c> sí es editable — es config de
+/// negocio del producto (define cómo se factura y rastrea).</para>
+/// </summary>
 public class ProductoDto
 {
     public ulong Id { get; set; }
@@ -17,6 +26,11 @@ public class ProductoDto
     public bool Activo { get; set; }
 }
 
+/// <summary>
+/// DTO de alta de producto. NO incluye <c>Activo</c> (lo setea el Service en
+/// <c>true</c>). Sin esto el operador podía crear un producto inactivo desde
+/// el formulario — un estado operacional incoherente. Issue #114.
+/// </summary>
 public class CreateProductoDto
 {
     [Display(Name = "Código")]
@@ -49,9 +63,15 @@ public class CreateProductoDto
     public decimal PrecioActual { get; set; }
 
     public bool ManejaGarrafaIndividual { get; set; }
-    public bool Activo { get; set; }
 }
 
+/// <summary>
+/// DTO de edición de producto. NO incluye <c>Activo</c>: es estado y solo
+/// cambia vía Delete. Editarlo desde el form producía estados zombie
+/// (<c>Activo=false</c> con <c>DeletedAt=null</c>). El Service lo preserva
+/// vía <c>ProductoEditRules.PreservarFlagsNoEditables</c>. Issue #114.
+/// <c>ManejaGarrafaIndividual</c> sí es editable (config de negocio).
+/// </summary>
 public class UpdateProductoDto
 {
     public ulong Id { get; set; }
@@ -86,5 +106,4 @@ public class UpdateProductoDto
     public decimal PrecioActual { get; set; }
 
     public bool ManejaGarrafaIndividual { get; set; }
-    public bool Activo { get; set; }
 }

--- a/src/ExtraGasMVC/Extensions/ProductoEditRules.cs
+++ b/src/ExtraGasMVC/Extensions/ProductoEditRules.cs
@@ -1,0 +1,36 @@
+using ExtraGasMVC.Data.Entities;
+
+namespace ExtraGasMVC.Extensions;
+
+/// <summary>
+/// Reglas de edición de la entidad <see cref="Producto"/> centralizadas para
+/// poder testear sin DbContext. Aplica la convención "doble flag acoplado"
+/// del módulo productos — análoga a <see cref="ProveedorEditRules"/>,
+/// <see cref="ClienteEditRules"/> y <see cref="EmpleadoEditRules"/>.
+///
+/// <para>A diferencia de Cliente, este NO preserva una fecha: Producto no
+/// tiene campo fecha de alta (se usa <c>CreatedAt</c> a nivel EF/BD).
+/// <c>ManejaGarrafaIndividual</c> sí es editable — es config de negocio.</para>
+///
+/// <para>Issue #114 (replicado en Productos): corrige el bug de integridad
+/// por el cual <c>UpdateProductoDto.Activo</c> era editable desde el
+/// formulario de Edit, permitiendo estados zombie
+/// (<c>Activo=false</c> con <c>DeletedAt=null</c>).</para>
+/// </summary>
+public static class ProductoEditRules
+{
+    /// <summary>
+    /// Restaura los flags del producto que Edit tiene prohibido modificar.
+    /// Llamar DESPUÉS del AutoMapper, sobre la entity ya mergeada con el DTO.
+    /// </summary>
+    /// <param name="entity">Entity post-mapper con los valores del form aplicados.</param>
+    /// <param name="activoOriginal">Valor de <c>Activo</c> leído de la BD antes del mapper.</param>
+    public static void PreservarFlagsNoEditables(Producto entity, bool activoOriginal)
+    {
+        // REGLA DURA: el flag Activo solo cambia vía Delete. Si el operador
+        // lo destilda en el form de Edit, la edición silenciosamente no lo
+        // modifica — más amigable que un 400. Para (des)activar un producto
+        // hay que pasar por la acción dedicada.
+        entity.Activo = activoOriginal;
+    }
+}

--- a/src/ExtraGasMVC/Services/Implementations/ProductoService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ProductoService.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 using ExtraGasMVC.Data.Context;
 using ExtraGasMVC.Data.Entities;
 using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Extensions;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
@@ -86,6 +87,9 @@ public class ProductoService : IProductoService
     public async Task<ProductoDto> CreateAsync(CreateProductoDto producto, ulong? usuarioId, CancellationToken ct = default)
     {
         var entity = _mapper.Map<Producto>(producto);
+        // Issue #114: Activo no viene del DTO. Lo setea el Service en true
+        // porque es estado, no dato de carga del operador.
+        entity.Activo = true;
         entity.CreatedAt = DateTime.UtcNow;
         entity.UpdatedAt = DateTime.UtcNow;
         entity.CreatedBy = usuarioId;
@@ -103,9 +107,16 @@ public class ProductoService : IProductoService
         if (entity == null)
             throw new KeyNotFoundException($"Producto con Id {producto.Id} no encontrado.");
 
+        // Snapshot de Activo ANTES del AutoMapper: el formulario de Edit no
+        // debe poder modificarlo. Si el operador lo manda distinto (sea por
+        // bug del DTO, por curl o por form antiguo en cache), lo restauramos
+        // silenciosamente. ManejaGarrafaIndividual NO se preserva — es config.
+        var activoOriginal = entity.Activo;
+
         _mapper.Map(producto, entity);
         entity.UpdatedAt = DateTime.UtcNow;
         entity.UpdatedBy = usuarioId;
+        ProductoEditRules.PreservarFlagsNoEditables(entity, activoOriginal);
 
         await _context.SaveChangesAsync(ct);
 
@@ -118,9 +129,15 @@ public class ProductoService : IProductoService
         if (producto == null)
             return false;
 
+        // Issue #114 (replicado): soft-delete completo — marca DeletedAt Y
+        // baja Activo. Mantiene la invariante "Activo=false implica
+        // DeletedAt != null" que las vistas y la consulta de activos esperan.
+        // Antes solo se seteaba DeletedAt, dejando Activo=true: un zombie.
         producto.DeletedAt = DateTime.UtcNow;
+        producto.Activo = false;
+        producto.UpdatedAt = DateTime.UtcNow;
         await _context.SaveChangesAsync(ct);
-        
+
         return true;
     }
 }

--- a/src/ExtraGasMVC/Views/Productos/Create.cshtml
+++ b/src/ExtraGasMVC/Views/Productos/Create.cshtml
@@ -60,12 +60,6 @@
                         <label asp-for="ManejaGarrafaIndividual" class="form-check-label">Maneja garrafa individual</label>
                     </div>
                 </div>
-                <div class="col-md-2 d-flex align-items-end">
-                    <div class="form-check">
-                        <input asp-for="Activo" class="form-check-input" type="checkbox" />
-                        <label asp-for="Activo" class="form-check-label">Producto activo</label>
-                    </div>
-                </div>
                 <div class="col-12">
                     <label asp-for="Descripcion" class="form-label">Descripción</label>
                     <textarea asp-for="Descripcion" class="form-control" rows="3"></textarea>

--- a/src/ExtraGasMVC/Views/Productos/Edit.cshtml
+++ b/src/ExtraGasMVC/Views/Productos/Edit.cshtml
@@ -62,9 +62,19 @@
                     </div>
                 </div>
                 <div class="col-md-2 d-flex align-items-end">
-                    <div class="form-check">
-                        <input asp-for="Activo" class="form-check-input" type="checkbox" />
-                        <label asp-for="Activo" class="form-check-label">Producto activo</label>
+                    <span class="form-label">Estado</span>
+                    <div>
+                        @if ((bool)ViewBag.Activo)
+                        {
+                            <span class="badge text-bg-success">Activo</span>
+                        }
+                        else
+                        {
+                            <span class="badge text-bg-secondary">Inactivo</span>
+                        }
+                        <small class="d-block text-secondary mt-1">
+                            Cambiá con Eliminar del listado.
+                        </small>
                     </div>
                 </div>
                 <div class="col-12">

--- a/tests/ExtraGasMVC.Tests/ProductoEditRulesTests.cs
+++ b/tests/ExtraGasMVC.Tests/ProductoEditRulesTests.cs
@@ -1,0 +1,125 @@
+using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Extensions;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Tests de la regla "no editable" del módulo Productos.
+/// Garantizan que <see cref="ProductoEditRules.PreservarFlagsNoEditables"/>
+/// impone la convención: <c>Activo</c> solo cambia vía Delete, evitando el
+/// estado zombie <c>Activo=false</c> + <c>DeletedAt=null</c>.
+///
+/// <para>A diferencia de Cliente, <c>ManejaGarrafaIndividual</c> NO se
+/// preserva — es config de negocio (editable).</para>
+/// </summary>
+public class ProductoEditRulesTests
+{
+    private static Producto NewEntity(bool activo, bool manejaGarrafa = false) => new()
+    {
+        Id = 1,
+        Codigo = "GAS-10",
+        Nombre = "Garrafa 10kg",
+        TipoProductoId = 1,
+        UnidadVenta = "UNIDAD",
+        PrecioActual = 15000m,
+        ManejaGarrafaIndividual = manejaGarrafa,
+        Activo = activo,
+    };
+
+    [Fact]
+    public void PreservarFlags_ConActivoOriginalTrue_YEntityFalse_LoRestauraATrue()
+    {
+        var entity = NewEntity(activo: true);
+        entity.Activo = false; // valor que dejó el AutoMapper
+
+        ProductoEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true);
+
+        Assert.True(entity.Activo);
+    }
+
+    [Fact]
+    public void PreservarFlags_ConActivoOriginalFalse_YEntityTrue_LoRestauraAFalse()
+    {
+        var entity = NewEntity(activo: false);
+        entity.Activo = true;
+
+        ProductoEditRules.PreservarFlagsNoEditables(entity, activoOriginal: false);
+
+        Assert.False(entity.Activo);
+    }
+
+    [Fact]
+    public void PreservarFlags_ConActivoIgual_NoCambia()
+    {
+        var entity = NewEntity(activo: true);
+
+        ProductoEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true);
+
+        Assert.True(entity.Activo);
+    }
+
+    [Fact]
+    public void PreservarFlags_NoTocaManejaGarrafaIndividual_ConfigDeNegocio()
+    {
+        // ManejaGarrafaIndividual es config de negocio: el operador puede
+        // descubrir que un producto SÍ maneja garrafas y cambiarlo.
+        var entity = NewEntity(activo: true, manejaGarrafa: false);
+        entity.ManejaGarrafaIndividual = true; // operador corrigió
+
+        ProductoEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true);
+
+        Assert.True(entity.ManejaGarrafaIndividual);
+    }
+
+    [Fact]
+    public void PreservarFlags_NoTocaOtrosCampos()
+    {
+        var entity = NewEntity(activo: true);
+        entity.Nombre = "Garrafa 15kg";
+        entity.Activo = false;
+
+        ProductoEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true);
+
+        Assert.True(entity.Activo);
+        Assert.Equal("Garrafa 15kg", entity.Nombre);
+    }
+}
+
+/// <summary>
+/// Tests de regresión estructurales: garantizan que el contrato del DTO no
+/// vuelve a exponer <c>Activo</c> como propiedad editable.
+/// </summary>
+public class ProductoDtoContratoTests
+{
+    [Fact]
+    public void UpdateProductoDto_NoExponeActivo()
+    {
+        Assert.Null(typeof(UpdateProductoDto).GetProperty("Activo"));
+    }
+
+    [Fact]
+    public void CreateProductoDto_NoExponeActivo()
+    {
+        Assert.Null(typeof(CreateProductoDto).GetProperty("Activo"));
+    }
+
+    [Fact]
+    public void ProductoDto_SiExponeActivo_ParaDisplay()
+    {
+        Assert.NotNull(typeof(ProductoDto).GetProperty("Activo"));
+    }
+
+    [Fact]
+    public void UpdateProductoDto_MantieneManejaGarrafaIndividual_PorqueEsConfigDeNegocio()
+    {
+        Assert.NotNull(typeof(UpdateProductoDto).GetProperty("ManejaGarrafaIndividual"));
+    }
+
+    [Fact]
+    public void CreateProductoDto_MantieneManejaGarrafaIndividual_PorqueEsConfigDeNegocio()
+    {
+        Assert.NotNull(typeof(CreateProductoDto).GetProperty("ManejaGarrafaIndividual"));
+    }
+}


### PR DESCRIPTION
## Contexto

Mismo bug que #114 (PR #119 y PR #120), pero en el módulo Productos. `ProductoDto.Activo` era editable y `CreateAsync` no forzaba `Activo=true` — el operador podía crear productos inactivos y dejarlos en estado zombie.

**Diferencia clave**: el `Delete` del Controller estaba implementado como un `UpdateAsync` con `Activo=false` (anti-patrón). Eso dependía de que `Activo` fuera editable. Para hacer este fix correctamente, hay que refactorizar `Delete` para que delegue en `DeleteAsync` del Service, que ahora hace soft-delete completo (`DeletedAt` + `Activo=false` en una operación), consistente con Cliente/Empleado/Proveedor.

`ManejaGarrafaIndividual` se mantiene editable — es config de negocio del producto (define cómo se factura y rastrea).

## Cambios

- **`DTOs/ProductoDto.cs`**: `Activo` sale de `CreateProductoDto` y `UpdateProductoDto`. Sigue en `ProductoDto` (display).
- **`Extensions/ProductoEditRules.cs`** (nuevo): helper testeable análogo a los existentes. Solo preserva `Activo`.
- **`Services/Implementations/ProductoService.cs`**:
  - `CreateAsync` setea `Activo=true` (antes no lo hacía).
  - `UpdateAsync` captura `Activo` antes del mapper y lo restaura vía el helper.
  - `DeleteAsync` ahora setea `DeletedAt` Y `Activo=false` (antes solo `DeletedAt`, dejando `Activo=true` zombie).
- **`Controllers/ProductosController.cs`**:
  - `Create GET` ya no setea `Activo=true` en el DTO.
  - `Edit GET` pasa `Activo` por `ViewBag` para mostrarlo como info read-only.
  - **`Delete`**: refactor clave. Antes hacía `UpdateAsync` con `Activo=false`; ahora llama `DeleteAsync` directamente.
- **`Views/Productos/Create.cshtml`**: sin checkbox de `Activo`.
- **`Views/Productos/Edit.cshtml`**: badge read-only en lugar de checkbox.
- **`tests/ExtraGasMVC.Tests/ProductoEditRulesTests.cs`** (nuevo): 10 tests (helper + contrato del DTO + invariante "ManejaGarrafaIndividual sigue editable").

## Validación

- `dotnet build ExtraGasMVC.sln` → 0 errores
- `dotnet test ExtraGasMVC.sln --no-build` → 104/104 pasaron (94 base + 10 nuevos)

## Bonus de este PR

El refactor del `Delete` del Controller elimina un anti-patrón: ahora el soft-delete de Producto es **atómico a nivel Service** (consistente con el resto de los módulos). Antes el Controller se las arreglaba con un `Update` para desactivar — eso dependía del flag editable, justamente lo que estamos quitando.

## Relación con PRs previos

PR hermano de #119 (Cliente) y #120 (Empleado). Cada uno aplica el mismo patrón a su módulo, con helpers separados para no generar dependencia cruzada.