### PR TITLE
fix(ci): cablear dotnet-sonarscanner para que new_coverage reporte cobertura real (#134)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,7 +298,7 @@ No ejecutar comandos costosos solo por costumbre.
 
 ## SonarQube (issue #134)
 
-El plugin `opencode-sonarqube` usa el **scanner Java** estándar, que NO integra con MSBuild ni levanta `coverage.opencover.xml` → reporta `new_coverage: 0%` aunque los tests corran.
+El plugin `opencode-sonarqube` usa el **scanner Java** estándar, que NO integra con MSBuild ni dispara `coverlet.collector` durante el build → reporta `new_coverage: 0%` aunque los tests corran y `coverage.cobertura.xml` exista en disco.
 
 **Para cobertura real y Quality Gate usable:**
 
@@ -308,7 +308,11 @@ export SONAR_TOKEN="squ_..."      # generar en el server (User > Security > Gene
 ./scripts/sonar-analyze.sh        # flujo begin/build/test/end con MSBuild integration
 ```
 
-El script `scripts/sonar-analyze.sh` envuelve `dotnet-sonarscanner 11.x`, mueve `sonar-project.properties` durante el flujo (el scanner .NET se queja si está en la raíz), y deja todo el coverage en `tests/.../TestResults/*/coverage.opencover.xml`.
+El script `scripts/sonar-analyze.sh` envuelve `dotnet-sonarscanner 11.x`, mueve `sonar-project.properties` durante el flujo (el scanner .NET se queja si está en la raíz), y deja todo el coverage en `tests/.../TestResults/*/coverage.cobertura.xml`.
+
+Notas sobre el server:
+- Es **Community Edition**, no Developer/Enterprise. Por eso el script NO usa `sonar.branch.name`/`sonar.branch.target` — esas props requieren Developer+. Si en el futuro migran, agregarlas y volver al análisis por branch.
+- Auth: solo `SONAR_TOKEN` funciona en `end` (las passwords devuelven "Not authorized"). Generar token en User > Security > Generate Tokens.
 
 `sonarqube({ action: "analyze" })` sigue siendo válido para **validación rápida sin coverage** (typos, code smells en código nuevo). NO mezclar ambos flujos en la misma rama — el segundo `analyze` resetea las métricas del server.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,6 +296,22 @@ No ejecutar comandos costosos solo por costumbre.
 | MEDIANA | analizar → planificar → implementar → probar → validar |
 | GRANDE | OpenSpec/SDD completo |
 
+## SonarQube (issue #134)
+
+El plugin `opencode-sonarqube` usa el **scanner Java** estándar, que NO integra con MSBuild ni levanta `coverage.opencover.xml` → reporta `new_coverage: 0%` aunque los tests corran.
+
+**Para cobertura real y Quality Gate usable:**
+
+```bash
+# Una vez (si no está): dotnet tool install -g dotnet-sonarscanner
+export SONAR_TOKEN="squ_..."      # generar en el server (User > Security > Generate Tokens)
+./scripts/sonar-analyze.sh        # flujo begin/build/test/end con MSBuild integration
+```
+
+El script `scripts/sonar-analyze.sh` envuelve `dotnet-sonarscanner 11.x`, mueve `sonar-project.properties` durante el flujo (el scanner .NET se queja si está en la raíz), y deja todo el coverage en `tests/.../TestResults/*/coverage.opencover.xml`.
+
+`sonarqube({ action: "analyze" })` sigue siendo válido para **validación rápida sin coverage** (typos, code smells en código nuevo). NO mezclar ambos flujos en la misma rama — el segundo `analyze` resetea las métricas del server.
+
 ## Recursos
 
 - Skill `database-designer` en `.agents/skills/database-designer/` — usar para optimizaciones, índices y migraciones futuras.

--- a/scripts/sonar-analyze.sh
+++ b/scripts/sonar-analyze.sh
@@ -125,7 +125,7 @@ dotnet sonarscanner begin \
     /d:sonar.sources="src" \
     /d:sonar.tests="tests" \
     /d:sonar.test.inclusions="**/*Tests.cs,**/*Tests.csproj" \
-    /d:sonar.cs.cobertura.reportPaths="tests/ExtraGasMVC.Tests/TestResults/*/coverage.cobertura.xml" \
+    /d:sonar.cs.cobertura.reportsPaths="tests/ExtraGasMVC.Tests/TestResults/*/coverage.cobertura.xml" \
     ${SONAR_AUTH}
 
 echo "[3/5] dotnet build"

--- a/scripts/sonar-analyze.sh
+++ b/scripts/sonar-analyze.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# =============================================================================
+# sonar-analyze.sh — SonarQube analysis with real .NET coverage
+# =============================================================================
+#
+# Por qué este script existe (issue #134):
+#
+#   El plugin `opencode-sonarqube` corre el scanner Java estándar. Ese scanner:
+#     - Sabe analizar .cs/.js/.cshtml
+#     - NO genera .sonarqube/bin/targets/SonarQube.Integration.targets
+#     - NO dispara coverlet.collector durante el build
+#     - Reporta new_coverage=0% aunque el coverage.opencover.xml exista
+#
+#   Este script usa `dotnet-sonarscanner` 11.x, que SÍ integra con MSBuild:
+#     1. `begin` injecta el target SonarQube.Integration.targets en el build
+#     2. `dotnet build` ejecuta el target → cubre los .cs compilados
+#     3. `dotnet test --collect:"XPlat Code Coverage"` corre los tests y
+#        genera coverage.opencover.xml vía coverlet.collector
+#     4. `end` sube el reporte al server junto con la cobertura
+#
+# Requisitos:
+#   - dotnet-sonarscanner 11.x instalado globalmente (dotnet tool install -g dotnet-sonarscanner)
+#   - SONAR_TOKEN o SONAR_PASSWORD configurado en el entorno (recomendado: SONAR_TOKEN;
+#     password legacy puede fallar en `end` con "Not authorized" — ver issue #134)
+#   - SONAR_HOST_URL apuntando al server (default: https://sonarqube.elflacoseba.online)
+#
+# Uso:
+#   ./scripts/sonar-analyze.sh                                    # rama actual contra develop
+#   ./scripts/sonar-analyze.sh feature/mi-rama develop             # branch y base explícitos
+#   SONAR_HOST_URL=http://localhost:9000 ./scripts/sonar-analyze.sh
+#
+# Salida esperada:
+#   - .sonarqube/bin/targets/SonarQube.Integration.targets (generado)
+#   - tests/ExtraGasMVC.Tests/TestResults/<guid>/coverage.opencover.xml
+#   - Quality Gate actualizado en el server
+# =============================================================================
+
+set -euo pipefail
+
+# ---------- Configuración ----------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+HEAD_BRANCH="${1:-$(git rev-parse --abbrev-ref HEAD)}"
+BASE_BRANCH="${2:-develop}"
+
+# Resolver token: SONAR_TOKEN tiene prioridad; SONAR_PASSWORD es fallback legacy.
+#
+# dotnet-sonarscanner 11.x en SonarQube exige `sonar.token` (no `sonar.login`,
+# que es para SonarCloud). Si solo tenés password, primero generá un token en
+# el server: User > Security > Generate Tokens, y exportá SONAR_TOKEN.
+if [[ -n "${SONAR_TOKEN:-}" ]]; then
+    SONAR_AUTH="/d:sonar.token=${SONAR_TOKEN}"
+    AUTH_SOURCE="SONAR_TOKEN"
+elif [[ -n "${SONAR_PASSWORD:-}" ]]; then
+    # Fallback legacy: tratamos el password como si fuera token. En la práctica
+    # las passwords no funcionan en `end` (devuelve "Not authorized"). Es solo
+    # un puente hasta que generes SONAR_TOKEN.
+    SONAR_AUTH="/d:sonar.token=${SONAR_PASSWORD}"
+    AUTH_SOURCE="SONAR_PASSWORD (legacy — puede fallar en 'end')"
+else
+    echo "ERROR: ni SONAR_TOKEN ni SONAR_PASSWORD están definidos." >&2
+    echo "       Generar token en el server (User > Security > Generate Tokens) y" >&2
+    echo "       export SONAR_TOKEN=squ_..." >&2
+    exit 1
+fi
+
+SONAR_HOST_URL="${SONAR_HOST_URL:-https://sonarqube.elflacoseba.online}"
+
+# ---------- Pre-flight ----------
+command -v dotnet-sonarscanner >/dev/null 2>&1 || {
+    echo "ERROR: dotnet-sonarscanner no está instalado." >&2
+    echo "       dotnet tool install -g dotnet-sonarscanner" >&2
+    exit 1
+}
+
+echo "=== SonarQube Analysis ==="
+echo "Repo:           ${REPO_ROOT}"
+echo "Branch:         ${HEAD_BRANCH} (base: ${BASE_BRANCH})"
+echo "Server:         ${SONAR_HOST_URL}"
+echo "Auth:           ${AUTH_SOURCE}"
+echo ""
+
+# ---------- Renombrar sonar-project.properties temporalmente ----------
+# El .NET scanner falla si encuentra `sonar-project.properties` en la raíz
+# (asume que es un proyecto Java). Lo movemos a un nombre no conflictivo y
+# lo restauramos al final, incluso si el script falla mid-flight.
+PROPS_FILE="sonar-project.properties"
+PROPS_BACKUP=".sonar-project.properties.scanner-backup"
+PROPS_RENAMED=false
+
+rename_props() {
+    if [[ -f "${PROPS_FILE}" && "${PROPS_RENAMED}" == "false" ]]; then
+        mv "${PROPS_FILE}" "${PROPS_BACKUP}"
+        PROPS_RENAMED=true
+        echo "[1/5] sonar-project.properties renombrado a ${PROPS_BACKUP}"
+    fi
+}
+
+restore_props() {
+    if [[ "${PROPS_RENAMED}" == "true" && -f "${PROPS_BACKUP}" ]]; then
+        mv "${PROPS_BACKUP}" "${PROPS_FILE}"
+        echo "[cleanup] ${PROPS_FILE} restaurado"
+    fi
+}
+trap restore_props EXIT
+
+# ---------- Flujo begin → build → test → end ----------
+rename_props
+
+echo "[2/5] dotnet sonarscanner begin"
+dotnet sonarscanner begin \
+    /k:"extragas" \
+    /n:"extragas" \
+    /v:"1.0" \
+    /d:sonar.host.url="${SONAR_HOST_URL}" \
+    /d:sonar.branch.name="${HEAD_BRANCH}" \
+    /d:sonar.branch.target="${BASE_BRANCH}" \
+    /d:sonar.sources="src" \
+    /d:sonar.tests="tests" \
+    /d:sonar.test.inclusions="**/*Tests.cs,**/*Tests.csproj" \
+    /d:sonar.cs.opencover.reportsPaths="tests/ExtraGasMVC.Tests/TestResults/*/coverage.opencover.xml" \
+    ${SONAR_AUTH}
+
+echo "[3/5] dotnet build"
+dotnet build "${REPO_ROOT}/ExtraGasMVC.sln" --nologo
+
+echo "[4/5] dotnet test --collect:\"XPlat Code Coverage\""
+dotnet test "${REPO_ROOT}/tests/ExtraGasMVC.Tests/ExtraGasMVC.Tests.csproj" \
+    --nologo \
+    --collect:"XPlat Code Coverage"
+
+echo "[5/5] dotnet sonarscanner end"
+dotnet sonarscanner end ${SONAR_AUTH}
+
+echo ""
+echo "=== Análisis subido a ${SONAR_HOST_URL}/dashboard?id=extragas ==="

--- a/scripts/sonar-analyze.sh
+++ b/scripts/sonar-analyze.sh
@@ -9,13 +9,13 @@
 #     - Sabe analizar .cs/.js/.cshtml
 #     - NO genera .sonarqube/bin/targets/SonarQube.Integration.targets
 #     - NO dispara coverlet.collector durante el build
-#     - Reporta new_coverage=0% aunque el coverage.opencover.xml exista
+#     - Reporta new_coverage=0% aunque el coverage.cobertura.xml exista
 #
 #   Este script usa `dotnet-sonarscanner` 11.x, que SÍ integra con MSBuild:
 #     1. `begin` injecta el target SonarQube.Integration.targets en el build
 #     2. `dotnet build` ejecuta el target → cubre los .cs compilados
 #     3. `dotnet test --collect:"XPlat Code Coverage"` corre los tests y
-#        genera coverage.opencover.xml vía coverlet.collector
+#        genera coverage.cobertura.xml vía coverlet.collector
 #     4. `end` sube el reporte al server junto con la cobertura
 #
 # Requisitos:
@@ -31,8 +31,13 @@
 #
 # Salida esperada:
 #   - .sonarqube/bin/targets/SonarQube.Integration.targets (generado)
-#   - tests/ExtraGasMVC.Tests/TestResults/<guid>/coverage.opencover.xml
+#   - tests/ExtraGasMVC.Tests/TestResults/<guid>/coverage.cobertura.xml
 #   - Quality Gate actualizado en el server
+#
+# Limitaciones:
+#   - `sonar.branch.name` y `sonar.branch.target` requieren Developer Edition
+#     o superior. Este server es Community Edition, así que el script NO las
+#     usa — analiza siempre la rama actual sin comparar contra base.
 # =============================================================================
 
 set -euo pipefail
@@ -110,17 +115,17 @@ trap restore_props EXIT
 rename_props
 
 echo "[2/5] dotnet sonarscanner begin"
+# NOTA: NO pasamos sonar.branch.name/target — el server es Community
+# Edition y esas props requieren Developer Edition o superior.
 dotnet sonarscanner begin \
     /k:"extragas" \
     /n:"extragas" \
     /v:"1.0" \
     /d:sonar.host.url="${SONAR_HOST_URL}" \
-    /d:sonar.branch.name="${HEAD_BRANCH}" \
-    /d:sonar.branch.target="${BASE_BRANCH}" \
     /d:sonar.sources="src" \
     /d:sonar.tests="tests" \
     /d:sonar.test.inclusions="**/*Tests.cs,**/*Tests.csproj" \
-    /d:sonar.cs.opencover.reportsPaths="tests/ExtraGasMVC.Tests/TestResults/*/coverage.opencover.xml" \
+    /d:sonar.cs.cobertura.reportPaths="tests/ExtraGasMVC.Tests/TestResults/*/coverage.cobertura.xml" \
     ${SONAR_AUTH}
 
 echo "[3/5] dotnet build"


### PR DESCRIPTION
## Resumen

Resuelve el bug del Quality Gate de SonarQube documentado en #134 (`new_coverage: 0%` siempre, incluso con tests pasando). Después de este fix, el server reporta **35.9% de cobertura real** (2809/7159 líneas cubiertas).

## Causa raíz

El plugin `opencode-sonarqube` usa el scanner **Java** estándar que no integra con MSBuild → nunca levanta `coverage.cobertura.xml`. Pero ese era solo uno de dos bugs.

El segundo bug era un **typo** en el nombre de la propiedad:

```diff
- sonar.cs.cobertura.reportPaths=...
+ sonar.cs.cobertura.reportsPaths=...
```

El sensor `C# Tests Coverage Report Import` solo se activa cuando la propiedad tiene la `s` final. Sin la `s`, el log verbose muestra:

```
'C# Tests Coverage Report Import' skipped because of missing configuration requirements.
- sonar.cs.cobertura.reportsPaths: <empty>
```

Y la cobertura queda en 0% aunque el archivo `coverage.cobertura.xml` exista con datos válidos.

## Solución

Script `scripts/sonar-analyze.sh` que envuelve `dotnet-sonarscanner 11.x` con el flujo `begin → build → test → end`. Cada commit del PR arregla una capa:

1. **`8a8f3f1`** — script + nota en AGENTS.md.
2. **`a300ff5`** — server es **Community Edition**, no Developer → quitamos `sonar.branch.name`/`sonar.branch.target`. Y `coverlet.collector` con `--collect:"XPlat Code Coverage"` emite `coverage.cobertura.xml`, no `opencover.xml`.
3. **`427338b`** — typo final: `reportPaths` → `reportsPaths` (con 's'). Sin esto el sensor se skipea silenciosamente.

## Verificación end-to-end

```bash
$ export SONAR_TOKEN="squ_..."   # generado en el server
$ ./scripts/sonar-analyze.sh

=== SonarQube Analysis ===
Repo:           /Users/elflacoseba/Source/ExtraGas
Branch:         fix/sonarqube-coverage-134 (base: develop)
Server:         https://sonarqube.elflacoseba.online
Auth:           SONAR_TOKEN

[1/5] sonar-project.properties renombrado a .sonar-project.properties.scanner-backup
[2/5] dotnet sonarscanner begin
[3/5] dotnet build
[4/5] dotnet test --collect:"XPlat Code Coverage"
  Passed!  - Failed: 0, Passed: 233, Skipped: 0, Total: 233
[5/5] dotnet sonarscanner end
  ANALYSIS SUCCESSFUL
```

Métricas post-fix (vía API del server):
- **Coverage**: 35.9% (era 0%)
- `lines_to_cover`: 7159
- `uncovered_lines`: 4350
- `lines_covered`: 2809 (matchea exactamente con `coverage.cobertura.xml`)

El Quality Gate sigue en ERROR pero ahora por `new_violations: 19` (issues pre-existentes, no por coverage). El gate default de Community Edition requiere 80% en `new_coverage` para el "new code period" — y como este análisis no introduce código nuevo vs el análisis previo (los archivos son los mismos), `new_lines_to_cover: 0` y la condición no aplica.

## Cambios

| Archivo | Tipo | Descripción |
|---|---|---|
| `scripts/sonar-analyze.sh` | nuevo | Flujo completo `dotnet-sonarscanner` con auth token-aware, manejo de `sonar-project.properties` y pre-flight. |
| `AGENTS.md` | modificado | Nueva sección "SonarQube (issue #134)" explicando cuándo usar el script vs el plugin opencode. |
| `sonar-project.properties` | local (gitignored) | Typo corregido: `sonar.cs.cobertura.reportPaths` → `sonar.cs.cobertura.reportsPaths`. |

## Limitaciones descubiertas durante el fix

- El server es **Community Edition** → no se puede usar `sonar.branch.name` (requiere Developer+). El script ya no las pasa.
- **Auth**: solo `SONAR_TOKEN` funciona en `end` (las passwords devuelven "Not authorized"). Generar token en User > Security > Generate Tokens.
- `sonarqube({ action: "analyze" })` sigue siendo válido para smoke tests sin coverage. **No mezclar** ambos flujos en la misma rama — el segundo `analyze` resetea las métricas del server.

## Uso

```bash
# Una vez (si no está): dotnet tool install -g dotnet-sonarscanner
export SONAR_TOKEN="squ_..."      # generar en el server: User > Security > Generate Tokens
./scripts/sonar-analyze.sh        # rama actual contra develop
```

Closes #134