### PR TITLE
feat(clientes): papelera de clientes soft-deleted (#111)

### DIFF
--- a/src/ExtraGasMVC/Controllers/ClientesController.cs
+++ b/src/ExtraGasMVC/Controllers/ClientesController.cs
@@ -180,4 +180,14 @@ public class ClientesController : BaseController
         var saldos = await _clienteService.GetSaldosAsync(ct);
         return View(saldos);
     }
+
+    // Issue #111: ruta dedicada a la papelera de clientes soft-deleted. La Index
+    // los oculta porque el QueryFilter global los filtra; aca los listamos via
+    // IgnoreQueryFilters() y exponemos el boton Restaurar (ya existente en Restore POST).
+    public async Task<IActionResult> Papelera(string? busqueda, int pagina = 1, int tamanio = 25, CancellationToken ct = default)
+    {
+        var resultado = await _clienteService.GetDeletedAsync(busqueda, pagina, tamanio, ct);
+        ViewBag.Busqueda = busqueda;
+        return View(resultado);
+    }
 }

--- a/src/ExtraGasMVC/DTOs/ClienteDto.cs
+++ b/src/ExtraGasMVC/DTOs/ClienteDto.cs
@@ -83,6 +83,9 @@ public class ClienteDtoBase
 /// ningún formulario: se exponen solo para display (Details, Index, listados).
 /// Issue #114: <c>Activo</c> solo cambia vía Delete/Restore; <c>FechaAlta</c>
 /// es audit trail del alta y no debe retrocederse.
+/// <para>Issue #111: <c>DeletedAt</c> se expone para que la pantalla
+/// /Clientes/Papelera muestre la fecha de baja. Es null para clientes
+/// activos (la mayoria del tiempo) y no es editable.</para>
 /// </summary>
 public class ClienteDto : ClienteDtoBase
 {
@@ -93,6 +96,9 @@ public class ClienteDto : ClienteDtoBase
 
     [Display(Name = "Activo")]
     public bool Activo { get; set; }
+
+    [Display(Name = "Fecha de baja")]
+    public DateTime? DeletedAt { get; set; }
 }
 
 /// <summary>

--- a/src/ExtraGasMVC/Services/Implementations/ClienteService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ClienteService.cs
@@ -241,6 +241,55 @@ public class ClienteService : IClienteService
         return true;
     }
 
+    /// <summary>
+    /// Lista clientes soft-deleted para la pantalla /Clientes/Papelera.
+    /// Issue #111: usa IgnoreQueryFilters() porque el QueryFilter global oculta
+    /// los DeletedAt != null. Filtra adicionalmente por DeletedAt != null para
+    /// quedarse solo con soft-deleted. Soporta busqueda con la misma logica que
+    /// <see cref="SearchAsync"/> (Issue #113: normaliza DNI/telefono) para que
+    /// el operador pueda encontrar un cliente especifico dentro de la papelera.
+    /// </summary>
+    public async Task<PagedResult<ClienteDto>> GetDeletedAsync(
+        string? busqueda, int pagina, int tamanio, CancellationToken ct = default)
+    {
+        var query = _context.Clientes
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .Where(c => c.DeletedAt != null);
+
+        if (!string.IsNullOrWhiteSpace(busqueda))
+        {
+            // Issue #113: normalizamos query para que el operador pueda tipear
+            // " 12345678 " o "+54 11 4455-6677" y matchear contra valores canónicos.
+            var q = busqueda.Trim();
+            var dniNormalizado = StringNormalizer.NormalizarDni(q) ?? q;
+            var telNormalizado = StringNormalizer.NormalizarTelefono(q) ?? q;
+            query = query.Where(c =>
+                c.Nombre.Contains(q)
+                || c.Apellido.Contains(q)
+                || (c.Dni != null && c.Dni.Contains(dniNormalizado))
+                || (c.CuitCuil != null && c.CuitCuil.Contains(q))
+                || c.TelefonoPrincipal.Contains(telNormalizado));
+        }
+
+        var total = await query.CountAsync(ct);
+
+        var clientes = await query
+            .OrderBy(c => c.Apellido)
+            .ThenBy(c => c.Nombre)
+            .Skip((pagina - 1) * tamanio)
+            .Take(tamanio)
+            .ToListAsync(ct);
+
+        return new PagedResult<ClienteDto>
+        {
+            Items = _mapper.Map<List<ClienteDto>>(clientes),
+            Total = total,
+            Page = pagina,
+            PageSize = tamanio
+        };
+    }
+
     public async Task<List<ProvinciaDto>> GetProvinciasAsync(CancellationToken ct = default)
     {
         return await _cache.GetOrCreateAsync(ProvinciasCacheKey, async entry =>

--- a/src/ExtraGasMVC/Services/Interfaces/IClienteService.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IClienteService.cs
@@ -19,6 +19,15 @@ public interface IClienteService
     Task<List<ProvinciaDto>> GetProvinciasAsync(CancellationToken ct = default);
 
     /// <summary>
+    /// Lista clientes soft-deleted (papelera) para la pantalla /Clientes/Papelera.
+    /// Usa IgnoreQueryFilters() porque el global query filter oculta los DeletedAt != null.
+    /// Devuelve TODOS los soft-deleted, activos o no.
+    /// Issue #111.
+    /// </summary>
+    Task<PagedResult<ClienteDto>> GetDeletedAsync(
+        string? busqueda, int pagina, int tamanio, CancellationToken ct = default);
+
+    /// <summary>
     /// Saldos agregados por cliente para la pantalla CuentasCorrientes.
     /// Lee la vista <c>v_saldo_clientes</c> (una sola query) en lugar de
     /// cargar todos los clientes y resolver saldo/pedidos en la vista (N+1).

--- a/src/ExtraGasMVC/Views/Clientes/Index.cshtml
+++ b/src/ExtraGasMVC/Views/Clientes/Index.cshtml
@@ -14,6 +14,9 @@
             <a asp-action="Create" class="btn btn-primary">
                 <i class="bi bi-plus-circle me-1"></i> Nuevo cliente
             </a>
+            <a asp-action="Papelera" class="btn btn-outline-warning float-end me-2">
+                <i class="bi bi-trash3 me-1"></i> Papelera
+            </a>
             <a asp-action="CuentasCorrientes" class="btn btn-outline-primary float-end">
                 <i class="bi bi-wallet2 me-1"></i> Cuentas corrientes
             </a>

--- a/src/ExtraGasMVC/Views/Clientes/Papelera.cshtml
+++ b/src/ExtraGasMVC/Views/Clientes/Papelera.cshtml
@@ -1,0 +1,110 @@
+@model ExtraGasMVC.Models.ViewModels.PagedResult<ExtraGasMVC.DTOs.ClienteDto>
+@{
+    ViewData["Title"] = "Papelera de clientes";
+    var busqueda = ViewBag.Busqueda as string;
+    var pagina = Model.Page;
+    var tamanio = Model.PageSize;
+    var total = Model.Total;
+    var totalPaginas = Model.TotalPages;
+}
+@section PageHeader {
+    <div class="row mb-3">
+        <div class="col-12">
+            <h4 class="mb-1">Papelera de clientes</h4>
+            <p class="text-secondary mb-2">Clientes eliminados que pueden recuperarse. La papelera muestra unicamente los soft-deleted (no se borran de la BD).</p>
+            <a asp-action="Index" class="btn btn-outline-secondary">
+                <i class="bi bi-arrow-left me-1"></i> Volver al listado
+            </a>
+            <a asp-action="Create" class="btn btn-primary float-end">
+                <i class="bi bi-plus-circle me-1"></i> Nuevo cliente
+            </a>
+        </div>
+    </div>
+}
+
+<div class="card">
+    <div class="card-header">
+        <form method="get" class="row g-2 align-items-end">
+            <div class="col-md-9">
+                <label class="form-label small mb-1" for="busqueda">Buscar</label>
+                <input type="text" id="busqueda" name="busqueda" value="@busqueda" class="form-control" placeholder="Nombre, apellido, DNI, CUIT o teléfono" />
+            </div>
+            <div class="col-md-3 d-grid gap-2 d-md-flex">
+                <button type="submit" class="btn btn-primary flex-fill">
+                    <i class="bi bi-search me-1"></i> Buscar
+                </button>
+                <a asp-action="Papelera" class="btn btn-outline-secondary">
+                    <i class="bi bi-arrow-counterclockwise"></i>
+                </a>
+            </div>
+        </form>
+    </div>
+    <div class="card-body table-responsive p-0">
+        <table class="table table-hover table-striped align-middle mb-0">
+            <thead>
+                <tr>
+                    <th>Código</th>
+                    <th>Nombre completo</th>
+                    <th>DNI / CUIT</th>
+                    <th>Teléfono</th>
+                    <th>Ciudad</th>
+                    <th class="text-center">Estado</th>
+                    <th class="text-end" style="width: 200px;">Acciones</th>
+                </tr>
+            </thead>
+            <tbody>
+                @if (!Model.Items.Any())
+                {
+                    <tr><td colspan="7" class="text-center py-4 text-secondary">No hay clientes en la papelera.</td></tr>
+                }
+                @foreach (var c in Model.Items)
+                {
+                    <tr>
+                        <td><code>@(c.Codigo ?? "-")</code></td>
+                        <td><strong>@c.Apellido, @c.Nombre</strong></td>
+                        <td>@(c.Dni ?? c.CuitCuil ?? "-")</td>
+                        <td>@c.TelefonoPrincipal</td>
+                        <td>@(c.Ciudad ?? "-")</td>
+                        <td class="text-center">
+                            <span class="badge text-bg-secondary">Eliminado</span>
+                            @if (c.DeletedAt.HasValue)
+                            {
+                                <small class="d-block text-secondary">@c.DeletedAt.Value.ToString("dd/MM/yyyy")</small>
+                            }
+                        </td>
+                        <td class="text-end">
+                            <form asp-action="Restore" asp-route-id="@c.Id" method="post" class="d-inline js-confirm-form" data-name="este cliente" data-action="reactivar">
+                                @Html.AntiForgeryToken()
+                                <button type="button" class="btn btn-sm btn-success" title="Restaurar" onclick="confirmarAccion(this)">
+                                    <i class="bi bi-arrow-counterclockwise me-1"></i> Restaurar
+                                </button>
+                            </form>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+    <div class="card-footer clearfix">
+        <div class="float-end">
+            <small class="text-secondary me-2">@total cliente@(total == 1 ? "" : "s") en la papelera</small>
+        </div>
+        @if (totalPaginas > 1)
+        {
+            <nav>
+                <ul class="pagination pagination-sm m-0 float-end">
+                    @for (var i = 1; i <= totalPaginas; i++)
+                    {
+                        <li class="page-item @(i == pagina ? "active" : "")">
+                            <a class="page-link"
+                               asp-action="Papelera"
+                               asp-route-busqueda="@busqueda"
+                               asp-route-pagina="@i"
+                               asp-route-tamanio="@tamanio">@i</a>
+                        </li>
+                    }
+                </ul>
+            </nav>
+        }
+    </div>
+</div>

--- a/tests/ExtraGasMVC.Tests/ClienteServiceTests.cs
+++ b/tests/ExtraGasMVC.Tests/ClienteServiceTests.cs
@@ -181,4 +181,72 @@ actualizado.Nombre.Should().Be("Juan Modificado", "el resto de los campos si se 
         await act.Should().ThrowAsync<ClienteSoftDeletedException>()
             .Where(ex => ex.ClienteId == creado.Id);
     }
+
+    // ====================================================================
+    // Issue #111: papelera de clientes soft-deleted
+    // ====================================================================
+
+    [Fact]
+    public async Task DeleteAsync_Y_RestoreAsync_RoundTrip_DevuelveClienteActivoSinDeletedAt()
+    {
+        var (service, context) = NewService(nameof(DeleteAsync_Y_RestoreAsync_RoundTrip_DevuelveClienteActivoSinDeletedAt));
+
+        // Arrange: crear un cliente
+        var dto = NewCreateDto();
+        var creado = await service.CreateAsync(dto, createdBy: 1);
+
+        // Act 1: soft-delete
+        var deleted = await service.DeleteAsync(creado.Id, updatedBy: 1);
+        deleted.Should().BeTrue();
+
+        // Verificar que el cliente esta soft-deleted en BD
+        var entity = await context.Clientes.IgnoreQueryFilters().FirstAsync(c => c.Id == creado.Id);
+        entity.DeletedAt.Should().NotBeNull();
+        entity.Activo.Should().BeFalse();
+
+        // Act 2: restore
+        var restored = await service.RestoreAsync(creado.Id, updatedBy: 1);
+        restored.Should().BeTrue();
+
+        // Assert: DeletedAt es null y Activo es true otra vez
+        var afterRestore = await context.Clientes.IgnoreQueryFilters().FirstAsync(c => c.Id == creado.Id);
+        afterRestore.DeletedAt.Should().BeNull();
+        afterRestore.Activo.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetDeletedAsync_DevuelveSoloSoftDeleted_InclusoSiActivoEsFalse()
+    {
+        var (service, context) = NewService(nameof(GetDeletedAsync_DevuelveSoloSoftDeleted_InclusoSiActivoEsFalse));
+
+        // Arrange: 2 clientes normales + 1 soft-deleted
+        await service.CreateAsync(NewCreateDto("11111111"), createdBy: 1);
+        await service.CreateAsync(NewCreateDto("22222222"), createdBy: 1);
+        var tercero = await service.CreateAsync(NewCreateDto("33333333"), createdBy: 1);
+        await service.DeleteAsync(tercero.Id, updatedBy: 1);
+
+        // Act
+        var resultado = await service.GetDeletedAsync(busqueda: null, pagina: 1, tamanio: 25);
+
+        // Assert: solo el tercero aparece, y DeletedAt != null
+        resultado.Total.Should().Be(1);
+        resultado.Items.Should().HaveCount(1);
+        resultado.Items[0].Id.Should().Be(tercero.Id);
+    }
+
+    [Fact]
+    public async Task GetDeletedAsync_RespetaFiltroDeBusqueda()
+    {
+        var (service, _) = NewService(nameof(GetDeletedAsync_RespetaFiltroDeBusqueda));
+
+        await service.CreateAsync(NewCreateDto(dni: "11111111"), createdBy: 1);
+        await service.CreateAsync(NewCreateDto(dni: "22222222"), createdBy: 1);
+        var tercero = await service.CreateAsync(NewCreateDto(dni: "33333333"), createdBy: 1);
+        await service.DeleteAsync(tercero.Id, updatedBy: 1);
+
+        var resultado = await service.GetDeletedAsync(busqueda: "33333333", pagina: 1, tamanio: 25);
+
+        resultado.Total.Should().Be(1);
+        resultado.Items[0].Id.Should().Be(tercero.Id);
+    }
 }

--- a/tests/ExtraGasMVC.Tests/ClientesControllerEditNotFoundTests.cs
+++ b/tests/ExtraGasMVC.Tests/ClientesControllerEditNotFoundTests.cs
@@ -276,6 +276,7 @@ public class ClientesControllerEditNotFoundTests
         public Task<ClienteDto?> GetByDniAsync(string dni, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<IEnumerable<ClienteDto>> GetActivosAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task<PagedResult<ClienteDto>> SearchAsync(string? b, bool s, int p, int t, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<PagedResult<ClienteDto>> GetDeletedAsync(string? b, int p, int t, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<ClienteDto> CreateAsync(CreateClienteDto c, ulong? b, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<bool> DeleteAsync(ulong id, ulong? u, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<bool> RestoreAsync(ulong id, ulong? u, CancellationToken ct = default) => throw new NotImplementedException();

--- a/tests/ExtraGasMVC.Tests/ControllersActivoViewBagTests.cs
+++ b/tests/ExtraGasMVC.Tests/ControllersActivoViewBagTests.cs
@@ -171,6 +171,7 @@ public class ControllersActivoViewBagTests
         public Task<ClienteDto?> GetByDniAsync(string dni, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<IEnumerable<ClienteDto>> GetActivosAsync(CancellationToken ct = default) => Task.FromResult<IEnumerable<ClienteDto>>(new List<ClienteDto>());
         public Task<PagedResult<ClienteDto>> SearchAsync(string? b, bool s, int p, int t, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<PagedResult<ClienteDto>> GetDeletedAsync(string? b, int p, int t, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<ClienteDto> CreateAsync(CreateClienteDto d, ulong? c, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<ClienteDto> UpdateAsync(UpdateClienteDto d, ulong? u, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<bool> DeleteAsync(ulong id, ulong? u, CancellationToken ct = default) => throw new NotImplementedException();


### PR DESCRIPTION
## Issue

Closes #111

## Problema

`ClienteService.RestoreAsync` y la accion `Restore` POST en `ClientesController` ya existian, pero el `HasQueryFilter(c => c.DeletedAt == null)` en `ClienteConfiguration` ocultaba los soft-deleted para siempre. Un operador no tenia manera de descubrir que clientes fueron borrados, y la papelera quedaba inutilizable salvo que alguien conociera el ID exacto.

## Solucion (Opcion B de la issue — recomendada)

Ruta dedicada `/Clientes/Papelera` con vista, tabla y filtros propios. Reutiliza el `Restore` POST ya existente (no agrega endpoints nuevos de escritura).

## Cambios

- **`IClienteService` / `ClienteService`**: nuevo metodo `GetDeletedAsync(busqueda, pagina, tamanio, ct)` con `IgnoreQueryFilters()` y filtro `DeletedAt != null`. Reusa la logica de busqueda de `SearchAsync`, incluida la normalizacion de DNI/telefono de Issue #113.
- **`ClientesController`**: nueva accion GET `Papelera(string? busqueda, int pagina, int tamanio)` que proyecta la papelera a `PagedResult<ClienteDto>`.
- **`Views/Clientes/Papelera.cshtml`** (nuevo, 110 lineas): layout AdminLTE consistente con `Index`, busqueda, badge `Eliminado` + fecha de baja, boton `Restaurar` (POST a `Restore` con antiforgery y confirmacion SweetAlert2), paginacion y estado vacio.
- **`Views/Clientes/Index.cshtml`**: link `Papelera` en el header (junto a `Cuentas corrientes`).
- **`ClienteDto`**: expone `DeletedAt` (`DateTime?`, read-only) para que la vista muestre la fecha de baja. No es editable desde ningun formulario.
- **Tests** (`ClienteServiceTests`): round-trip `DeleteAsync` -> `RestoreAsync` (verifica `DeletedAt` null y `Activo` true post-restore), `GetDeletedAsync` devuelve solo soft-deleted (incluso si `Activo` fuera false), `GetDeletedAsync` respeta filtro de busqueda.
- **Stubs de test** en `ClientesControllerEditNotFoundTests` y `ControllersActivoViewBagTests` actualizados para satisfacer la nueva firma de `IClienteService`.

## Criterios de aceptacion

- [x] Desde la UI se pueden listar clientes soft-deleted (`/Clientes/Papelera`)
- [x] Boton "Restaurar" disponible para cada uno (POST a `Restore` con antiforgery + SweetAlert2)
- [x] Restauracion cambia `DeletedAt` a NULL y `Activo` a true en una sola transaccion (`RestoreAsync` ya lo hacia: unico `SaveChangesAsync`)
- [x] Test que cubre el round-trip soft-delete -> restore (`DeleteAsync_Y_RestoreAsync_RoundTrip_DevuelveClienteActivoSinDeletedAt`)

## Validacion

- `dotnet build`: OK, 0 errors, 4 warnings pre-existentes (NU1903 sobre AutoMapper 12.0.1, no introducidos por este PR).
- `dotnet test --filter ClienteService`: **211 / 211 pasaron**. 3 tests nuevos verdes.
- `git diff --stat`: 9 archivos, +257 lineas, 0 borradas.

## Notas para reviewer

- La accion `Restore` POST redirige a `Index`, no a `Papelera`. Despues de restaurar desde la papelera el usuario aterriza en el listado normal — mismo flujo que ya tenia `Index`. Mejorar la UX con un `returnUrl` queda fuera de scope (se puede hacer en un follow-up si queres).
- `ClienteDto.DeletedAt` ahora se mapea desde la entity via AutoMapper. `ReverseMap()` propaga `DeletedAt` desde DTO a entity, pero ningun form de Create/Update lo carga hoy, asi que no rompe nada.
- Las 2 issues de SonarQube (`parseFloat` en `wwwroot/js/recepciones.js`) son pre-existentes en `develop`, no las introdujo este PR.