### PR TITLE
fix(clientes): handle not-found and soft-deleted cases in Edit POST (#108)

### DIFF
--- a/src/ExtraGasMVC/Controllers/ClientesController.cs
+++ b/src/ExtraGasMVC/Controllers/ClientesController.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Services.Exceptions;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -116,11 +117,28 @@ public class ClientesController : BaseController
             TempData["Success"] = $"Cliente {cliente.Nombre} {cliente.Apellido} actualizado.";
             return RedirectToAction(nameof(Index));
         }
+        catch (ClienteSoftDeletedException ex)
+        {
+            // Issue #108: el cliente está soft-deleted. Mostramos el mensaje
+            // específico (que viene de la excepción) y redirigimos a Index.
+            // Distinct de KeyNotFoundException porque la solución es distinta:
+            // restaurar en lugar de crear uno nuevo.
+            TempData["Error"] = ex.Message;
+            return RedirectToAction(nameof(Index));
+        }
         catch (InvalidOperationException ex)
         {
+            // Típicamente: DNI ya registrado (issue #105).
             ModelState.AddModelError("Dni", ex.Message);
             await LoadViewBagsAsync(ct);
             return View(cliente);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            // Issue #108: el cliente no existe (o fue purgado). Redirigimos a
+            // Index con el mensaje que viene del Service.
+            TempData["Error"] = ex.Message;
+            return RedirectToAction(nameof(Index));
         }
         catch (Exception ex)
         {

--- a/src/ExtraGasMVC/Services/Exceptions/ClienteSoftDeletedException.cs
+++ b/src/ExtraGasMVC/Services/Exceptions/ClienteSoftDeletedException.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace ExtraGasMVC.Services.Exceptions;
+
+/// <summary>
+/// Se lanza cuando se intenta operar (Update, etc.) sobre un cliente que
+/// está soft-deleted en la BD. Distinct de <see cref="KeyNotFoundException"/>
+/// (cliente nunca existió o ya fue purgado) para que el Controller pueda
+/// mostrar al operador el mensaje correcto: "debe restaurarlo primero" en
+/// lugar de "no encontrado".
+///
+/// <para>Issue #108: antes se confundía con <see cref="KeyNotFoundException"/>
+/// porque <c>UpdateAsync</c> usaba <c>FindAsync</c> (que respeta el
+/// QueryFilter global) y devolvía <c>null</c> tanto para inexistentes como
+/// para soft-deleted. Ahora se distingue con <c>IgnoreQueryFilters()</c> +
+/// check de <c>DeletedAt</c>.</para>
+/// </summary>
+public class ClienteSoftDeletedException : InvalidOperationException
+{
+    public ulong ClienteId { get; }
+
+    public ClienteSoftDeletedException(ulong clienteId)
+        : base("No se puede editar un cliente eliminado; debe restaurarlo primero.")
+    {
+        ClienteId = clienteId;
+    }
+}

--- a/src/ExtraGasMVC/Services/Implementations/ClienteService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ClienteService.cs
@@ -3,6 +3,7 @@ using ExtraGasMVC.Data.Context;
 using ExtraGasMVC.Data.Entities;
 using ExtraGasMVC.DTOs;
 using ExtraGasMVC.Extensions;
+using ExtraGasMVC.Services.Exceptions;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
@@ -127,9 +128,21 @@ public class ClienteService : IClienteService
 
     public async Task<ClienteDto> UpdateAsync(UpdateClienteDto cliente, ulong? updatedBy, CancellationToken ct = default)
     {
-        var entity = await _context.Clientes.FindAsync(new object[] { cliente.Id }, ct);
+        // Issue #108: usamos IgnoreQueryFilters() para distinguir "no existe"
+        // (KeyNotFoundException) de "existe pero está soft-deleted"
+        // (ClienteSoftDeletedException). Antes, FindAsync respetaba el
+        // QueryFilter global y devolvía null para los dos casos, lo que hacía
+        // que el Controller no pudiera mostrarle al operador el mensaje
+        // correcto.
+        var entity = await _context.Clientes
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(c => c.Id == cliente.Id, ct);
+
         if (entity == null)
             throw new KeyNotFoundException($"Cliente con Id {cliente.Id} no encontrado.");
+
+        if (entity.DeletedAt != null)
+            throw new ClienteSoftDeletedException(cliente.Id);
 
         if (!await IsDniUniqueAsync(cliente.Dni, cliente.Id, ct))
             throw new InvalidOperationException("El DNI ingresado ya está registrado.");

--- a/tests/ExtraGasMVC.Tests/ClienteServiceTests.cs
+++ b/tests/ExtraGasMVC.Tests/ClienteServiceTests.cs
@@ -3,6 +3,7 @@ using ExtraGasMVC.Data.Context;
 using ExtraGasMVC.Data.Entities;
 using ExtraGasMVC.DTOs;
 using ExtraGasMVC.Mappings;
+using ExtraGasMVC.Services.Exceptions;
 using ExtraGasMVC.Services.Implementations;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
@@ -58,6 +59,19 @@ public class ClienteServiceTests
         Dni = c.Dni,
         TelefonoPrincipal = c.TelefonoPrincipal,
         // Sin Activo ni FechaAlta: el DTO ya no los expone.
+    };
+
+    /// <summary>
+    /// Overload para tests que reciben un <see cref="ClienteDto"/> (lo que
+    /// devuelven los metodos del Service) en lugar de la entity.
+    /// </summary>
+    private static UpdateClienteDto NewUpdateDto(ClienteDto c) => new()
+    {
+        Id = c.Id,
+        Nombre = "Juan Modificado",
+        Apellido = c.Apellido,
+        Dni = c.Dni,
+        TelefonoPrincipal = c.TelefonoPrincipal,
     };
 
     [Fact]
@@ -124,5 +138,47 @@ var creado = await service.CreateAsync(NewCreateDto(), createdBy: 1);
         actualizado.FechaAlta.Should().Be(fechaAltaOriginal,
             "FechaAlta debe preservarse desde la BD aunque el DTO no la traiga");
 actualizado.Nombre.Should().Be("Juan Modificado", "el resto de los campos si se actualizan");
+    }
+
+    // ====================================================================
+    // Issue #108: distinguir cliente inexistente de cliente soft-deleted
+    // ====================================================================
+
+    [Fact]
+    public async Task UpdateAsync_ClienteNoExiste_LanzaKeyNotFoundException()
+    {
+        var (service, _) = NewService(nameof(UpdateAsync_ClienteNoExiste_LanzaKeyNotFoundException));
+
+        var updateDto = new UpdateClienteDto
+        {
+            Id = 999999,
+            Nombre = "Fantasma",
+            Apellido = "No existe",
+            Dni = "00000000",
+            TelefonoPrincipal = "0000000000",
+        };
+
+        var act = async () => await service.UpdateAsync(updateDto, updatedBy: 1);
+
+        await act.Should().ThrowAsync<KeyNotFoundException>()
+            .WithMessage("*999999*");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ClienteSoftDeleted_LanzaClienteSoftDeletedException()
+    {
+        var (service, _) = NewService(nameof(UpdateAsync_ClienteSoftDeleted_LanzaClienteSoftDeletedException));
+
+        // Seed: crear y luego soft-deleted via el metodo del Service (que
+        // respeta la BD y setea DeletedAt).
+        var creado = await service.CreateAsync(NewCreateDto(), createdBy: 1);
+        await service.DeleteAsync(creado.Id, updatedBy: 1);
+
+        var updateDto = NewUpdateDto(creado);
+
+        var act = async () => await service.UpdateAsync(updateDto, updatedBy: 1);
+
+        await act.Should().ThrowAsync<ClienteSoftDeletedException>()
+            .Where(ex => ex.ClienteId == creado.Id);
     }
 }

--- a/tests/ExtraGasMVC.Tests/ClientesControllerEditNotFoundTests.cs
+++ b/tests/ExtraGasMVC.Tests/ClientesControllerEditNotFoundTests.cs
@@ -1,0 +1,297 @@
+using AutoMapper;
+using ExtraGasMVC.Controllers;
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Mappings;
+using ExtraGasMVC.Services.Exceptions;
+using ExtraGasMVC.Services.Interfaces;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Tests de regresion del flujo POST Edit del ClientesController.
+///
+/// Issue #108: cuando el cliente no existe o esta soft-deleted, el Service
+/// lanza una excepcion especifica (KeyNotFoundException /
+/// ClienteSoftDeletedException). Antes, esos casos caian en el catch
+/// generico de Exception y devolvian 500. Ahora el Controller los mapea
+/// a TempData["Error"] + redirect a Index.
+///
+/// Patrón: DefaultHttpContext + ClaimsPrincipal (igual que
+/// ChangePasswordTempDataFlowTests) + FakeClienteService que se configura
+/// por test para devolver success o tirar la excepcion esperada.
+/// </summary>
+public class ClientesControllerEditNotFoundTests
+{
+    private const string TestUserId = "1";
+
+    // ---------- Rama 1: Update exitoso -> redirect con Success ----------
+
+    [Fact]
+    public async Task Edit_POST_UpdateExitoso_RedirigeAIndexConSuccess()
+    {
+        var fake = new FakeClienteService
+        {
+            UpdateScenario = FakeClienteService.Scenario.Success,
+        };
+        var (controller, _, _, _) = NewControllerAndEnv(fake);
+
+        var result = await controller.Edit(
+            id: 10,
+            cliente: NewUpdateDto(10),
+            ct: default);
+
+        var redirect = result.Should().BeOfType<RedirectToActionResult>().Subject;
+        redirect.ActionName.Should().Be(nameof(ClientesController.Index));
+
+        var tempData = SaveAndReadTempData(controller);
+        tempData.Should().ContainKey("Success");
+        tempData["Success"].Should().BeOfType<string>()
+            .Which.Should().Contain("actualizado");
+        tempData.Should().NotContainKey("Error",
+            "en el happy path no debe haber mensaje de error");
+    }
+
+    // ---------- Rama 2: Cliente no existe -> KeyNotFoundException ----------
+
+    [Fact]
+    public async Task Edit_POST_ClienteNoExiste_RedirigeAIndexConError_KeyNotFound()
+    {
+        var fake = new FakeClienteService
+        {
+            UpdateScenario = FakeClienteService.Scenario.KeyNotFound,
+        };
+        var (controller, _, _, _) = NewControllerAndEnv(fake);
+
+        var result = await controller.Edit(
+            id: 999999,
+            cliente: NewUpdateDto(999999),
+            ct: default);
+
+        var redirect = result.Should().BeOfType<RedirectToActionResult>().Subject;
+        redirect.ActionName.Should().Be(nameof(ClientesController.Index));
+
+        var tempData = SaveAndReadTempData(controller);
+        tempData.Should().ContainKey("Error");
+        tempData["Error"].Should().BeOfType<string>()
+            .Which.Should().Be("Cliente con Id 999999 no encontrado.");
+    }
+
+    // ---------- Rama 3: Cliente soft-deleted -> ClienteSoftDeletedException ----------
+
+    [Fact]
+    public async Task Edit_POST_ClienteSoftDeleted_RedirigeAIndexConMensajeRestaurar()
+    {
+        var fake = new FakeClienteService
+        {
+            UpdateScenario = FakeClienteService.Scenario.SoftDeleted,
+        };
+        var (controller, _, _, _) = NewControllerAndEnv(fake);
+
+        var result = await controller.Edit(
+            id: 42,
+            cliente: NewUpdateDto(42),
+            ct: default);
+
+        var redirect = result.Should().BeOfType<RedirectToActionResult>().Subject;
+        redirect.ActionName.Should().Be(nameof(ClientesController.Index));
+
+        var tempData = SaveAndReadTempData(controller);
+        tempData.Should().ContainKey("Error");
+        tempData["Error"].Should().BeOfType<string>()
+            .Which.Should().Be(
+                "No se puede editar un cliente eliminado; debe restaurarlo primero.");
+    }
+
+    // ---------- Rama 4: DNI duplicado -> InvalidOperationException -> re-render ----------
+
+    [Fact]
+    public async Task Edit_POST_DniDuplicado_ReRenderDelFormConModelStateError()
+    {
+        var fake = new FakeClienteService
+        {
+            UpdateScenario = FakeClienteService.Scenario.InvalidOperation,
+        };
+        var (controller, _, _, _) = NewControllerAndEnv(fake);
+
+        var dto = NewUpdateDto(7);
+        var result = await controller.Edit(id: 7, cliente: dto, ct: default);
+
+        // DNI duplicado: NO redirige, re-renderiza la vista con error en el
+        // campo Dni para que el operador pueda corregir.
+        var view = result.Should().BeOfType<ViewResult>().Subject;
+        view.Model.Should().BeSameAs(dto);
+
+        controller.ModelState.Should().ContainKey("Dni");
+        controller.ModelState["Dni"]!.Errors
+            .Should().ContainSingle()
+            .Which.ErrorMessage.Should().Be("El DNI ingresado ya está registrado.");
+    }
+
+    // ====================================================================
+    // Helpers
+    // ====================================================================
+
+    private static UpdateClienteDto NewUpdateDto(ulong id) => new()
+    {
+        Id = id,
+        Nombre = "Juan",
+        Apellido = "Perez",
+        Dni = "12345678",
+        TelefonoPrincipal = "1144556677",
+    };
+
+    /// <summary>
+    /// Arma el HttpContext con TempDataProvider in-memory + ITempDataDictionaryFactory +
+    /// IUrlHelperFactory registrados, igual que ChangePasswordTempDataFlowTests.
+    /// Devuelve el controller, el HttpContext original (para SaveTempData), el
+    /// factory y el provider.
+    /// </summary>
+    private static (ClientesController controller,
+                    DefaultHttpContext postContext,
+                    ITempDataDictionaryFactory factory,
+                    InMemoryTempDataProvider provider)
+        NewControllerAndEnv(FakeClienteService fake)
+    {
+        var provider = new InMemoryTempDataProvider();
+        var services = new ServiceCollection()
+            .AddSingleton<ITempDataProvider>(provider)
+            .AddSingleton<ITempDataDictionaryFactory, TempDataDictionaryFactory>()
+            .AddSingleton<IUrlHelperFactory, UrlHelperFactory>()
+            .BuildServiceProvider();
+
+        var httpContext = new DefaultHttpContext { RequestServices = services };
+        httpContext.User = new System.Security.Claims.ClaimsPrincipal(
+            new System.Security.Claims.ClaimsIdentity(
+                new[]
+                {
+                    new System.Security.Claims.Claim(
+                        System.Security.Claims.ClaimTypes.NameIdentifier, TestUserId),
+                },
+                "TestAuth"));
+
+        var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        var mapper = mapperConfig.CreateMapper();
+
+        var controller = new ClientesController(fake, mapper)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext,
+                RouteData = new RouteData(),
+            },
+        };
+
+        var factory = services.GetRequiredService<ITempDataDictionaryFactory>();
+        return (controller, httpContext, factory, provider);
+    }
+
+    /// <summary>
+    /// Simula lo que hace el filtro SaveTempDataFilter al final del POST:
+    /// obtiene el ITempDataDictionary del HttpContext actual, llama a Save()
+    /// y luego arma un nuevo HttpContext (un GET hipotetico) que comparte el
+    /// provider. Asi se valida que TempData["Error"] sobrevive al redirect.
+    /// </summary>
+    private static IDictionary<string, object?> SaveAndReadTempData(ClientesController controller)
+    {
+        var context = controller.HttpContext;
+        var factory = context.RequestServices.GetRequiredService<ITempDataDictionaryFactory>();
+        var postTempData = factory.GetTempData(context);
+        postTempData.Save();
+
+        // Simular un nuevo HttpContext (GET siguiente) que comparta provider
+        // y factory. Asi verificamos que el TempData["Error"] que escribio el
+        // Controller en el POST sigue siendo legible en el GET.
+        var nextContext = new DefaultHttpContext
+        {
+            RequestServices = context.RequestServices,
+        };
+        nextContext.User = context.User;
+        var nextTempData = factory.GetTempData(nextContext);
+        // ITempDataDictionary implementa IDictionary<string, object?>
+        return nextTempData;
+    }
+
+    // ====================================================================
+    // Fakes
+    // ====================================================================
+
+    /// <summary>
+    /// Fake de <see cref="IClienteService"/> que se configura por test segun
+    /// el escenario. Solo implementa los metodos ejercitados por estos tests;
+    /// el resto lanza <see cref="NotImplementedException"/> (mismo patron que
+    /// los fakes de Usuarios) para que un cambio en el wiring del Controller
+    /// rompa un test en lugar de fallar silenciosamente.
+    /// </summary>
+    private sealed class FakeClienteService : IClienteService
+    {
+        public enum Scenario
+        {
+            Success,
+            KeyNotFound,
+            SoftDeleted,
+            InvalidOperation,
+        }
+
+        public Scenario UpdateScenario { get; set; } = Scenario.Success;
+
+        public Task<ClienteDto> UpdateAsync(UpdateClienteDto cliente, ulong? updatedBy, CancellationToken ct = default)
+        {
+            return UpdateScenario switch
+            {
+                Scenario.Success => Task.FromResult(new ClienteDto
+                {
+                    Id = cliente.Id,
+                    Nombre = cliente.Nombre,
+                    Apellido = cliente.Apellido,
+                    Dni = cliente.Dni,
+                    TelefonoPrincipal = cliente.TelefonoPrincipal,
+                }),
+                Scenario.KeyNotFound =>
+                    throw new KeyNotFoundException($"Cliente con Id {cliente.Id} no encontrado."),
+                Scenario.SoftDeleted =>
+                    throw new ClienteSoftDeletedException(cliente.Id),
+                Scenario.InvalidOperation =>
+                    throw new InvalidOperationException("El DNI ingresado ya está registrado."),
+                _ => throw new InvalidOperationException($"Scenario no soportado: {UpdateScenario}"),
+            };
+        }
+
+        public Task<List<ProvinciaDto>> GetProvinciasAsync(CancellationToken ct = default)
+            => Task.FromResult(new List<ProvinciaDto>());
+
+        // Metodos no usados por estos tests:
+        public Task<ClienteDto?> GetByIdAsync(ulong id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<IEnumerable<ClienteDto>> GetAllAsync(CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<ClienteDto?> GetByDniAsync(string dni, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<IEnumerable<ClienteDto>> GetActivosAsync(CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<SearchResultDto<ClienteDto>> SearchAsync(string? b, bool s, int p, int t, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<ClienteDto> CreateAsync(CreateClienteDto c, ulong? b, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<bool> DeleteAsync(ulong id, ulong? u, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<bool> RestoreAsync(ulong id, ulong? u, CancellationToken ct = default) => throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// ITempDataProvider in-memory compartido entre el POST y el GET
+    /// hipotetico. Mismo patron que ChangePasswordTempDataFlowTests.
+    /// </summary>
+    private sealed class InMemoryTempDataProvider : ITempDataProvider
+    {
+        public Dictionary<string, object?> Store { get; } = new();
+
+        public IDictionary<string, object?> LoadTempData(HttpContext context) => Store;
+
+        public void SaveTempData(HttpContext context, IDictionary<string, object?> values)
+        {
+            Store.Clear();
+            foreach (var kv in values) Store[kv.Key] = kv.Value;
+        }
+    }
+}


### PR DESCRIPTION
## Resumen

`ClientesController.Edit` POST devolvía **500** cuando el cliente no existía o estaba soft-deleted, porque `ClienteService.UpdateAsync` lanzaba `KeyNotFoundException` y el Controller solo capturaba `InvalidOperationException` + `Exception` general.

Este PR distingue los dos casos a nivel Service y los mapea a respuestas HTTP correctas en el Controller.

## Cambios

### `ClienteService.UpdateAsync`
- Reemplazado `FindAsync` (que respeta el QueryFilter global) por `IgnoreQueryFilters()` + `FirstOrDefaultAsync`.
- Distingue ahora los dos casos que antes se confundían:
  - **Cliente no existe** (incluso ignorando filtros) → `KeyNotFoundException("Cliente con Id {id} no encontrado.")`
  - **Cliente existe pero está soft-deleted** (`DeletedAt != null`) → nueva `ClienteSoftDeletedException`

### `ClientesController.Edit` (POST)
- Agregados dos `catch` específicos **antes** del catch genérico de `InvalidOperationException`:
  - `ClienteSoftDeletedException` → `TempData["Error"]` con mensaje de restauración + `RedirectToAction(nameof(Index))`
  - `KeyNotFoundException` → `TempData["Error"]` con mensaje del Service + `RedirectToAction(nameof(Index))`
- `InvalidOperationException` sigue capturando el caso de DNI duplicado (issue #105) → re-render del form con `ModelState["Dni"]` (sin cambios).

### Nueva excepción
- `src/ExtraGasMVC/Services/Exceptions/ClienteSoftDeletedException.cs`
- Hereda de `InvalidOperationException` (por si algún caller genérico la necesita capturar como IOE).
- Expone `ClienteId` para futuros callers que quieran operar sobre el id.

## Criterios de aceptación (#108)

- [x] Captura agregada en POST Edit (KeyNotFoundException + ClienteSoftDeletedException)
- [x] Captura revisada en POST Delete y POST Restore: ya manejan `false` → TempData["Error"] correctamente (ver nota de follow-up)
- [x] Tests unitarios que verifican el comportamiento

## Tests

6 tests nuevos, todos verdes:

| Test | Cubre |
|---|---|
| `ClienteServiceTests.UpdateAsync_ClienteNoExiste_LanzaKeyNotFoundException` | Service: inexistente → `KeyNotFoundException` |
| `ClienteServiceTests.UpdateAsync_ClienteSoftDeleted_LanzaClienteSoftDeletedException` | Service: soft-deleted → `ClienteSoftDeletedException` |
| `ClientesControllerEditNotFoundTests.Edit_POST_UpdateExitoso_RedirigeAIndexConSuccess` | Controller: happy path → Success + redirect |
| `ClientesControllerEditNotFoundTests.Edit_POST_ClienteNoExiste_RedirigeAIndexConError_KeyNotFound` | Controller: KeyNotFound → TempData Error + redirect |
| `ClientesControllerEditNotFoundTests.Edit_POST_ClienteSoftDeleted_RedirigeAIndexConMensajeRestaurar` | Controller: SoftDeleted → TempData Error + redirect |
| `ClientesControllerEditNotFoundTests.Edit_POST_DniDuplicado_ReRenderDelFormConModelStateError` | Controller: DNI duplicado sigue re-renderizando con `ModelState["Dni"]` |

Patrón de tests de Controller: `FakeClienteService` configurable + `ITempDataProvider` in-memory + `ITempDataDictionaryFactory` (mismo patrón que `ChangePasswordTempDataFlowTests`, sin `WebApplicationFactory`).

## Notas de implementación

- El orden de los `catch` es crítico: `ClienteSoftDeletedException` se captura **antes** que `InvalidOperationException` (porque hereda de ella), y `KeyNotFoundException` se captura **antes** que el `Exception` general.
- Mensajes de error vienen de la excepción (single source of truth), no están hardcodeados en el Controller.

## Follow-up sugerido

`ClienteService.DeleteAsync` tiene el **mismo bug** que `UpdateAsync` tenía antes: usa `FindAsync` (respeta el QueryFilter), por lo que si el operador hace POST Delete sobre un cliente ya soft-deleted, devuelve `false` y el Controller muestra "No se encontró el cliente" (engañoso). Misma solución aplica: `IgnoreQueryFilters()` + check de `DeletedAt` + mapear a un mensaje específico. Vale la pena abrir una issue separada para mantener este PR enfocado en #108.

Resolves #108