### PR TITLE
fix(garrafas): make Activo non-editable (Activo=soft-delete, estado_garrafa_id=operacional)

### DIFF
--- a/src/ExtraGasMVC/Controllers/GarrafasController.cs
+++ b/src/ExtraGasMVC/Controllers/GarrafasController.cs
@@ -118,10 +118,11 @@ public class GarrafasController : BaseController
     public async Task<IActionResult> Create(CancellationToken ct = default)
     {
         await LoadViewBagsAsync(ct);
+        // Issue #114: CreateGarrafaDto ya no expone Activo — lo setea el
+        // Service en true.
         return View(new CreateGarrafaDto
         {
             EstadoGarrafaId = 1,
-            Activo = true,
             FechaCompra = DateOnly.FromDateTime(DateTime.UtcNow)
         });
     }
@@ -196,6 +197,11 @@ public class GarrafasController : BaseController
 
         await LoadViewBagsAsync(ct);
 
+        // Issue #114: UpdateGarrafaDto ya no expone Activo (es estado y solo
+        // cambia vía Delete). Lo pasamos por ViewBag para mostrarlo como info
+        // read-only en la vista.
+        ViewBag.Activo = garrafa.Activo;
+
         var updateDto = new UpdateGarrafaDto
         {
             Id = garrafa.Id,
@@ -206,7 +212,6 @@ public class GarrafasController : BaseController
             FechaCompra = garrafa.FechaCompra,
             EstadoGarrafaId = garrafa.EstadoGarrafaId,
             ClienteId = garrafa.ClienteId,
-            Activo = garrafa.Activo,
             Observaciones = garrafa.Observaciones
         };
 

--- a/src/ExtraGasMVC/DTOs/GarrafaDto.cs
+++ b/src/ExtraGasMVC/DTOs/GarrafaDto.cs
@@ -48,6 +48,14 @@ public class GarrafaDto
     public string? ProveedorNombre { get; set; }
 }
 
+/// <summary>
+/// DTO de alta de garrafa. NO incluye <c>Activo</c> (lo setea el Service en
+/// <c>true</c>). El flag <c>Activo</c> de Garrafa cumple un rol distinto al
+/// de <c>estado_garrafa_id</c>: marca si la garrafa está dada de baja
+/// (soft-delete), mientras que el estado describe la situación operacional
+/// (LLENA_DEPOSITO, EN_CLIENTE, FUERA_SERVICIO, etc.). Solo cambia vía
+/// Delete. Issue #114.
+/// </summary>
 public class CreateGarrafaDto
 {
     [Display(Name = "Código")]
@@ -75,11 +83,19 @@ public class CreateGarrafaDto
 
     public ulong? ClienteId { get; set; }
 
-    public bool Activo { get; set; }
-
     public string? Observaciones { get; set; }
 }
 
+/// <summary>
+/// DTO de edición de garrafa. NO incluye <c>Activo</c>: es estado y solo
+/// cambia vía Delete. El Service lo preserva vía
+/// <c>GarrafaEditRules.PreservarFlagsNoEditables</c>. Issue #114.
+///
+/// <para>El estado operacional de la garrafa (<c>EstadoGarrafaId</c>) sí es
+/// editable — se cambia con la acción dedicada "Cambiar estado" del
+/// Controller, que valida contra la matriz de transiciones. NO se mezcla
+/// con <c>Activo</c>: son dos flags con propósitos distintos.</para>
+/// </summary>
 public class UpdateGarrafaDto
 {
     public ulong Id { get; set; }
@@ -108,8 +124,6 @@ public class UpdateGarrafaDto
     public ulong EstadoGarrafaId { get; set; }
 
     public ulong? ClienteId { get; set; }
-
-    public bool Activo { get; set; }
 
     public string? Observaciones { get; set; }
 }

--- a/src/ExtraGasMVC/Extensions/GarrafaEditRules.cs
+++ b/src/ExtraGasMVC/Extensions/GarrafaEditRules.cs
@@ -1,0 +1,44 @@
+using ExtraGasMVC.Data.Entities;
+
+namespace ExtraGasMVC.Extensions;
+
+/// <summary>
+/// Reglas de edición de la entidad <see cref="Garrafa"/> centralizadas para
+/// poder testear sin DbContext. Aplica la convención "Activo es estado de
+/// soft-delete, no dato operacional" — análoga a los demás
+/// <c>*EditRules</c> (Proveedor, Cliente, Empleado, Producto, Usuario).
+///
+/// <para>Garrafa tiene DOS flags que parecen superponerse pero son ortogonales:
+/// <list type="bullet">
+/// <item><c>Activo</c>: si la garrafa está dada de baja (soft-delete). Lo
+/// cambia solo <c>Delete</c>.</item>
+/// <item><c>estado_garrafa_id</c>: situación operacional (LLENA_DEPOSITO,
+/// EN_CLIENTE, FUERA_SERVICIO, etc.). Lo cambia la acción dedicada
+/// "Cambiar estado" con validación contra <c>GarrafaTransiciones</c>.</item>
+/// </list>
+/// Este helper solo preserva <c>Activo</c>. El estado operacional se
+/// gestiona por otro camino.</para>
+///
+/// <para>Issue #114 (replicado en Garrafas): corrige el bug por el cual
+/// <c>UpdateGarrafaDto.Activo</c> era editable desde el formulario de Edit,
+/// permitiendo desactivar garrafas sin pasar por Delete y dejar el campo
+/// inconsistente con el sistema de estados.</para>
+/// </summary>
+public static class GarrafaEditRules
+{
+    /// <summary>
+    /// Restaura el flag <c>Activo</c> de la garrafa que Edit tiene prohibido
+    /// modificar. Llamar DESPUÉS del AutoMapper, sobre la entity ya mergeada
+    /// con el DTO.
+    /// </summary>
+    /// <param name="entity">Entity post-mapper con los valores del form aplicados.</param>
+    /// <param name="activoOriginal">Valor de <c>Activo</c> leído de la BD antes del mapper.</param>
+    public static void PreservarFlagsNoEditables(Garrafa entity, bool activoOriginal)
+    {
+        // REGLA DURA: el flag Activo solo cambia vía Delete. Si el operador
+        // lo destilda en el form de Edit, la edición silenciosamente no lo
+        // modifica — más amigable que un 400. Para dar de baja una garrafa
+        // hay que pasar por la acción dedicada.
+        entity.Activo = activoOriginal;
+    }
+}

--- a/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/GarrafaService.cs
@@ -5,6 +5,7 @@ using ExtraGasMVC.Data.Context;
 using ExtraGasMVC.Data.Entities;
 using ExtraGasMVC.Data.Entities.Views;
 using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Extensions;
 using ExtraGasMVC.Models.ViewModels;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
@@ -218,6 +219,9 @@ public class GarrafaService : IGarrafaService
             throw new InvalidOperationException($"Ya existe una garrafa con el código {garrafa.Codigo}.");
 
         var entity = _mapper.Map<Garrafa>(garrafa);
+        // Issue #114: Activo no viene del DTO. Lo setea el Service en true
+        // porque es estado (soft-delete), no dato de carga del operador.
+        entity.Activo = true;
         entity.CreatedAt = DateTime.UtcNow;
         entity.UpdatedAt = DateTime.UtcNow;
         entity.CreatedBy = usuarioId;
@@ -238,9 +242,16 @@ public class GarrafaService : IGarrafaService
         if (await _context.Garrafas.AnyAsync(g => g.Codigo == garrafa.Codigo && g.Id != garrafa.Id, ct))
             throw new InvalidOperationException($"Ya existe una garrafa con el código {garrafa.Codigo}.");
 
+        // Snapshot de Activo ANTES del AutoMapper: el formulario de Edit no
+        // debe poder modificarlo. Si el operador lo manda distinto, lo
+        // restauramos silenciosamente. El estado operacional
+        // (estado_garrafa_id) NO se preserva — lo cambia la acción dedicada.
+        var activoOriginal = entity.Activo;
+
         _mapper.Map(garrafa, entity);
         entity.UpdatedAt = DateTime.UtcNow;
         entity.UpdatedBy = usuarioId;
+        GarrafaEditRules.PreservarFlagsNoEditables(entity, activoOriginal);
 
         await SaveOrThrowDuplicateAsync(garrafa.Codigo, ct);
 

--- a/src/ExtraGasMVC/Views/Garrafas/Create.cshtml
+++ b/src/ExtraGasMVC/Views/Garrafas/Create.cshtml
@@ -75,9 +75,14 @@
                     </select>
                 </div>
                 <div class="col-md-12 d-flex align-items-end">
-                    <div class="form-check">
-                        <input asp-for="Activo" class="form-check-input" type="checkbox" />
-                        <label asp-for="Activo" class="form-check-label">Activo</label>
+                    <div>
+                        <span class="form-label">Estado</span>
+                        <div>
+                            <span class="badge text-bg-success">Se crea activa</span>
+                            <small class="d-block text-secondary mt-1">
+                                Para darla de baja, use <strong>Eliminar</strong> desde el listado.
+                            </small>
+                        </div>
                     </div>
                 </div>
                 <div class="col-12">

--- a/src/ExtraGasMVC/Views/Garrafas/Edit.cshtml
+++ b/src/ExtraGasMVC/Views/Garrafas/Edit.cshtml
@@ -87,9 +87,21 @@
                     </select>
                 </div>
                 <div class="col-md-12 d-flex align-items-end">
-                    <div class="form-check">
-                        <input asp-for="Activo" class="form-check-input" type="checkbox" />
-                        <label asp-for="Activo" class="form-check-label">Activo</label>
+                    <div>
+                        <span class="form-label">Estado</span>
+                        <div>
+                            @if ((bool)ViewBag.Activo)
+                            {
+                                <span class="badge text-bg-success">Activo</span>
+                            }
+                            else
+                            {
+                                <span class="badge text-bg-secondary">Inactivo</span>
+                            }
+                            <small class="d-block text-secondary mt-1">
+                                Se gestiona desde <strong>Eliminar</strong> del listado.
+                            </small>
+                        </div>
                     </div>
                 </div>
                 <div class="col-12">

--- a/tests/ExtraGasMVC.Tests/GarrafaEditRulesTests.cs
+++ b/tests/ExtraGasMVC.Tests/GarrafaEditRulesTests.cs
@@ -1,0 +1,121 @@
+using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Extensions;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Tests de la regla "no editable" del módulo Garrafas.
+/// Garantizan que <see cref="GarrafaEditRules.PreservarFlagsNoEditables"/>
+/// impone la convención: <c>Activo</c> solo cambia vía Delete.
+///
+/// <para>Garrafa tiene DOS flags ortogonales: <c>Activo</c> (soft-delete) y
+/// <c>estado_garrafa_id</c> (situación operacional). Este helper solo
+/// preserva <c>Activo</c>; el estado operacional se gestiona por la acción
+/// dedicada con validación contra la matriz de transiciones.</para>
+/// </summary>
+public class GarrafaEditRulesTests
+{
+    private static Garrafa NewEntity(bool activo, ulong estadoId = 1) => new()
+    {
+        Id = 1,
+        Codigo = "GAR-001",
+        CapacidadKg = 10,
+        FechaCompra = new DateOnly(2024, 1, 15),
+        EstadoGarrafaId = estadoId,
+        Activo = activo,
+    };
+
+    [Fact]
+    public void PreservarFlags_ConActivoOriginalTrue_YEntityFalse_LoRestauraATrue()
+    {
+        var entity = NewEntity(activo: true);
+        entity.Activo = false;
+
+        GarrafaEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true);
+
+        Assert.True(entity.Activo);
+    }
+
+    [Fact]
+    public void PreservarFlags_ConActivoOriginalFalse_YEntityTrue_LoRestauraAFalse()
+    {
+        var entity = NewEntity(activo: false);
+        entity.Activo = true;
+
+        GarrafaEditRules.PreservarFlagsNoEditables(entity, activoOriginal: false);
+
+        Assert.False(entity.Activo);
+    }
+
+    [Fact]
+    public void PreservarFlags_ConActivoIgual_NoCambia()
+    {
+        var entity = NewEntity(activo: true);
+
+        GarrafaEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true);
+
+        Assert.True(entity.Activo);
+    }
+
+    [Fact]
+    public void PreservarFlags_NoTocaEstadoOperacional_CambioPorAccionDedicada()
+    {
+        // El estado operacional (estado_garrafa_id) SÍ es editable vía la
+        // acción CambiarEstado con validación contra la matriz. Edit no
+        // debe tocar este flag directamente — pero el helper NO lo restaura.
+        // Eso lo deja en manos de la acción dedicada, que es la autoridad.
+        var entity = NewEntity(activo: true, estadoId: 1);
+        entity.EstadoGarrafaId = 3; // operador cambió el estado
+
+        GarrafaEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true);
+
+        Assert.Equal((ulong)3, entity.EstadoGarrafaId);
+    }
+
+    [Fact]
+    public void PreservarFlags_NoTocaOtrosCampos()
+    {
+        var entity = NewEntity(activo: true);
+        entity.Observaciones = "Observación nueva";
+        entity.Activo = false;
+
+        GarrafaEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true);
+
+        Assert.True(entity.Activo);
+        Assert.Equal("Observación nueva", entity.Observaciones);
+    }
+}
+
+/// <summary>
+/// Tests de regresión estructurales del DTO.
+/// </summary>
+public class GarrafaDtoContratoTests
+{
+    [Fact]
+    public void UpdateGarrafaDto_NoExponeActivo()
+    {
+        Assert.Null(typeof(UpdateGarrafaDto).GetProperty("Activo"));
+    }
+
+    [Fact]
+    public void CreateGarrafaDto_NoExponeActivo()
+    {
+        Assert.Null(typeof(CreateGarrafaDto).GetProperty("Activo"));
+    }
+
+    [Fact]
+    public void GarrafaDto_SiExponeActivo_ParaDisplay()
+    {
+        Assert.NotNull(typeof(GarrafaDto).GetProperty("Activo"));
+    }
+
+    [Fact]
+    public void UpdateGarrafaDto_MantieneEstadoGarrafaId_PorqueEsEstadoOperacional()
+    {
+        // El estado operacional SÍ es editable desde Edit (cambio de
+        // situación). Distinto de Activo, que es soft-delete.
+        Assert.NotNull(typeof(UpdateGarrafaDto).GetProperty("EstadoGarrafaId"));
+    }
+}


### PR DESCRIPTION
## Contexto

Aplicando el patrón #114 al módulo Garrafas. GarrafaDto.Activo era editable y `CreateAsync` no forzaba `Activo=true`.

**Particularidad**: Garrafa tiene DOS flags ortogonales que parecen superponerse pero cumplen roles distintos:

- **`Activo`**: soft-delete. Lo cambia solo `Delete`. → Se bloquea con este PR.
- **`estado_garrafa_id`**: situación operacional (`LLENA_DEPOSITO`, `EN_CLIENTE`, `FUERA_SERVICIO`, etc.). Lo cambia la acción dedicada "Cambiar Estado" con validación contra `GarrafaTransiciones`. → Sigue editable vía esa acción.

Solo `Activo` recibe el patrón. El estado operacional sigue siendo editable por la acción dedicada.

## Cambios

- **`DTOs/GarrafaDto.cs`**: `Activo` sale de `CreateGarrafaDto` y `UpdateGarrafaDto`. Sigue en `GarrafaDto` (display).
- **`Extensions/GarrafaEditRules.cs`** (nuevo): helper testeable análogo a los existentes. Solo preserva `Activo`.
- **`Services/Implementations/GarrafaService.cs`**:
  - `CreateAsync` setea `Activo=true` (antes no).
  - `UpdateAsync` captura `Activo` antes del mapper y lo restaura vía el helper.
- **`Controllers/GarrafasController.cs`**: `Create GET` ya no setea `Activo=true` en el DTO. `Edit GET` pasa `Activo` por `ViewBag`.
- **`Views/Garrafas/Create.cshtml`**: badge "Se crea activa" en lugar del checkbox.
- **`Views/Garrafas/Edit.cshtml`**: badge read-only en lugar del checkbox.
- **`tests/.../GarrafaEditRulesTests.cs`** (nuevo): 9 tests.

## Validación

- `dotnet build` → 0 errores
- `dotnet test` → 143/143 pasaron (134 base con los 4 PRs anteriores mergeados + 9 nuevos)

## Estado del patrón tras este PR

6 módulos siguen la convención "Activo solo cambia vía Delete/Restore":

| Módulo | Helper | Service fuerza `Activo=true` en alta |
|---|---|---|
| Proveedores | `ProveedorEditRules` | ✅ |
| Clientes | `ClienteEditRules` (+ `FechaAlta`) | ✅ |
| Empleados | `EmpleadoEditRules` | ✅ |
| Productos | `ProductoEditRules` | ✅ |
| Usuarios | `UsuarioEditRules` | ✅ |
| **Garrafas** | **`GarrafaEditRules`** | **✅ (este PR)** |

PR hermano de #119, #120, #121, #122, #123.