### PR TITLE
fix(usuarios): make Activo non-editable + clean up obsolete self-disable check

### DIFF
--- a/src/ExtraGasMVC/Controllers/UsuariosController.cs
+++ b/src/ExtraGasMVC/Controllers/UsuariosController.cs
@@ -42,7 +42,9 @@ public class UsuariosController : BaseController
     public async Task<IActionResult> Create(CancellationToken ct = default)
     {
         await LoadViewBagsAsync(ct);
-        return View(new CreateUsuarioDto { Activo = true });
+        // Issue #114: CreateUsuarioDto ya no expone Activo — lo setea el
+        // Service en true.
+        return View(new CreateUsuarioDto());
     }
 
     [HttpPost]
@@ -97,7 +99,6 @@ public class UsuariosController : BaseController
             Id = usuario.Id,
             Email = usuario.Email,
             RolId = usuario.RolId,
-            Activo = usuario.Activo
         };
 
         // TempData de la password temporal se consume en este render: Peek para leer
@@ -108,6 +109,10 @@ public class UsuariosController : BaseController
         if (temporaryPassword is not null) TempData.Remove("TemporaryPassword");
         if (temporaryPasswordUsername is not null) TempData.Remove("TemporaryPasswordUsername");
 
+        // Issue #114: UpdateUsuarioDto ya no expone Activo (es estado y solo
+        // cambia vía Delete). Lo pasamos por ViewBag para mostrarlo como info
+        // read-only en la vista.
+        ViewBag.Activo = usuario.Activo;
         ViewBag.TemporaryPassword = temporaryPassword;
         ViewBag.TemporaryPasswordUsername = temporaryPasswordUsername;
         ViewBag.Usuario = usuario;
@@ -128,23 +133,23 @@ public class UsuariosController : BaseController
             return View(dto);
         }
 
-        // Reglas sobre el propio usuario logueado. La autoridad es el server
-        // (la UI deshabilita los controles pero no es barrera).
-        //   - No puede desactivarse: dejaria la app sin admin (o sin su
-        //     propia cuenta) sin posibilidad de re-entrar.
-        //   - No puede cambiarse el rol: podria auto-degradarse y perder
-        //     permisos para volver a entrar (la policy [Authorize(Role =
-        //     ADMIN)] del propio controller lo bloquearia).
-        // Mismo patron que Delete y ResetPassword, que ya comparan
-        // id == currentUserId.
+        // Issue #114: la regla "no puede desactivarse a sí mismo" que vivía
+        // acá quedó obsoleta — UpdateUsuarioDto ya no expone Activo, por lo
+        // que el operador ya no puede desactivarse desde este formulario.
+        // La protección real está en Delete (que también compara
+        // id == currentUserId y rechaza TempData["Error"]).
+
+        // Regla que sí sigue vigente: no puede cambiarse el propio rol.
+        // Podria auto-degradarse y perder permisos para volver a entrar
+        // (la policy [Authorize(Role = ADMIN)] del propio controller lo
+        // bloquearia). La autoridad es el server — la UI deshabilita el
+        // select pero no es barrera.
         var currentUserId = GetCurrentUserId();
         if (id == currentUserId)
         {
             var current = await _usuarioService.GetByIdAsync(id, ct);
             if (current is null) return NotFound();
 
-            if (!dto.Activo)
-                ModelState.AddModelError(nameof(dto.Activo), "No puede desactivarse a si mismo.");
             if (dto.RolId != current.RolId)
                 ModelState.AddModelError(nameof(dto.RolId), "No puede cambiar su propio rol.");
 

--- a/src/ExtraGasMVC/DTOs/UsuarioDto.cs
+++ b/src/ExtraGasMVC/DTOs/UsuarioDto.cs
@@ -23,6 +23,11 @@ public class UsuarioDto
     public string? EmpleadoNombre { get; set; }
 }
 
+/// <summary>
+/// DTO de alta de usuario. NO incluye <c>Activo</c> (lo setea el Service en
+/// <c>true</c>). Sin esto el operador podía crear un usuario inactivo desde
+/// el formulario — un estado operacional incoherente. Issue #114.
+/// </summary>
 public class CreateUsuarioDto
 {
     [Required(ErrorMessage = "El nombre de usuario es obligatorio.")]
@@ -41,11 +46,17 @@ public class CreateUsuarioDto
     [Required(ErrorMessage = "El rol es obligatorio.")]
     public ulong RolId { get; set; }
 
-    public bool Activo { get; set; } = true;
-
     public ulong? EmpleadoId { get; set; }
 }
 
+/// <summary>
+/// DTO de edición de usuario. NO incluye <c>Activo</c>: es estado y solo
+/// cambia vía Delete (la regla "no puede desactivarse a sí mismo" del
+/// controller queda redundante: el propio Controller de Delete ya bloquea
+/// la auto-eliminación). Editarlo desde el form producía estados zombie
+/// (<c>Activo=false</c> con <c>DeletedAt=null</c>). El Service lo preserva
+/// vía <c>UsuarioEditRules.PreservarFlagsNoEditables</c>. Issue #114.
+/// </summary>
 public class UpdateUsuarioDto
 {
     public ulong Id { get; set; }
@@ -56,8 +67,6 @@ public class UpdateUsuarioDto
 
     [Required(ErrorMessage = "El rol es obligatorio.")]
     public ulong RolId { get; set; }
-
-    public bool Activo { get; set; }
 }
 
 public class ChangePasswordDto

--- a/src/ExtraGasMVC/Extensions/UsuarioEditRules.cs
+++ b/src/ExtraGasMVC/Extensions/UsuarioEditRules.cs
@@ -1,0 +1,34 @@
+using ExtraGasMVC.Data.Entities;
+
+namespace ExtraGasMVC.Extensions;
+
+/// <summary>
+/// Reglas de edición de la entidad <see cref="Usuario"/> centralizadas para
+/// poder testear sin DbContext. Aplica la convención "doble flag acoplado"
+/// del módulo usuarios — análoga a <see cref="ProveedorEditRules"/>,
+/// <see cref="ClienteEditRules"/>, <see cref="EmpleadoEditRules"/> y
+/// <see cref="ProductoEditRules"/>.
+///
+/// <para>Issue #114 (replicado en Usuarios): corrige el bug de integridad por
+/// el cual <c>UpdateUsuarioDto.Activo</c> era editable desde el formulario
+/// de Edit, permitiendo estados zombie (<c>Activo=false</c> con
+/// <c>DeletedAt=null</c>).</para>
+/// </summary>
+public static class UsuarioEditRules
+{
+    /// <summary>
+    /// Restaura los flags del usuario que Edit tiene prohibido modificar.
+    /// Llamar DESPUÉS del AutoMapper, sobre la entity ya mergeada con el DTO.
+    /// </summary>
+    /// <param name="entity">Entity post-mapper con los valores del form aplicados.</param>
+    /// <param name="activoOriginal">Valor de <c>Activo</c> leído de la BD antes del mapper.</param>
+    public static void PreservarFlagsNoEditables(Usuario entity, bool activoOriginal)
+    {
+        // REGLA DURA: el flag Activo solo cambia vía Delete. Si el operador
+        // lo destilda en el form de Edit, la edición silenciosamente no lo
+        // modifica — más amigable que un 400. Para (des)activar un usuario
+        // hay que pasar por la acción dedicada (que además bloquea la
+        // auto-eliminación por seguridad).
+        entity.Activo = activoOriginal;
+    }
+}

--- a/src/ExtraGasMVC/Services/Implementations/UsuarioService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/UsuarioService.cs
@@ -6,6 +6,7 @@ using ExtraGasMVC.Configuration;
 using ExtraGasMVC.Data.Context;
 using ExtraGasMVC.Data.Entities;
 using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Extensions;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
@@ -248,6 +249,9 @@ public class UsuarioService : IUsuarioService
     public async Task<UsuarioDto> CreateAsync(CreateUsuarioDto dto, ulong? createdBy, CancellationToken ct = default)
     {
         var usuario = _mapper.Map<Usuario>(dto);
+        // Issue #114: Activo no viene del DTO. Lo setea el Service en true
+        // porque es estado, no dato de carga del operador.
+        usuario.Activo = true;
         usuario.PasswordHash = BCrypt.Net.BCrypt.HashPassword(dto.Password);
         usuario.CreatedAt = DateTime.UtcNow;
         usuario.UpdatedAt = DateTime.UtcNow;
@@ -280,9 +284,15 @@ public class UsuarioService : IUsuarioService
         if (usuario is null)
             throw new KeyNotFoundException($"Usuario con Id {dto.Id} no encontrado.");
 
+        // Snapshot de Activo ANTES del AutoMapper: el formulario de Edit no
+        // debe poder modificarlo. Si llega por bug del DTO, curl o form
+        // antiguo en cache, lo restauramos silenciosamente.
+        var activoOriginal = usuario.Activo;
+
         _mapper.Map(dto, usuario);
         usuario.UpdatedAt = DateTime.UtcNow;
         usuario.UpdatedBy = updatedBy;
+        UsuarioEditRules.PreservarFlagsNoEditables(usuario, activoOriginal);
 
         await _context.SaveChangesAsync(ct);
 

--- a/src/ExtraGasMVC/Views/Usuarios/Create.cshtml
+++ b/src/ExtraGasMVC/Views/Usuarios/Create.cshtml
@@ -58,12 +58,6 @@
                     <label for="confirmPassword" class="form-label">Confirmar contraseña</label> <span class="text-danger">*</span>
                     <input type="password" id="confirmPassword" name="confirmPassword" class="form-control" required />
                 </div>
-                <div class="col-md-4 d-flex align-items-end">
-                    <div class="form-check">
-                        <input asp-for="Activo" class="form-check-input" type="checkbox" />
-                        <label asp-for="Activo" class="form-check-label">Usuario activo</label>
-                    </div>
-                </div>
             </div>
 
             <h5 class="mt-4">Vinculacion con empleado <small class="text-secondary">(opcional)</small></h5>

--- a/src/ExtraGasMVC/Views/Usuarios/Edit.cshtml
+++ b/src/ExtraGasMVC/Views/Usuarios/Edit.cshtml
@@ -81,23 +81,21 @@
                     <span asp-validation-for="RolId" class="text-danger small"></span>
                 </div>
                 <div class="col-md-4 d-flex align-items-end">
-                    <div class="form-check">
-                        @* Si es el propio usuario logueado, deshabilitamos el checkbox:
-                           la regla de negocio "no puede desactivarse a si mismo" la
-                           enforza el server en Edit POST, pero la UI debe reflejarlo
-                           para no tentar al usuario. Un campo hidden preserva el
-                           valor al submittar (un checkbox disabled no envia nada). *@
-                        @if (currentUserId.HasValue && currentUserId.Value == Model.Id)
-                        {
-                            <input asp-for="Activo" class="form-check-input" type="checkbox" disabled />
-                            <label class="form-check-label" for="Activo">Usuario activo (no puede desactivarse a si mismo)</label>
-                            <input type="hidden" name="Activo" value="@(Model.Activo ? "true" : "false")" />
-                        }
-                        else
-                        {
-                            <input asp-for="Activo" class="form-check-input" type="checkbox" />
-                            <label asp-for="Activo" class="form-check-label">Usuario activo</label>
-                        }
+                    <div>
+                        <span class="form-label">Estado</span>
+                        <div>
+                            @if ((bool)ViewBag.Activo)
+                            {
+                                <span class="badge text-bg-success">Activo</span>
+                            }
+                            else
+                            {
+                                <span class="badge text-bg-secondary">Inactivo</span>
+                            }
+                            <small class="d-block text-secondary mt-1">
+                                Cambiá con Eliminar del listado.
+                            </small>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/tests/ExtraGasMVC.Tests/UsuarioEditRulesTests.cs
+++ b/tests/ExtraGasMVC.Tests/UsuarioEditRulesTests.cs
@@ -1,0 +1,124 @@
+using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Extensions;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Tests de la regla "no editable" del módulo Usuarios.
+/// Garantizan que <see cref="UsuarioEditRules.PreservarFlagsNoEditables"/>
+/// impone la convención: <c>Activo</c> solo cambia vía Delete.
+///
+/// <para>La regla "no puede desactivarse a sí mismo" del Controller de Edit
+/// quedó obsoleta con este fix (el DTO ya no expone Activo); la protección
+/// real pasó a Delete, que ya comparaba id == currentUserId.</para>
+/// </summary>
+public class UsuarioEditRulesTests
+{
+    private static Usuario NewEntity(bool activo) => new()
+    {
+        Id = 1,
+        Username = "jperez",
+        PasswordHash = "hash",
+        RolId = 1,
+        Activo = activo,
+    };
+
+    [Fact]
+    public void PreservarFlags_ConActivoOriginalTrue_YEntityFalse_LoRestauraATrue()
+    {
+        var entity = NewEntity(activo: true);
+        entity.Activo = false;
+
+        UsuarioEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true);
+
+        Assert.True(entity.Activo);
+    }
+
+    [Fact]
+    public void PreservarFlags_ConActivoOriginalFalse_YEntityTrue_LoRestauraAFalse()
+    {
+        var entity = NewEntity(activo: false);
+        entity.Activo = true;
+
+        UsuarioEditRules.PreservarFlagsNoEditables(entity, activoOriginal: false);
+
+        Assert.False(entity.Activo);
+    }
+
+    [Fact]
+    public void PreservarFlags_ConActivoIgual_NoCambia()
+    {
+        var entity = NewEntity(activo: true);
+
+        UsuarioEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true);
+
+        Assert.True(entity.Activo);
+    }
+
+    [Fact]
+    public void PreservarFlags_NoTocaPasswordHash()
+    {
+        // Defense-in-depth: si alguien agrega Password al DTO por error,
+        // el helper no debe pisar el hash persistido.
+        var entity = NewEntity(activo: true);
+        entity.PasswordHash = "hash-original";
+
+        UsuarioEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true);
+
+        Assert.Equal("hash-original", entity.PasswordHash);
+    }
+
+    [Fact]
+    public void PreservarFlags_NoTocaEmail_CampoEditable()
+    {
+        // Email sí es editable (el operador puede corregirlo).
+        var entity = NewEntity(activo: true);
+        entity.Email = "nuevo@email.com";
+
+        UsuarioEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true);
+
+        Assert.Equal("nuevo@email.com", entity.Email);
+    }
+}
+
+/// <summary>
+/// Tests de regresión estructurales: garantizan que el contrato del DTO no
+/// vuelve a exponer <c>Activo</c> como propiedad editable.
+/// </summary>
+public class UsuarioDtoContratoTests
+{
+    [Fact]
+    public void UpdateUsuarioDto_NoExponeActivo()
+    {
+        Assert.Null(typeof(UpdateUsuarioDto).GetProperty("Activo"));
+    }
+
+    [Fact]
+    public void CreateUsuarioDto_NoExponeActivo()
+    {
+        Assert.Null(typeof(CreateUsuarioDto).GetProperty("Activo"));
+    }
+
+    [Fact]
+    public void UsuarioDto_SiExponeActivo_ParaDisplay()
+    {
+        Assert.NotNull(typeof(UsuarioDto).GetProperty("Activo"));
+    }
+
+    [Fact]
+    public void UpdateUsuarioDto_MantieneEmailYRolId_PorqueSonEditables()
+    {
+        Assert.NotNull(typeof(UpdateUsuarioDto).GetProperty("Email"));
+        Assert.NotNull(typeof(UpdateUsuarioDto).GetProperty("RolId"));
+    }
+
+    [Fact]
+    public void UpdateUsuarioDto_NoExponeUsername_PorqueEsIdentidad()
+    {
+        // Username es identidad del usuario (no se cambia). Si alguien lo
+        // agrega al DTO de Update, este test rompe en compilación.
+        Assert.Null(typeof(UpdateUsuarioDto).GetProperty("Username"));
+    }
+}

--- a/tests/ExtraGasMVC.Tests/UsuariosCreateViewBagTests.cs
+++ b/tests/ExtraGasMVC.Tests/UsuariosCreateViewBagTests.cs
@@ -141,7 +141,7 @@ public sealed class UsuariosCreateViewBagTests
         Email = "nuevo@test.local",
         RolId = 1,
         Password = "Valida123!",
-        Activo = true,
+        // Issue #114: Activo ya no se setea desde el DTO — lo hace el Service.
     };
 
     private static FakeUsuarioService NewUsuarioService(


### PR DESCRIPTION
## Contexto

Mismo bug que #114 (PR #119, #120, #121), pero en el módulo Usuarios. `UpdateUsuarioDto.Activo` era editable y `CreateAsync` no forzaba `Activo=true` — el operador podía crear usuarios inactivos y dejarlos en estado zombie.

**Limpieza incluida**: la regla "no puede desactivarse a sí mismo" del Controller de Edit POST quedaba redundante con este fix. La protección real (auto-eliminación) ya estaba en `Delete`, que comparaba `id == currentUserId`. Se elimina la regla obsoleta y se mantiene "no puede cambiar su propio rol" (sigue vigente).

`Username` no es editable por convención del sistema (identidad del usuario); `UpdateUsuarioDto` ya no lo expone y se mantiene así.

## Cambios

- **`DTOs/UsuarioDto.cs`**: `Activo` sale de `CreateUsuarioDto` y `UpdateUsuarioDto`. Sigue en `UsuarioDto` (display).
- **`Extensions/UsuarioEditRules.cs`** (nuevo): helper testeable análogo a los existentes.
- **`Services/Implementations/UsuarioService.cs`**:
  - `CreateAsync` setea `Activo=true` (antes no lo hacía).
  - `UpdateAsync` captura `Activo` antes del mapper y lo restaura vía el helper.
- **`Controllers/UsuariosController.cs`**:
  - `Create GET` ya no setea `Activo=true` en el DTO.
  - `Edit GET` pasa `Activo` por `ViewBag` para mostrarlo como info read-only.
  - `Edit POST`: se elimina la validación obsoleta de auto-desactivación.
- **`Views/Usuarios/Create.cshtml`**: sin checkbox de `Activo`.
- **`Views/Usuarios/Edit.cshtml`**: badge read-only en lugar del bloque del checkbox disabled (ya no aplica).
- **`tests/ExtraGasMVC.Tests/UsuarioEditRulesTests.cs`** (nuevo): 10 tests.
- **`tests/ExtraGasMVC.Tests/UsuariosCreateViewBagTests.cs`**: adaptado al nuevo DTO (era el único test que asumía `Activo=true` en `CreateUsuarioDto`).

## Validación

- `dotnet build ExtraGasMVC.sln` → 0 errores
- `dotnet test ExtraGasMVC.sln --no-build` → 104/104 pasaron (94 base + 10 nuevos)

## Estado del patrón "no editable" en el repo

Tras este PR, los 5 módulos con `Activo` siguen la misma convención:

| Módulo | Helper | Campos preservados | Service fuerza `Activo=true` en alta |
|---|---|---|---|
| Proveedores | `ProveedorEditRules` | `Activo` | ✅ |
| Clientes | `ClienteEditRules` | `Activo`, `FechaAlta` | ✅ |
| Empleados | `EmpleadoEditRules` | `Activo` | ✅ (antes no) |
| Productos | `ProductoEditRules` | `Activo` | ✅ (antes no) |
| Usuarios | `UsuarioEditRules` | `Activo` | ✅ (antes no) |

## Relación con PRs previos

PR hermano de #119 (Cliente), #120 (Empleado) y #121 (Productos). Cada uno aplica el mismo patrón a su módulo, con helpers separados para no generar dependencia cruzada.

Módulos restantes: Pedido (no tiene `Activo`), Garrafa (lo maneja por estado), Pago (sin `Activo`). **Auditados y limpios.**