### PR TITLE
fix(clientes): resolve N+1 en CuentasCorrientes usando v_saldo_clientes (#109)

### DIFF
--- a/src/ExtraGasMVC/Controllers/ClientesController.cs
+++ b/src/ExtraGasMVC/Controllers/ClientesController.cs
@@ -172,9 +172,15 @@ public class ClientesController : BaseController
         return RedirectToAction(nameof(Index));
     }
 
+    // Issue #109: CuentasCorrientes usaba GetAllAsync (trae TODOS los clientes
+    // con su dirección completa) y la vista no mostraba saldo ni pedidos
+    // pendientes. Si la vista disparaba queries adicionales por cliente era
+    // un N+1 garantizado. Ahora delegamos en GetSaldosAsync, que proyecta la
+    // vista SQL v_saldo_clientes (cliente + saldo + pedidos pendientes en
+    // una sola fila agregada en MySQL).
     public async Task<IActionResult> CuentasCorrientes(CancellationToken ct = default)
     {
-        var clientes = await _clienteService.GetAllAsync(ct);
-        return View(clientes);
+        var saldos = await _clienteService.GetSaldosAsync(ct);
+        return View(saldos);
     }
 }

--- a/src/ExtraGasMVC/DTOs/VSaldoClienteDto.cs
+++ b/src/ExtraGasMVC/DTOs/VSaldoClienteDto.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ExtraGasMVC.DTOs;
+
+/// <summary>
+/// DTO de salida para <see cref="Data.Entities.Views.VSaldoCliente"/>.
+/// Proyecta las 5 columnas de la vista <c>v_saldo_clientes</c>:
+/// cliente_id, cliente (formateado "Apellido, Nombre"), teléfono principal,
+/// pedidos pendientes (count) y saldo total (DECIMAL 12,2).
+///
+/// Se usa en /Clientes/CuentasCorrientes para resolver el N+1 que producía
+/// <see cref="Data.Entities.Cliente"/> + iteración por cliente (issue #109):
+/// la vista entrega cliente + saldo + pedidos pendientes en una sola fila
+/// agregada en MySQL.
+/// </summary>
+public class VSaldoClienteDto
+{
+    [Display(Name = "Cliente")]
+    public string Cliente { get; set; } = null!;
+
+    [Display(Name = "Teléfono")]
+    public string? TelefonoPrincipal { get; set; }
+
+    [Display(Name = "Pedidos pendientes")]
+    public int PedidosPendientes { get; set; }
+
+    [Display(Name = "Saldo")]
+    public decimal SaldoTotal { get; set; }
+
+    /// <summary>
+    /// Id del cliente. No se muestra en la grilla — se usa como route param
+    /// para los links de acción (ir a Details del cliente).
+    /// </summary>
+    public ulong ClienteId { get; set; }
+}

--- a/src/ExtraGasMVC/Mappings/MappingProfile.cs
+++ b/src/ExtraGasMVC/Mappings/MappingProfile.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.Data.Entities.Views;
 using ExtraGasMVC.DTOs;
 
 namespace ExtraGasMVC.Mappings;
@@ -21,6 +22,14 @@ public class MappingProfile : Profile
         ConfigureUsuario();
         ConfigureProvincia();
         ConfigureEmpleado();
+        ConfigureVSaldoCliente();
+    }
+
+    // Issue #109: mapping de la vista v_saldo_clientes para evitar N+1 en
+    // CuentasCorrientes. AutoMapper proyecta las 5 columnas 1:1 (mismo nombre).
+    private void ConfigureVSaldoCliente()
+    {
+        CreateMap<VSaldoCliente, VSaldoClienteDto>().ReverseMap();
     }
 
     private void ConfigureCliente()

--- a/src/ExtraGasMVC/Services/Implementations/ClienteService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ClienteService.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using ExtraGasMVC.Data.Context;
 using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.Data.Entities.Views;
 using ExtraGasMVC.DTOs;
 using ExtraGasMVC.Extensions;
 using ExtraGasMVC.Services.Exceptions;
@@ -229,6 +230,25 @@ public class ClienteService : IClienteService
 
             return _mapper.Map<List<ProvinciaDto>>(provincias);
         }) ?? [];
+    }
+
+    /// <summary>
+    /// Saldos agregados por cliente para /Clientes/CuentasCorrientes.
+    /// Issue #109: la vista SQL <c>v_saldo_clientes</c> ya devuelve cliente +
+    /// teléfono + pedidos pendientes + saldo en una sola fila agregada, así
+    /// que acá solo proyectamos a DTO y ordenamos. AsNoTracking porque es
+    /// read-only. El OrderByDescending es defensivo: la vista declara
+    /// ORDER BY saldo_total DESC pero EF no garantiza preservarlo.
+    /// </summary>
+    public async Task<IEnumerable<VSaldoClienteDto>> GetSaldosAsync(CancellationToken ct = default)
+    {
+        var saldos = await _context.VSaldosClientes
+            .AsNoTracking()
+            .OrderByDescending(v => v.SaldoTotal)
+            .ThenBy(v => v.Cliente)
+            .ToListAsync(ct);
+
+        return _mapper.Map<IEnumerable<VSaldoClienteDto>>(saldos);
     }
 
     private Task<bool> IsDniUniqueAsync(string? dni, CancellationToken ct)

--- a/src/ExtraGasMVC/Services/Interfaces/IClienteService.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IClienteService.cs
@@ -16,4 +16,13 @@ public interface IClienteService
     Task<bool> DeleteAsync(ulong id, ulong? updatedBy, CancellationToken ct = default);
     Task<bool> RestoreAsync(ulong id, ulong? updatedBy, CancellationToken ct = default);
     Task<List<ProvinciaDto>> GetProvinciasAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Saldos agregados por cliente para la pantalla CuentasCorrientes.
+    /// Lee la vista <c>v_saldo_clientes</c> (una sola query) en lugar de
+    /// cargar todos los clientes y resolver saldo/pedidos en la vista (N+1).
+    /// Orden: saldo DESC, nombre ASC para que los deudores más grandes
+    /// queden arriba. Issue #109.
+    /// </summary>
+    Task<IEnumerable<VSaldoClienteDto>> GetSaldosAsync(CancellationToken ct = default);
 }

--- a/src/ExtraGasMVC/Views/Clientes/CuentasCorrientes.cshtml
+++ b/src/ExtraGasMVC/Views/Clientes/CuentasCorrientes.cshtml
@@ -1,4 +1,4 @@
-@model IEnumerable<ExtraGasMVC.DTOs.ClienteDto>
+@model IEnumerable<ExtraGasMVC.DTOs.VSaldoClienteDto>
 @{
     ViewData["Title"] = "Cuentas corrientes";
     ViewData["Breadcrumbs"] = new List<BreadcrumbItem>
@@ -28,20 +28,37 @@
                 </tr>
             </thead>
             <tbody>
+                @* Issue #109: la vista muestra clientes con saldo pendiente
+                   (la query SQL ya filtra HAVING saldo_total > 0), por eso el
+                   mensaje vacío habla de saldo y no de "clientes cargados". *@
                 @if (!Model.Any())
                 {
-                    <tr><td colspan="5" class="text-center py-4 text-secondary">No hay clientes cargados.</td></tr>
+                    <tr><td colspan="5" class="text-center py-4 text-secondary">No hay clientes con saldo pendiente.</td></tr>
                 }
-                @foreach (var c in Model)
+                @foreach (var s in Model)
                 {
                     <tr>
-                        <td><strong>@c.Apellido, @c.Nombre</strong></td>
-                        <td>@c.TelefonoPrincipal</td>
-                        <td class="text-end">-</td>
-                        <td class="text-end">-</td>
+                        <td><strong>@s.Cliente</strong></td>
+                        <td>@s.TelefonoPrincipal</td>
                         <td class="text-end">
-                            <a asp-controller="Pedidos" asp-action="Index" asp-route-numero="@c.Codigo" class="btn btn-sm btn-outline-primary">
-                                <i class="bi bi-search"></i> Ver pedidos
+                            @if (s.PedidosPendientes > 0)
+                            {
+                                <span class="badge text-bg-warning">@s.PedidosPendientes</span>
+                            }
+                            else
+                            {
+                                <span class="text-secondary">0</span>
+                            }
+                        </td>
+                        <td class="text-end fw-semibold text-danger">@s.SaldoTotal.ToArs()</td>
+                        <td class="text-end">
+                            @* Antes este link iba a Pedidos/Index?numero=<Codigo>,
+                               pero Codigo es del cliente (no del pedido) y el
+                               parámetro de Pedidos no es clienteId: el link estaba
+                               roto. Ahora vamos al detail del cliente, que es la
+                               acción semánticamente correcta desde este listado. *@
+                            <a asp-action="Details" asp-route-id="@s.ClienteId" class="btn btn-sm btn-outline-primary">
+                                <i class="bi bi-eye"></i> Ver cliente
                             </a>
                         </td>
                     </tr>
@@ -50,7 +67,3 @@
         </table>
     </div>
 </div>
-<p class="text-secondary small mt-3">
-    Los totales por cliente se computan en la vista <code>v_saldos_clientes</code> de la base de datos. Este listado se completará
-    con la integración correspondiente.
-</p>

--- a/tests/ExtraGasMVC.Tests/ClientesControllerEditNotFoundTests.cs
+++ b/tests/ExtraGasMVC.Tests/ClientesControllerEditNotFoundTests.cs
@@ -266,6 +266,8 @@ public class ClientesControllerEditNotFoundTests
 
         public Task<List<ProvinciaDto>> GetProvinciasAsync(CancellationToken ct = default)
             => Task.FromResult(new List<ProvinciaDto>());
+        public Task<IEnumerable<VSaldoClienteDto>> GetSaldosAsync(CancellationToken ct = default)
+            => Task.FromResult<IEnumerable<VSaldoClienteDto>>(new List<VSaldoClienteDto>());
 
         // Metodos no usados por estos tests:
         public Task<ClienteDto?> GetByIdAsync(ulong id, CancellationToken ct = default) => throw new NotImplementedException();

--- a/tests/ExtraGasMVC.Tests/ControllersActivoViewBagTests.cs
+++ b/tests/ExtraGasMVC.Tests/ControllersActivoViewBagTests.cs
@@ -176,6 +176,7 @@ public class ControllersActivoViewBagTests
         public Task<bool> DeleteAsync(ulong id, ulong? u, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<bool> RestoreAsync(ulong id, ulong? u, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<ProvinciaDto>> GetProvinciasAsync(CancellationToken ct = default) => Task.FromResult(new List<ProvinciaDto>());
+        public Task<IEnumerable<VSaldoClienteDto>> GetSaldosAsync(CancellationToken ct = default) => Task.FromResult<IEnumerable<VSaldoClienteDto>>(new List<VSaldoClienteDto>());
     }
 
     private sealed class FakeEmpleadoService : IEmpleadoService


### PR DESCRIPTION
## Resuelve #109 — N+1 en CuentasCorrientes: la vista no usa v_saldo_clientes

### Problema

`ClientesController.CuentasCorrientes` invocaba `GetAllAsync` (trae TODOS los clientes activos con su dirección completa) y la vista no mostraba saldo ni pedidos pendientes. Si la vista disparaba queries adicionales por cliente, había N+1 garantizado. Además, la vista SQL `v_saldo_clientes` ya estaba disponible y mapeada en EF (`VSaldoCliente` + `VSaldoClienteConfiguration`) pero sin uso.

### Fix

| Capa | Cambio |
|---|---|
| DTOs | Nuevo `VSaldoClienteDto` con las 5 columnas de la vista |
| Mapping | `CreateMap<VSaldoCliente, VSaldoClienteDto>().ReverseMap()` en `MappingProfile` |
| Service | Nuevo `IClienteService.GetSaldosAsync` — proyecta `_context.VSaldosClientes` con `AsNoTracking` + `OrderByDescending(saldo)` + `ThenBy(cliente)` |
| Controller | `CuentasCorrientes` ahora usa `GetSaldosAsync` en lugar de `GetAllAsync` |
| Vista | Bind a `VSaldoClienteDto`. Muestra saldo con `ToArs()`, badge para pedidos pendientes, link "Ver cliente" (antes iba a Pedidos con un route param roto) |
| Tests | Fakes de `IClienteService` en `ClientesControllerEditNotFoundTests` y `ControllersActivoViewBagTests` actualizados con el nuevo método |

### Criterios de aceptación

- [x] Una sola query a la BD cuando se carga `/Clientes/CuentasCorrientes` (la vista `v_saldo_clientes` agrega cliente + teléfono + pedidos pendientes + saldo en MySQL)
- [x] Vista muestra: cliente, teléfono, pedidos pendientes (badge), saldo formateado (`ToArs()`)
- [x] Orden por saldo DESC (deudores más grandes primero)
- [x] Sin N+1 detectable

### Validación

- `dotnet build` → 0 errores
- `dotnet test` → 187/187 pasan
- Solo se modificaron 7 archivos + 1 nuevo DTO (~110 líneas)

### Notas

- El link "Ver pedidos" de la vista anterior estaba roto: usaba `asp-route-numero="@c.Codigo"` cuando `Codigo` es del cliente (no del pedido) y `PedidosController.Index` no acepta `clienteId`. Lo reemplacé por `asp-action="Details" asp-route-id="@s.ClienteId"`, que es la acción semánticamente correcta desde este listado.
- `v_saldo_clientes` ya filtra con `HAVING saldo_total > 0`, así que no mostramos clientes con saldo 0 (que es lo que espera el operador en esta pantalla).