### PR TITLE
fix(proveedores): close DTO contract hole for Activo

### DIFF
--- a/src/ExtraGasMVC/Controllers/ProveedoresController.cs
+++ b/src/ExtraGasMVC/Controllers/ProveedoresController.cs
@@ -40,7 +40,9 @@ public class ProveedoresController : BaseController
     public async Task<IActionResult> Create(CancellationToken ct = default)
     {
         await LoadViewBagsAsync(ct);
-        return View(new CreateProveedorDto { Activo = true });
+        // Issue #114: CreateProveedorDto ya no expone Activo — lo setea el
+        // Service en true.
+        return View(new CreateProveedorDto());
     }
 
     [HttpPost]
@@ -77,7 +79,12 @@ public class ProveedoresController : BaseController
     {
         var proveedor = await _proveedorService.GetByIdAsync(id, ct);
         if (proveedor is null) return NotFound();
-        
+
+        // Issue #114: UpdateProveedorDto ya no expone Activo (es estado y solo
+        // cambia vía Delete). Lo pasamos por ViewBag para mostrarlo como info
+        // read-only en la vista.
+        ViewBag.Activo = proveedor.Activo;
+
         var updateDto = _mapper.Map<UpdateProveedorDto>(proveedor);
         await LoadViewBagsAsync(ct);
         return View(updateDto);

--- a/src/ExtraGasMVC/DTOs/ProveedorDto.cs
+++ b/src/ExtraGasMVC/DTOs/ProveedorDto.cs
@@ -28,6 +28,12 @@ public class ProveedorDto
     public bool Activo { get; set; }
 }
 
+/// <summary>
+/// DTO de alta de proveedor. NO incluye <c>Activo</c> (lo setea el Service en
+/// <c>true</c>). El flag <c>Activo</c> de Proveedor solo cambia vía Delete —
+/// el helper <see cref="ProveedorEditRules"/> preserva el patrón en Update.
+/// Issue #114.
+/// </summary>
 public class CreateProveedorDto
 {
     [Display(Name = "Código")]
@@ -95,11 +101,15 @@ public class CreateProveedorDto
 
     [Display(Name = "Observaciones")]
     public string? Observaciones { get; set; }
-
-    [Display(Name = "Activo")]
-    public bool Activo { get; set; }
 }
 
+/// <summary>
+/// DTO de edición de proveedor. NO incluye <c>Activo</c>: el flag es estado y
+/// solo cambia vía Delete. El Service lo preserva vía
+/// <see cref="ProveedorEditRules.PreservarFlagsNoEditables"/>. Issue #114.
+/// (La defensa en UI — checkbox disabled con nota — ya existía; este cambio
+/// cierra la inconsistencia del contrato del DTO).
+/// </summary>
 public class UpdateProveedorDto
 {
     public ulong Id { get; set; }
@@ -169,7 +179,4 @@ public class UpdateProveedorDto
 
     [Display(Name = "Observaciones")]
     public string? Observaciones { get; set; }
-
-    [Display(Name = "Activo")]
-    public bool Activo { get; set; }
 }

--- a/src/ExtraGasMVC/Services/Implementations/ProveedorService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ProveedorService.cs
@@ -82,6 +82,9 @@ public class ProveedorService : IProveedorService
             throw new InvalidOperationException("El CUIT ingresado ya está registrado.");
 
         var entity = _mapper.Map<Proveedor>(proveedor);
+        // Issue #114: Activo no viene del DTO. Lo setea el Service en true
+        // porque es estado, no dato de carga del operador.
+        entity.Activo = true;
         entity.CreatedAt = DateTime.UtcNow;
         entity.UpdatedAt = DateTime.UtcNow;
         entity.CreatedBy = createdBy;

--- a/src/ExtraGasMVC/Views/Proveedores/Create.cshtml
+++ b/src/ExtraGasMVC/Views/Proveedores/Create.cshtml
@@ -41,16 +41,15 @@
                     <span asp-validation-for="NombreFantasia" class="text-danger"></span>
                 </div>
                 <div class="col-md-3 d-flex align-items-end">
-                    <div class="form-check">
-                        <input asp-for="Activo" class="form-check-input" type="checkbox" disabled checked />
-                        <label asp-for="Activo" class="form-check-label"></label>
+                    <div>
+                        <span class="form-label">Estado</span>
+                        <div>
+                            <span class="badge text-bg-success">Se crea activo</span>
+                            <small class="d-block text-secondary mt-1">
+                                Para desactivarlo, use <strong>Eliminar</strong> desde el listado.
+                            </small>
+                        </div>
                     </div>
-                </div>
-                <div class="col-12">
-                    <small class="text-secondary">
-                        <i class="bi bi-info-circle me-1"></i>
-                        Los proveedores nuevos nacen activos. Para desactivarlos, use <strong>Eliminar</strong> desde el listado.
-                    </small>
                 </div>
             </div>
             <h5 class="mt-4">Contacto</h5>

--- a/src/ExtraGasMVC/Views/Proveedores/Edit.cshtml
+++ b/src/ExtraGasMVC/Views/Proveedores/Edit.cshtml
@@ -42,16 +42,22 @@
                     <span asp-validation-for="NombreFantasia" class="text-danger"></span>
                 </div>
                 <div class="col-md-3 d-flex align-items-end">
-                    <div class="form-check">
-                        <input asp-for="Activo" class="form-check-input" type="checkbox" disabled />
-                        <label asp-for="Activo" class="form-check-label"></label>
+                    <div>
+                        <span class="form-label">Estado</span>
+                        <div>
+                            @if ((bool)ViewBag.Activo)
+                            {
+                                <span class="badge text-bg-success">Activo</span>
+                            }
+                            else
+                            {
+                                <span class="badge text-bg-secondary">Inactivo</span>
+                            }
+                            <small class="d-block text-secondary mt-1">
+                                Se gestiona desde <strong>Eliminar</strong> del listado.
+                            </small>
+                        </div>
                     </div>
-                </div>
-                <div class="col-12">
-                    <small class="text-secondary">
-                        <i class="bi bi-info-circle me-1"></i>
-                        El estado de activación se gestiona desde <strong>Eliminar</strong>; este formulario no lo modifica.
-                    </small>
                 </div>
             </div>
             <h5 class="mt-4">Contacto</h5>

--- a/tests/ExtraGasMVC.Tests/ProveedorDtoContratoTests.cs
+++ b/tests/ExtraGasMVC.Tests/ProveedorDtoContratoTests.cs
@@ -1,0 +1,39 @@
+using ExtraGasMVC.DTOs;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Tests de regresión estructurales: Garantizan que el contrato del DTO no
+/// vuelve a exponer <c>Activo</c> como propiedad editable. Si alguien lo
+/// vuelve a poner en CreateProveedorDto o UpdateProveedorDto, los tests
+/// fallan en compilación.
+///
+/// <para>El patrón es análogo al de Cliente, Empleado, Producto y Usuario
+/// (todos del issue #114). Proveedor es el último del recorrido porque ya
+/// tenía el helper <see cref="Extensions.ProveedorEditRules"/> y la defensa
+/// en UI, pero el DTO seguía editable — un agujero de contrato que un POST
+/// hand-crafted podría explotar.</para>
+/// </summary>
+public class ProveedorDtoContratoTests
+{
+    [Fact]
+    public void UpdateProveedorDto_NoExponeActivo()
+    {
+        Assert.Null(typeof(UpdateProveedorDto).GetProperty("Activo"));
+    }
+
+    [Fact]
+    public void CreateProveedorDto_NoExponeActivo()
+    {
+        Assert.Null(typeof(CreateProveedorDto).GetProperty("Activo"));
+    }
+
+    [Fact]
+    public void ProveedorDto_SiExponeActivo_ParaDisplay()
+    {
+        // El DTO de salida sigue exponiéndolo porque Details/Index lo
+        // necesitan para mostrar el badge de estado.
+        Assert.NotNull(typeof(ProveedorDto).GetProperty("Activo"));
+    }
+}


### PR DESCRIPTION
## Contexto

Cierre de la inconsistencia del patrón #114 en el módulo Proveedores. **Era el único módulo de los 5 con `Activo` que NO tenía el DTO limpio**:

- ✅ Defensa en UI: checkbox `disabled` con nota explicativa.
- ✅ Defensa en Service: `ProveedorEditRules.PreservarFlagsNoEditables` (issue previa).
- ❌ **Defensa en DTO: faltaba**. El contrato seguía editable.

Un POST hand-crafted (curl, raw form, form cacheado) podía mandar `Activo=false`. La defensa en Service lo restauraba silenciosamente — pero el contrato del DTO era engañoso, y un fallo futuro del helper (o un bypass) podría exponer el bug.

## Cambios

- **`DTOs/ProveedorDto.cs`**: `Activo` sale de `CreateProveedorDto` y `UpdateProveedorDto`. Sigue en `ProveedorDto` (read shape).
- **`Services/Implementations/ProveedorService.cs`**: `CreateAsync` ahora setea `Activo=true` (antes el operador podía crear proveedores inactivos).
- **`Controllers/ProveedoresController.cs`**:
  - `Create GET` ya no setea `Activo=true` en el DTO.
  - `Edit GET` pasa `Activo` por `ViewBag` para mostrarlo como info read-only.
- **`Views/Proveedores/Create.cshtml`**: badge "Se crea activo" en lugar del checkbox disabled checked.
- **`Views/Proveedores/Edit.cshtml`**: badge read-only con el estado actual (Activo/Inactivo) en lugar del checkbox disabled.
- **`tests/.../ProveedorDtoContratoTests.cs`** (nuevo): 3 tests de regresión.

## Validación

- `dotnet build` → 0 errores
- `dotnet test` → 97/97 pasaron (94 base + 3 nuevos)

## Estado del patrón tras este PR

| Módulo | Helper | DTO expone `Activo` | UI protegida | Service preserva | `CreateAsync` fuerza `true` |
|---|---|---|---|---|---|
| Proveedores | ✅ | ❌ (limpio ahora) | ✅ | ✅ | ✅ (ahora) |
| Clientes | ✅ | ❌ | ❌→badge | ✅ | ✅ |
| Empleados | ✅ | ❌ | ❌→badge | ✅ | ✅ |
| Productos | ✅ | ❌ | ❌→badge | ✅ | ✅ |
| Usuarios | ✅ | ❌ | ❌→badge | ✅ | ✅ |

Proveedor es ahora 100% consistente con el resto.