### PR TITLE
fix(recepciones): make Total derived (Subtotal - Descuento), not editable

### DIFF
--- a/src/ExtraGasMVC/DTOs/CrearRecepcionDto.cs
+++ b/src/ExtraGasMVC/DTOs/CrearRecepcionDto.cs
@@ -7,6 +7,12 @@ namespace ExtraGasMVC.DTOs;
 /// (issue #45). For each item, when the product is GARRAFA
 /// (<c>maneja_garrafa_individual = TRUE</c>) the <c>CodigosGarrafa</c> list
 /// must contain exactly <c>Cantidad</c> codes.
+///
+/// <para>El <c>Total</c> NO es input: se calcula como <c>Subtotal - Descuento</c>
+/// en el Service vía <see cref="Extensions.RecepcionTotalRules.Calcular"/>.
+/// Si el operador pudiera tipearlo a mano, podría quedar inconsistente
+/// con Subtotal y Descuento — bug clásico de "campo derivado editable".
+/// La vista lo muestra como readonly, recalculado por JS.</para>
 /// </summary>
 public class CrearRecepcionDto
 {
@@ -30,10 +36,6 @@ public class CrearRecepcionDto
     [Display(Name = "Descuento")]
     [Range(0, 9999999999.99, ErrorMessage = "El descuento debe estar entre {1} y {2}.")]
     public decimal Descuento { get; set; }
-
-    [Display(Name = "Total")]
-    [Range(0, 9999999999.99, ErrorMessage = "El total debe estar entre {1} y {2}.")]
-    public decimal Total { get; set; }
 
     [Display(Name = "Observaciones")]
     [StringLength(2000, ErrorMessage = "Las observaciones no pueden superar {1} caracteres.")]

--- a/src/ExtraGasMVC/Extensions/RecepcionTotalRules.cs
+++ b/src/ExtraGasMVC/Extensions/RecepcionTotalRules.cs
@@ -1,0 +1,42 @@
+namespace ExtraGasMVC.Extensions;
+
+/// <summary>
+/// Regla de cálculo del Total de una recepción de proveedor. Centralizada
+/// para poder testear sin DbContext y reusar en Service y, eventualmente,
+/// en UI (vía un endpoint de cálculo si fuera necesario).
+///
+/// <para>El Total es un campo derivado: <c>Subtotal - Descuento</c>. No es
+/// input del operador. Sacarlo del input del form y calcularlo acá
+/// garantiza la invariante contable incluso si alguien postea el form con
+/// un valor arbitrario (que el Service ignora porque el DTO no lo trae).</para>
+/// </summary>
+public static class RecepcionTotalRules
+{
+    /// <summary>
+    /// Calcula el Total de una recepción: <c>Subtotal - Descuento</c>.
+    /// Rechaza valores negativos o un descuento mayor al subtotal (no tiene
+    /// sentido económico y casi siempre indica un error de carga).
+    /// </summary>
+    /// <param name="subtotal">Suma de los items de la recepción (sin descuento).</param>
+    /// <param name="descuento">Descuento global aplicado a la recepción.</param>
+    /// <returns>Total resultante (siempre >= 0).</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Si <paramref name="subtotal"/> es negativo, <paramref name="descuento"/>
+    /// es negativo, o el descuento supera al subtotal.
+    /// </exception>
+    public static decimal Calcular(decimal subtotal, decimal descuento)
+    {
+        if (subtotal < 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(subtotal), subtotal, "El subtotal no puede ser negativo.");
+        if (descuento < 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(descuento), descuento, "El descuento no puede ser negativo.");
+        if (descuento > subtotal)
+            throw new ArgumentOutOfRangeException(
+                nameof(descuento), descuento,
+                $"El descuento ({descuento:0.00}) no puede ser mayor al subtotal ({subtotal:0.00}).");
+
+        return subtotal - descuento;
+    }
+}

--- a/src/ExtraGasMVC/Services/Implementations/RecepcionService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/RecepcionService.cs
@@ -2,6 +2,7 @@ using ExtraGasMVC.Constants;
 using ExtraGasMVC.Data.Context;
 using ExtraGasMVC.Data.Entities;
 using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Extensions;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using MySqlConnector;
@@ -33,6 +34,19 @@ public class RecepcionService : IRecepcionService
         if (dto.Items is null || dto.Items.Count == 0)
             throw new InvalidOperationException("La recepción debe incluir al menos un item.");
 
+        // El Total NO viene del DTO (es derivado). Lo calcula el Service para
+        // mantener la invariante contable aunque un cliente envíe un valor
+        // distinto. RecepcionTotalRules valida que Subtotal >= Descuento.
+        decimal total;
+        try
+        {
+            total = RecepcionTotalRules.Calcular(dto.Subtotal, dto.Descuento);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            throw new InvalidOperationException(ex.Message);
+        }
+
         var empleadoId = await ResolverEmpleadoIdAsync(usuarioId, ct)
             ?? throw new InvalidOperationException(
                 "No se pudo resolver el operador: el usuario autenticado no tiene un empleado activo vinculado.");
@@ -50,7 +64,7 @@ public class RecepcionService : IRecepcionService
             {
                 Fecha = dto.Fecha, ProveedorId = dto.ProveedorId, EmpleadoId = empleadoId,
                 NumeroFacturaProveedor = dto.NumeroFacturaProveedor,
-                Subtotal = dto.Subtotal, Descuento = dto.Descuento, Total = dto.Total,
+                Subtotal = dto.Subtotal, Descuento = dto.Descuento, Total = total,
                 Observaciones = dto.Observaciones,
                 CreatedAt = now, UpdatedAt = now, CreatedBy = usuarioId, UpdatedBy = usuarioId,
             };

--- a/src/ExtraGasMVC/Views/Recepciones/Create.cshtml
+++ b/src/ExtraGasMVC/Views/Recepciones/Create.cshtml
@@ -108,16 +108,24 @@
                     </div>
                 </div>
                 <div class="col-md-4">
-                    <label for="Recepcion_Total" class="form-label">Total <span class="text-danger">*</span></label>
+                    <label for="Recepcion_Total" class="form-label">Total</label>
                     <div class="input-group">
                         <span class="input-group-text"><i class="bi bi-currency-dollar"></i></span>
+                        @* Total es derivado (Subtotal - Descuento). El operador no lo edita:
+                           el JS lo recalcula en tiempo real cuando cambian Subtotal/Descuento.
+                           No tiene name para que el form NO lo mande al POST — el Service lo
+                           recalcula desde Subtotal/Descuento (defense-in-depth). *@
                         <input id="Recepcion_Total"
-                               name="Total"
-                               type="number" min="0" step="0.01"
+                               type="number"
                                class="form-control"
-                               value="@Model.Recepcion.Total.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture)"
-                               required />
+                               value="@(Model.Recepcion.Subtotal - Model.Recepcion.Descuento).ToString("0.00", System.Globalization.CultureInfo.InvariantCulture)"
+                               readonly
+                               tabindex="-1" />
                     </div>
+                    <small class="text-secondary">
+                        <i class="bi bi-info-circle me-1"></i>
+                        Calculado automáticamente: <code>Subtotal − Descuento</code>.
+                    </small>
                 </div>
                 <div class="col-12">
                     <label for="Recepcion_Observaciones" class="form-label">Observaciones</label>

--- a/src/ExtraGasMVC/wwwroot/js/recepciones.js
+++ b/src/ExtraGasMVC/wwwroot/js/recepciones.js
@@ -146,6 +146,22 @@
         if (btnConfirm) btnConfirm.disabled = conProducto === 0;
     }
 
+    /// Recalcula el campo Total (read-only) en función de Subtotal y
+    /// Descuento. El Service lo calcula también — el JS es solo UX para
+    /// que el operador vea el resultado sin esperar al POST.
+    /// Defensivo: si Subtotal/Descuento están vacíos, trata como 0.
+    function actualizarTotalMonetario() {
+        var subtotalEl = document.getElementById('Recepcion_Subtotal');
+        var descuentoEl = document.getElementById('Recepcion_Descuento');
+        var totalEl = document.getElementById('Recepcion_Total');
+        if (!subtotalEl || !descuentoEl || !totalEl) return;
+
+        var subtotal = parseFloat(subtotalEl.value) || 0;
+        var descuento = parseFloat(descuentoEl.value) || 0;
+        var total = Math.max(0, subtotal - descuento);
+        totalEl.value = total.toFixed(2);
+    }
+
     function itemsFromForm() {
         var items = [];
         tbody.querySelectorAll('tr[data-row]').forEach(function (tr) {
@@ -292,6 +308,15 @@
     if (btnAdd) btnAdd.addEventListener('click', function () { agregarFila(); });
     if (dataPreCargada.length > 0) dataPreCargada.forEach(function (it) { agregarFila(it); });
     actualizarTotal();
+
+    // Listeners para recalcular el Total (read-only) cuando cambian Subtotal o
+    // Descuento. El input Total no se postea (no tiene name); el Service lo
+    // recalcula desde Subtotal/Descuento en el POST. Esto es solo UX.
+    var subtotalEl = document.getElementById('Recepcion_Subtotal');
+    var descuentoEl = document.getElementById('Recepcion_Descuento');
+    if (subtotalEl) subtotalEl.addEventListener('input', actualizarTotalMonetario);
+    if (descuentoEl) descuentoEl.addEventListener('input', actualizarTotalMonetario);
+    actualizarTotalMonetario();
 
     window.__recepciones = { agregarFila: agregarFila, itemsFromForm: itemsFromForm };
 })();

--- a/tests/ExtraGasMVC.Tests/RecepcionTotalRulesTests.cs
+++ b/tests/ExtraGasMVC.Tests/RecepcionTotalRulesTests.cs
@@ -1,0 +1,84 @@
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Extensions;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Tests del calculo del Total de una recepcion de proveedor.
+/// Garantizan que <see cref="RecepcionTotalRules.Calcular"/> respeta la
+/// invariante contable: Total = Subtotal - Descuento, sin negativos,
+/// sin descuento mayor al subtotal.
+/// </summary>
+public class RecepcionTotalRulesTests
+{
+    [Fact]
+    public void Calcular_ConSubtotal100YDescuento10_Devuelve90()
+    {
+        Assert.Equal(90m, RecepcionTotalRules.Calcular(subtotal: 100m, descuento: 10m));
+    }
+
+    [Fact]
+    public void Calcular_ConDescuentoCero_DevuelveSubtotal()
+    {
+        Assert.Equal(100m, RecepcionTotalRules.Calcular(subtotal: 100m, descuento: 0m));
+    }
+
+    [Fact]
+    public void Calcular_ConSubtotalCero_DevuelveCero()
+    {
+        Assert.Equal(0m, RecepcionTotalRules.Calcular(subtotal: 0m, descuento: 0m));
+    }
+
+    [Fact]
+    public void Calcular_ConDescuentoIgualASubtotal_DevuelveCero()
+    {
+        Assert.Equal(0m, RecepcionTotalRules.Calcular(subtotal: 50m, descuento: 50m));
+    }
+
+    [Fact]
+    public void Calcular_ConSubtotalNegativo_LanzaExcepcion()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => RecepcionTotalRules.Calcular(subtotal: -1m, descuento: 0m));
+    }
+
+    [Fact]
+    public void Calcular_ConDescuentoNegativo_LanzaExcepcion()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => RecepcionTotalRules.Calcular(subtotal: 100m, descuento: -1m));
+    }
+
+    [Fact]
+    public void Calcular_ConDescuentoMayorQueSubtotal_LanzaExcepcion()
+    {
+        // Caso tipico: operador tipea Subtotal=100 y Descuento=150 por error.
+        // El calculo debe rechazar, no devolver un Total negativo.
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => RecepcionTotalRules.Calcular(subtotal: 100m, descuento: 150m));
+    }
+}
+
+/// <summary>
+/// Tests de regresion estructural del DTO. Garantizan que Total no vuelve
+/// al DTO como input editable.
+/// </summary>
+public class CrearRecepcionDtoContratoTests
+{
+    [Fact]
+    public void CrearRecepcionDto_NoExponeTotal_PorqueEsDerivado()
+    {
+        Assert.Null(typeof(CrearRecepcionDto).GetProperty("Total"));
+    }
+
+    [Fact]
+    public void CrearRecepcionDto_SiExponeSubtotalYDescuento_PorqueSonInputsDeNegocio()
+    {
+        // Subtotal y Descuento siguen siendo inputs del operador: son
+        // decisiones de negocio (cuanto compro, cuanto descuento aplico).
+        // Solo Total es derivado y se calcula en el Service.
+        Assert.NotNull(typeof(CrearRecepcionDto).GetProperty("Subtotal"));
+        Assert.NotNull(typeof(CrearRecepcionDto).GetProperty("Descuento"));
+    }
+}


### PR DESCRIPTION
## Contexto

Bug distinto al patrón #114 pero del mismo estilo: **campo derivado editable**.

`CrearRecepcionDto.Total` era un input del operador. Pero `Total` es un campo derivado: `Subtotal - Descuento`. Sin esta restricción, el operador podía tipear cualquier valor y quedar inconsistente con Subtotal/Descuento (p. ej. `Subtotal=100, Descuento=10, Total=9999`). Bug de consistencia contable.

## Cambios

- **`DTOs/CrearRecepcionDto.cs`**: `Total` sale del DTO. Sigue siendo campo de la entity (read shape), pero ya no es input.
- **`Extensions/RecepcionTotalRules.cs`** (nuevo): helper `Calcular(subtotal, descuento)` con validación (rechaza subtotal/descuento negativos, descuento > subtotal).
- **`Services/Implementations/RecepcionService.cs`**: `CreateAsync` calcula `Total = Subtotal - Descuento` y lo asigna al entity. Errores del helper se traducen a `InvalidOperationException` para que el Controller los muestre al usuario.
- **`Controllers/RecepcionesController.cs`**: sin cambios estructurales — el DTO ya no tiene `Total`, así que el binder lo ignora aunque el form lo mande.
- **`Views/Recepciones/Create.cshtml`**: input `Total` ahora `readonly` sin `name` (no se postea), con nota explicativa "Calculado automáticamente: Subtotal − Descuento".
- **`wwwroot/js/recepciones.js`**: nueva función `actualizarTotalMonetario()` que recalcula el campo readonly en tiempo real cuando cambian Subtotal o Descuento. Es solo UX — el Service lo recalcula de nuevo en el POST (defense-in-depth).
- **`tests/.../RecepcionTotalRulesTests.cs`** (nuevo): 9 tests (7 del helper + 2 del DTO).

## Validación

- `dotnet build` → 0 errores
- `dotnet test` → 143/143 pasaron (134 base + 9 nuevos)

## Por qué este es un fix importante (no ceremony)

Sin este fix, un operador podía cargar:
- Subtotal: $100
- Descuento: $10
- **Total: $9999** (lo que tipee)

Y la BD lo aceptaba. En un sistema con pagos a proveedor y cuentas corrientes, esto rompe la conciliación. El fix garantiza la invariante contable independientemente de lo que mande el form.

## Relación con PRs previos

PR hermano de #119, #120, #121, #122, #123, #124. Este es el primero del recorrido que **no es del patrón "Activo"** — es "campo derivado no debe ser input".

## Módulos restantes

`Pago` (no tiene campos derivados), `Pedido` (idéntico a Recepcion — `Total` también es derivado, pero está manejado a nivel entidad: el trigger `monto_pagado` y el cálculo `Saldo` están en la BD). Vale revisar si Pedido tiene el mismo problema en otra vuelta.