### PR TITLE
fix(clientes): normalizar DNI y telefono en Create/Update/Search (#113)

### DIFF
--- a/src/ExtraGasMVC/DTOs/ClienteDto.cs
+++ b/src/ExtraGasMVC/DTOs/ClienteDto.cs
@@ -20,7 +20,7 @@ public class ClienteDtoBase
 
     [Display(Name = "DNI")]
     [StringLength(15, ErrorMessage = "El DNI no puede superar {1} caracteres.")]
-    [RegularExpression("^[0-9]+$", ErrorMessage = "El DNI debe ser numérico.")]
+    [RegularExpression("^[0-9 .\\-]*$", ErrorMessage = "El DNI debe ser numérico (se admiten espacios, puntos y guiones como separadores).")]
     public string? Dni { get; set; }
 
     [Display(Name = "Cuit/Cuil")]
@@ -31,6 +31,7 @@ public class ClienteDtoBase
     [Display(Name = "Teléfono principal")]
     [Required(ErrorMessage = "El teléfono principal es obligatorio.")]
     [StringLength(25, ErrorMessage = "El teléfono no puede superar {1} caracteres.")]
+    [RegularExpression("^[0-9 +()\\-.]*$", ErrorMessage = "El teléfono admite dígitos, espacios y separadores (+, -, paréntesis, puntos).")]
     public string TelefonoPrincipal { get; set; } = null!;
 
     [Display(Name = "Teléfono secundario")]

--- a/src/ExtraGasMVC/Extensions/StringNormalizer.cs
+++ b/src/ExtraGasMVC/Extensions/StringNormalizer.cs
@@ -1,0 +1,58 @@
+using System.Text;
+
+namespace ExtraGasMVC.Extensions;
+
+/// <summary>
+/// Helpers de normalización de strings de identidad/contacto del cliente.
+/// Garantizan que valores equivalentes por formato (con/sin espacios, con/sin
+/// separadores) se almacenen, validen y busquen de forma canónica.
+/// Issue #113.
+/// </summary>
+public static class StringNormalizer
+{
+    /// <summary>
+    /// Normaliza un DNI: trim + remueve espacios, puntos y guiones.
+    /// Devuelve solo dígitos. null/vacío/whitespace → null.
+    /// </summary>
+    public static string? NormalizarDni(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input)) return null;
+
+        var trimmed = input.Trim();
+        var sb = new StringBuilder(trimmed.Length);
+        foreach (var ch in trimmed)
+        {
+            if (ch == ' ' || ch == '.' || ch == '-') continue;
+            sb.Append(ch);
+        }
+
+        return sb.Length == 0 ? null : sb.ToString();
+    }
+
+    /// <summary>
+    /// Normaliza un teléfono: trim + remueve espacios, guiones, paréntesis y
+    /// puntos. Conserva un '+' inicial (prefijo internacional) si estaba
+    /// presente, porque es semánticamente distinto tener código de país o no.
+    /// Devuelve solo '+' (si aplica) y dígitos. null/vacío/whitespace → null.
+    /// </summary>
+    public static string? NormalizarTelefono(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input)) return null;
+
+        var trimmed = input.Trim();
+        var sb = new StringBuilder(trimmed.Length);
+        var tieneMas = trimmed[0] == '+';
+        if (tieneMas) sb.Append('+');
+
+        foreach (var ch in trimmed)
+        {
+            // '+' se descarta acá: el '+' inicial ya se agregó arriba explícitamente;
+            // cualquier '+' en otra posición es ruido de tipeo (el código de país
+            // solo es semánticamente válido al inicio) y lo removemos.
+            if (ch == ' ' || ch == '-' || ch == '(' || ch == ')' || ch == '.' || ch == '+') continue;
+            sb.Append(ch);
+        }
+
+        return sb.Length == (tieneMas ? 1 : 0) ? null : sb.ToString();
+    }
+}

--- a/src/ExtraGasMVC/Services/Implementations/ClienteService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ClienteService.cs
@@ -80,13 +80,21 @@ public class ClienteService : IClienteService
 
         if (!string.IsNullOrWhiteSpace(busqueda))
         {
+            // Issue #113: normalizamos query para que el operador pueda tipear
+            // " 12345678 " o "+54 11 4455-6677" y matchear contra valores canónicos.
+            // Asumimos que los DNIs/teléfonos en BD están normalizados (garantizado
+            // por CreateAsync/UpdateAsync a partir de este fix). Datos viejos con
+            // separadores en BD NO matchearán; por criterio de aceptación de la issue
+            // esos registros conviven sin migrarse.
             var q = busqueda.Trim();
+            var dniNormalizado = StringNormalizer.NormalizarDni(q) ?? q;
+            var telNormalizado = StringNormalizer.NormalizarTelefono(q) ?? q;
             query = query.Where(c =>
                 c.Nombre.Contains(q)
                 || c.Apellido.Contains(q)
-                || (c.Dni != null && c.Dni.Contains(q))
+                || (c.Dni != null && c.Dni.Contains(dniNormalizado))
                 || (c.CuitCuil != null && c.CuitCuil.Contains(q))
-                || c.TelefonoPrincipal.Contains(q));
+                || c.TelefonoPrincipal.Contains(telNormalizado));
         }
 
         var total = await query.CountAsync(ct);
@@ -109,7 +117,12 @@ public class ClienteService : IClienteService
 
     public async Task<ClienteDto> CreateAsync(CreateClienteDto cliente, ulong? createdBy, CancellationToken ct = default)
     {
-        if (!await IsDniUniqueAsync(cliente.Dni, ct))
+        // Issue #113: normalizamos DNI y teléfono para que unicidad y storage
+        // operen sobre el valor canónico (sin espacios, puntos ni guiones).
+        var dniNormalizado = StringNormalizer.NormalizarDni(cliente.Dni);
+        var telNormalizado = StringNormalizer.NormalizarTelefono(cliente.TelefonoPrincipal);
+
+        if (!await IsDniUniqueAsync(dniNormalizado, ct))
             throw new InvalidOperationException("El DNI ingresado ya está registrado.");
 
         var entity = _mapper.Map<Cliente>(cliente);
@@ -117,6 +130,8 @@ public class ClienteService : IClienteService
         // porque son estado / audit trail, no datos de carga del operador.
         entity.Activo = true;
         entity.FechaAlta = DateOnly.FromDateTime(DateTime.UtcNow);
+        entity.Dni = dniNormalizado;                // Issue #113
+        entity.TelefonoPrincipal = telNormalizado!; // Issue #113 (es requerido, no null)
         entity.CreatedAt = DateTime.UtcNow;
         entity.UpdatedAt = DateTime.UtcNow;
         entity.CreatedBy = createdBy;
@@ -146,7 +161,11 @@ public class ClienteService : IClienteService
         if (entity.DeletedAt != null)
             throw new ClienteSoftDeletedException(cliente.Id);
 
-        if (!await IsDniUniqueAsync(cliente.Dni, cliente.Id, ct))
+        // Issue #113: normalizamos el DNI antes de validar unicidad y antes
+        // de pisar el entity. Si el operador tipea " 12.345.678 " debe matchear
+        // con el cliente cuyo DNI canónico es "12345678".
+        var dniNormalizado = StringNormalizer.NormalizarDni(cliente.Dni);
+        if (!await IsDniUniqueAsync(dniNormalizado, cliente.Id, ct))
             throw new InvalidOperationException("El DNI ingresado ya está registrado.");
 
         // Snapshot de Activo y FechaAlta ANTES del AutoMapper: el formulario
@@ -157,6 +176,8 @@ public class ClienteService : IClienteService
         var fechaAltaOriginal = entity.FechaAlta;
 
         _mapper.Map(cliente, entity);
+        entity.Dni = dniNormalizado;                                                     // Issue #113
+        entity.TelefonoPrincipal = StringNormalizer.NormalizarTelefono(cliente.TelefonoPrincipal)!; // Issue #113
         entity.UpdatedAt = DateTime.UtcNow;
         entity.UpdatedBy = updatedBy;
         ClienteEditRules.PreservarFlagsNoEditables(entity, activoOriginal, fechaAltaOriginal);
@@ -177,10 +198,13 @@ public class ClienteService : IClienteService
     /// </summary>
     internal static bool DniEsUnicoSobre(IQueryable<Cliente> clientes, string? dni)
     {
-        if (string.IsNullOrWhiteSpace(dni))
+        // Issue #113: normalizamos el DNI recibido para que el chequeo de
+        // unicidad evalúe contra el valor canónico almacenado en BD.
+        var dniNormalizado = StringNormalizer.NormalizarDni(dni);
+        if (string.IsNullOrWhiteSpace(dniNormalizado))
             return true;
 
-        return !clientes.Any(c => c.Dni == dni);
+        return !clientes.Any(c => c.Dni == dniNormalizado);
     }
 
     public async Task<bool> DeleteAsync(ulong id, ulong? updatedBy, CancellationToken ct = default)

--- a/tests/ExtraGasMVC.Tests/StringNormalizerTests.cs
+++ b/tests/ExtraGasMVC.Tests/StringNormalizerTests.cs
@@ -1,0 +1,144 @@
+using ExtraGasMVC.Extensions;
+using FluentAssertions;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Tests del normalizador de strings de identidad/contacto (DNI, teléfono).
+/// Issue #113: garantiza que variantes por formato (espacios, puntos, guiones,
+/// paréntesis, signo +) convergen al mismo valor canónico, y que entradas
+/// vacías / solo-separadores devuelven <c>null</c>.
+/// </summary>
+public class StringNormalizerTests
+{
+    // --- NormalizarDni ---
+
+    [Fact]
+    public void NormalizarDni_Null_DevuelveNull()
+    {
+        StringNormalizer.NormalizarDni(null).Should().BeNull();
+    }
+
+    [Fact]
+    public void NormalizarDni_Vacio_DevuelveNull()
+    {
+        StringNormalizer.NormalizarDni(string.Empty).Should().BeNull();
+    }
+
+    [Fact]
+    public void NormalizarDni_Whitespace_DevuelveNull()
+    {
+        StringNormalizer.NormalizarDni("   ").Should().BeNull();
+    }
+
+    [Fact]
+    public void NormalizarDni_SoloSeparadores_DevuelveNull()
+    {
+        StringNormalizer.NormalizarDni(" - . - ").Should().BeNull();
+    }
+
+    [Fact]
+    public void NormalizarDni_SinSeparadores_DevuelveMismo()
+    {
+        StringNormalizer.NormalizarDni("12345678").Should().Be("12345678");
+    }
+
+    [Fact]
+    public void NormalizarDni_EspaciosAlrededor_Trimea()
+    {
+        StringNormalizer.NormalizarDni(" 12345678 ").Should().Be("12345678");
+    }
+
+    [Fact]
+    public void NormalizarDni_ConPuntos_LosRemueve()
+    {
+        StringNormalizer.NormalizarDni("12.345.678").Should().Be("12345678");
+    }
+
+    [Fact]
+    public void NormalizarDni_ConGuiones_LosRemueve()
+    {
+        StringNormalizer.NormalizarDni("12-3456-78").Should().Be("12345678");
+    }
+
+    [Fact]
+    public void NormalizarDni_FormatoArgentino_DevuelveSoloDigitos()
+    {
+        StringNormalizer.NormalizarDni(" 12.345.678 ").Should().Be("12345678");
+    }
+
+    [Fact]
+    public void NormalizarDni_DniVacioTrasRemoverSeparadores_DevuelveNull()
+    {
+        StringNormalizer.NormalizarDni(" - . ").Should().BeNull();
+    }
+
+    // --- NormalizarTelefono ---
+
+    [Fact]
+    public void NormalizarTelefono_Null_DevuelveNull()
+    {
+        StringNormalizer.NormalizarTelefono(null).Should().BeNull();
+    }
+
+    [Fact]
+    public void NormalizarTelefono_Vacio_DevuelveNull()
+    {
+        StringNormalizer.NormalizarTelefono(string.Empty).Should().BeNull();
+    }
+
+    [Fact]
+    public void NormalizarTelefono_Whitespace_DevuelveNull()
+    {
+        StringNormalizer.NormalizarTelefono("   ").Should().BeNull();
+    }
+
+    [Fact]
+    public void NormalizarTelefono_SoloSeparadores_DevuelveNull()
+    {
+        StringNormalizer.NormalizarTelefono(" - ( ) . ").Should().BeNull();
+    }
+
+    [Fact]
+    public void NormalizarTelefono_SinSeparadores_DevuelveMismo()
+    {
+        StringNormalizer.NormalizarTelefono("1144556677").Should().Be("1144556677");
+    }
+
+    [Fact]
+    public void NormalizarTelefono_EspaciosAlrededor_Trimea()
+    {
+        StringNormalizer.NormalizarTelefono(" 1144556677 ").Should().Be("1144556677");
+    }
+
+    [Fact]
+    public void NormalizarTelefono_ConGuiones_LosRemueve()
+    {
+        StringNormalizer.NormalizarTelefono("11-4455-6677").Should().Be("1144556677");
+    }
+
+    [Fact]
+    public void NormalizarTelefono_ConParentesis_LosRemueve()
+    {
+        StringNormalizer.NormalizarTelefono("(011) 4455-6677").Should().Be("01144556677");
+    }
+
+    [Fact]
+    public void NormalizarTelefono_ConPuntos_LosRemueve()
+    {
+        StringNormalizer.NormalizarTelefono("11.4455.6677").Should().Be("1144556677");
+    }
+
+    [Fact]
+    public void NormalizarTelefono_ConPrefijoInternacional_ConservaSignoMas()
+    {
+        StringNormalizer.NormalizarTelefono("+54 11 4455-6677").Should().Be("+541144556677");
+    }
+
+    [Fact]
+    public void NormalizarTelefono_FormatoCompleto_DevuelveSoloMasYDigitos()
+    {
+        StringNormalizer.NormalizarTelefono(" +54 (011) 4455-6677 ").Should().Be("+5401144556677");
+    }
+}


### PR DESCRIPTION
## Resumen

Resuelve #113 — `ClienteService` no normalizaba DNI ni teléfono, así que `"12.345.678"` y `"12345678"` se trataban como clientes distintos. La validación de unicidad contra BD también fallaba: dos clientes podían coexistir si el operador tipeaba separadores en uno y no en el otro.

## Cambios

| Archivo | Tipo | Qué hace |
|---|---|---|
| `src/ExtraGasMVC/Extensions/StringNormalizer.cs` | nuevo | Helpers `NormalizarDni` (trim + remover ` `.` `-`) y `NormalizarTelefono` (trim + remover ` `-` `(` `)` `.`, conserva `+` inicial). |
| `src/ExtraGasMVC/DTOs/ClienteDto.cs` | modificado | Regex DNI abierto a `^[0-9 .\-]*$`. Regex nuevo permisivo para `TelefonoPrincipal`. Sin esto, los valores con espacios fallaban la validación de modelo antes de llegar al Service. |
| `src/ExtraGasMVC/Services/Implementations/ClienteService.cs` | modificado | `CreateAsync` y `UpdateAsync` normalizan DNI/tel antes de validar unicidad y antes de persistir. `DniEsUnicoSobre` (helper estático de #105) normaliza el input. `SearchAsync` normaliza el query del usuario. |
| `tests/ExtraGasMVC.Tests/StringNormalizerTests.cs` | nuevo | 21 tests del helper (null, vacío, whitespace, separadores puros, formato argentino `12.345.678`, prefijo internacional `+54 11 4455-6677`). |

## Detalles de diseño

- **`+` internacional se conserva**: `NormalizarTelefono("+54 11 4455-6677")` → `"+541144556677"`. Es semánticamente distinto tener código de país o no, así que cualquier `+` que aparezca fuera de la posición 0 se descarta como ruido de tipeo.
- **Datos preexistentes no se migran**: explícito en el criterio de aceptación de #113. Los clientes viejos con DNI/teléfono con formato raro conviven sin normalizar. El comentario en `SearchAsync` documenta este trade-off: el filtro busca contra valores canónicos, así que DNIs viejos con `.` o `-` no matchean búsquedas — aceptable porque a partir de este fix todos los nuevos registros se guardan canónicos.
- **La columna virtual `dni_unique` (issue #105) NO normaliza**: confirmado en `db/migrations/20260829_000001_clientes_dni_unique_soft_delete.sql`. Solo gestiona soft-delete. La responsabilidad de la normalización es 100% de la app.

## Validación

- `dotnet build` → exit 0.
- `dotnet test` (suite completa) → **208/208 pasan, 0 regresiones**.
- 21 tests nuevos en `StringNormalizerTests`.
- Cero cambios fuera de los 4 archivos listados.

## Checklist (criterios de aceptación de #113)

- [x] Helpers de normalización documentados (XML doc + comentarios inline).
- [x] Todos los flujos (crear, editar, buscar) pasan por el normalizador.
- [x] Tests unitarios de los helpers (espacios, separadores, formato argentino, prefijo internacional).
- [x] Datos existentes no se migran (asumir aceptable que convivan; documentado en comentario de `SearchAsync`).

## Notas de revisión

- El helper se diseñó como `public static class` con métodos `public static` para que pueda consumirse desde otros Services si en el futuro aparece el mismo bug en `Empleado`, `Proveedor`, etc.
- No introduje dependencias nuevas ni cambios en migraciones.
- Los 2 issues preexistentes de SonarQube en `wwwroot/js/recepciones.js:159-160` no se incluyen acá (scope creep; son del repo base, no de este fix).