### PR TITLE
test(canje): cerrar cobertura de new code con integration tests + controller branch (#138)

### DIFF
--- a/src/ExtraGasMVC/Data/Configurations/GarrafaConfiguration.cs
+++ b/src/ExtraGasMVC/Data/Configurations/GarrafaConfiguration.cs
@@ -68,7 +68,7 @@ public class GarrafaConfiguration : IEntityTypeConfiguration<Garrafa>
             .HasColumnName("deleted_at")
             .HasColumnType("datetime");
 
-        builder.HasOne<Proveedor>()
+        builder.HasOne(g => g.Proveedor)
             .WithMany()
             .HasForeignKey(g => g.ProveedorId)
             .OnDelete(DeleteBehavior.Restrict)
@@ -86,7 +86,7 @@ public class GarrafaConfiguration : IEntityTypeConfiguration<Garrafa>
             .OnDelete(DeleteBehavior.Restrict)
             .HasConstraintName("fk_garrafas_estado");
 
-        builder.HasOne<Cliente>()
+        builder.HasOne(g => g.Cliente)
             .WithMany()
             .HasForeignKey(g => g.ClienteId)
             .OnDelete(DeleteBehavior.Restrict)

--- a/tests/ExtraGasMVC.Tests/PedidoCanjeIntegrationTests.cs
+++ b/tests/ExtraGasMVC.Tests/PedidoCanjeIntegrationTests.cs
@@ -1,0 +1,991 @@
+using AutoMapper;
+using ExtraGasMVC.Constants;
+using ExtraGasMVC.Data.Context;
+using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.Data.Entities.Enums;
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Mappings;
+using ExtraGasMVC.Services.Implementations;
+using ExtraGasMVC.Services.Interfaces;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using MySqlConnector;
+using Testcontainers.MySql;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Tests de integración del flujo de canje de
+/// <see cref="PedidoService.RegistrarCanjePedidoAsync"/> contra un MySQL real
+/// dentro de un container Docker (Testcontainers.MySql).
+///
+/// Issue #138: el PR #137 cerró las 19 issues SonarQube en new code, pero
+/// quedó en <c>new_coverage: 44%</c> (threshold 80%) porque este método y sus
+/// helpers privados (LoadCatalogosParaCanjeAsync, LoadItemsParaCanjeAsync,
+/// AplicarCanjeYConfirmarAsync, etc.) no tenían ningún test. La cobertura de
+/// InMemory no alcanza porque el canje ejecuta escrituras en transacciones
+/// reales contra triggers MySQL (<c>trg_mov_garrafa_ai</c>) que actualizan
+/// <c>garrafas.estado_garrafa_id</c> en respuesta al INSERT del movimiento.
+///
+/// Patrón: IClassFixture comparte el container entre los tests (los containers
+/// son caros de arrancar). Cada test crea su propia base y aplica el schema
+/// mínimo para tener aislamiento. Réplica del patrón de
+/// <see cref="ClienteMySqlFixture"/>.
+/// </summary>
+public class PedidoCanjeIntegrationTests : IClassFixture<PedidoCanjeMySqlFixture>
+{
+    private readonly PedidoCanjeMySqlFixture _fixture;
+
+    public PedidoCanjeIntegrationTests(PedidoCanjeMySqlFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    // ====================================================================
+    // Happy path
+    // ====================================================================
+
+    [Fact]
+    public async Task RegistrarCanjePedidoAsync_HappyPath_EntregaYDevolucion_CreaMovimientosYConfirmaPedido()
+    {
+        // Cubre: LoadPedidoParaCanjeAsync, AsegurarNoCanjeadoAsync,
+        // LoadCatalogosParaCanjeAsync, LoadItemsParaCanjeAsync,
+        // ValidarItemsSonGarrafaCanjeable, NormalizarYValidarCodigos,
+        // ValidarCodigosContraInventarioAsync, AplicarCanjeYConfirmarAsync,
+        // AplicarCanjeDeItemAsync y la cadena hasta el COMMIT de la transacción.
+        var ctx = await _fixture.NewDbContextAsync(
+            nameof(RegistrarCanjePedidoAsync_HappyPath_EntregaYDevolucion_CreaMovimientosYConfirmaPedido));
+        var service = NewService(ctx);
+
+        var seed = await SeedPedidoCompletoAsync(ctx, incluirDevolucion: true);
+        // El seed crea: 2 garrafas LLENA_DEPOSITO (entrega) + 1 garrafa EN_CLIENTE del cliente (devolución).
+        var codigosPorItem = new Dictionary<ulong, List<string>>
+        {
+            [seed.ItemEntregaId] = new() { seed.CodigosEntrega[0], seed.CodigosEntrega[1] },
+            [seed.ItemDevolucionId] = new() { seed.CodigoDevolucion },
+        };
+
+        var ok = await service.RegistrarCanjePedidoAsync(
+            seed.PedidoId, codigosPorItem, usuarioId: 1);
+
+        ok.Should().BeTrue();
+
+        // 1) Pedido pasó a CONFIRMADO.
+        var pedidoFinal = await ctx.Pedidos.IgnoreQueryFilters()
+            .FirstAsync(p => p.Id == seed.PedidoId);
+        var confirmado = await ctx.EstadosPedido.FirstAsync(e => e.Codigo == PedidoEstados.Confirmado);
+        pedidoFinal.EstadoPedidoId.Should().Be(confirmado.Id);
+        pedidoFinal.UpdatedBy.Should().Be(1);
+
+        // 2) Se generaron 3 movimientos de garrafa (2 entrega + 1 devolución),
+        //    todos apuntando al pedido.
+        var movimientos = await ctx.MovimientosGarrafa
+            .Where(m => m.PedidoId == seed.PedidoId)
+            .OrderBy(m => m.Id)
+            .ToListAsync();
+        movimientos.Should().HaveCount(3);
+        movimientos.Should().OnlyContain(m => m.PedidoId == seed.PedidoId);
+
+        // 3) Estado origen/destino y tipo de movimiento de cada uno.
+        var entregaCliente = await ctx.TiposMovimientoGarrafa
+            .FirstAsync(t => t.Codigo == "ENTREGA_CLIENTE");
+        var devolucionCliente = await ctx.TiposMovimientoGarrafa
+            .FirstAsync(t => t.Codigo == "DEVOLUCION_CLIENTE");
+        var llenaDeposito = await ctx.EstadosGarrafa.FirstAsync(e => e.Codigo == GarrafaEstados.LlenaDeposito);
+        var enCliente = await ctx.EstadosGarrafa.FirstAsync(e => e.Codigo == GarrafaEstados.EnCliente);
+
+        movimientos.Count(m => m.TipoMovimientoId == entregaCliente.Id
+                            && m.EstadoDestinoId == enCliente.Id
+                            && m.ClienteId == seed.ClienteId).Should().Be(2,
+            "2 entregas a cliente");
+
+        movimientos.Count(m => m.TipoMovimientoId == devolucionCliente.Id
+                            && m.EstadoDestinoId == llenaDeposito.Id
+                            && m.ClienteId == null).Should().Be(1,
+            "1 devolución sin cliente (vuelve al depósito)");
+
+        // 4) Trigger trg_mov_garrafa_ai actualizó garrafa.estado_garrafa_id.
+        // Usamos AsNoTracking para no leer del tracker de EF (que cachea el
+        // estado anterior al canje).
+        var garrafas = await ctx.Garrafas.IgnoreQueryFilters().AsNoTracking()
+            .Where(g => seed.CodigosEntrega.Concat(new[] { seed.CodigoDevolucion }).Contains(g.Codigo))
+            .ToListAsync();
+        garrafas.Where(g => seed.CodigosEntrega.Contains(g.Codigo))
+            .Should().OnlyContain(g => g.EstadoGarrafaId == enCliente.Id
+                                    && g.ClienteId == seed.ClienteId);
+        garrafas.Single(g => g.Codigo == seed.CodigoDevolucion)
+            .EstadoGarrafaId.Should().Be(llenaDeposito.Id);
+        garrafas.Single(g => g.Codigo == seed.CodigoDevolucion)
+            .ClienteId.Should().BeNull("la devolución limpia el cliente_id");
+    }
+
+    [Fact]
+    public async Task RegistrarCanjePedidoAsync_SoloEntrega_SinDevolucion_TambienConfirma()
+    {
+        // Cubre la rama donde solo hay items ENTREGA. La tabla
+        // codigosPorItem incluye solo el item de entrega; no hay itemDevolucion.
+        var ctx = await _fixture.NewDbContextAsync(
+            nameof(RegistrarCanjePedidoAsync_SoloEntrega_SinDevolucion_TambienConfirma));
+        var service = NewService(ctx);
+
+        var seed = await SeedPedidoCompletoAsync(ctx, incluirDevolucion: false);
+        var codigosPorItem = new Dictionary<ulong, List<string>>
+        {
+            [seed.ItemEntregaId] = new() { seed.CodigosEntrega[0], seed.CodigosEntrega[1] },
+        };
+
+        var ok = await service.RegistrarCanjePedidoAsync(
+            seed.PedidoId, codigosPorItem, usuarioId: 1);
+
+        ok.Should().BeTrue();
+        var movimientos = await ctx.MovimientosGarrafa
+            .Where(m => m.PedidoId == seed.PedidoId).ToListAsync();
+        movimientos.Should().HaveCount(2);
+    }
+
+    // ====================================================================
+    // Idempotencia
+    // ====================================================================
+
+    [Fact]
+    public async Task RegistrarCanjePedidoAsync_DosVecesSobreElMismoPedido_RechazaPorEstadoConfirmado()
+    {
+        // Cubre LoadPedidoParaCanjeAsync: la segunda invocación rechaza el
+        // pedido que ya quedó en CONFIRMADO tras el primer canje exitoso.
+        // (AsegurarNoCanjeadoAsync es la red de seguridad para el caso más
+        // raro en que el pedido se revirtió a PENDIENTE sin deshacer los
+        // movimientos — no cubierto por este test del happy-path).
+        var ctx = await _fixture.NewDbContextAsync(
+            nameof(RegistrarCanjePedidoAsync_DosVecesSobreElMismoPedido_RechazaPorEstadoConfirmado));
+        var service = NewService(ctx);
+
+        var seed = await SeedPedidoCompletoAsync(ctx, incluirDevolucion: false);
+        var codigosPorItem = new Dictionary<ulong, List<string>>
+        {
+            [seed.ItemEntregaId] = new() { seed.CodigosEntrega[0], seed.CodigosEntrega[1] },
+        };
+
+        await service.RegistrarCanjePedidoAsync(seed.PedidoId, codigosPorItem, usuarioId: 1);
+
+        var act = async () => await service.RegistrarCanjePedidoAsync(
+            seed.PedidoId, codigosPorItem, usuarioId: 1);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*ya se encuentra en estado CONFIRMADO*");
+
+        // La cantidad de movimientos no se duplicó: sigue habiendo 2.
+        var total = await ctx.MovimientosGarrafa.AsNoTracking()
+            .CountAsync(m => m.PedidoId == seed.PedidoId);
+        total.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task RegistrarCanjePedidoAsync_PedidoConMovimientosPrevios_RechazaPorIdempotencia()
+    {
+        // Cubre AsegurarNoCanjeadoAsync: si ya hay movimientos registrados
+        // para el pedido (sin importar el estado), el canje rechaza. Para
+        // forzar este camino sin pasar por la validación de estado, dejamos
+        // el pedido en PENDIENTE pero le insertamos un movimiento "huérfano"
+        // por raw SQL — el EF tracker del pedido en PENDIENTE engaña al
+        // LoadPedidoParaCanjeAsync, así que llegamos a AsegurarNoCanjeadoAsync.
+        var ctx = await _fixture.NewDbContextAsync(
+            nameof(RegistrarCanjePedidoAsync_PedidoConMovimientosPrevios_RechazaPorIdempotencia));
+        var service = NewService(ctx);
+
+        var seed = await SeedPedidoCompletoAsync(ctx, incluirDevolucion: false);
+
+        // Forzar el escenario: el pedido sigue en PENDIENTE (tracker), pero
+        // la BD tiene un movimiento previo para el mismo pedido.
+        var conn = (MySqlConnection)ctx.Database.GetDbConnection();
+        if (conn.State != System.Data.ConnectionState.Open)
+            await conn.OpenAsync();
+        var entregaTipoId = (await ctx.TiposMovimientoGarrafa.AsNoTracking()
+            .FirstAsync(t => t.Codigo == "ENTREGA_CLIENTE")).Id;
+        var enClienteId = (await ctx.EstadosGarrafa.AsNoTracking()
+            .FirstAsync(e => e.Codigo == GarrafaEstados.EnCliente)).Id;
+        var garrafaId = (await ctx.Garrafas.AsNoTracking()
+            .FirstAsync(g => g.Codigo == seed.CodigosEntrega[0])).Id;
+
+        await using (var cmd = conn.CreateCommand())
+        {
+            // Movimiento huérfano: disparará el trigger que pasa la garrafa a
+            // EN_CLIENTE (no afecta al test, solo queremos un mov previo).
+            cmd.CommandText = @"INSERT INTO movimientos_garrafa
+                (garrafa_id, fecha, tipo_movimiento_id, pedido_id, estado_origen_id, estado_destino_id)
+                VALUES (@gar, NOW(), @tip, @ped, @est_origen, @est_destino);";
+            cmd.Parameters.Add(new MySqlParameter("@gar", garrafaId));
+            cmd.Parameters.Add(new MySqlParameter("@tip", entregaTipoId));
+            cmd.Parameters.Add(new MySqlParameter("@ped", seed.PedidoId));
+            cmd.Parameters.Add(new MySqlParameter("@est_origen", enClienteId));
+            cmd.Parameters.Add(new MySqlParameter("@est_destino", enClienteId));
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        var codigosPorItem = new Dictionary<ulong, List<string>>
+        {
+            [seed.ItemEntregaId] = new() { seed.CodigosEntrega[0], seed.CodigosEntrega[1] },
+        };
+
+        var act = async () => await service.RegistrarCanjePedidoAsync(
+            seed.PedidoId, codigosPorItem, usuarioId: 1);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*ya tiene movimientos de canje*");
+    }
+
+    // ====================================================================
+    // Catálogo incompleto
+    // ====================================================================
+
+    [Fact]
+    public async Task RegistrarCanjePedidoAsync_TipoMovimientoFaltante_LanzaInvalidOperationException()
+    {
+        // Cubre LoadCatalogosParaCanjeAsync cuando falta el tipo de
+        // movimiento DEVOLUCION_CLIENTE en la tabla tipos_movimiento_garrafa.
+        // El test elimina la fila antes de invocar el service.
+        var ctx = await _fixture.NewDbContextAsync(
+            nameof(RegistrarCanjePedidoAsync_TipoMovimientoFaltante_LanzaInvalidOperationException));
+        var service = NewService(ctx);
+
+        var seed = await SeedPedidoCompletoAsync(ctx, incluirDevolucion: true);
+        await ctx.TiposMovimientoGarrafa
+            .Where(t => t.Codigo == "DEVOLUCION_CLIENTE")
+            .ExecuteDeleteAsync();
+
+        var codigosPorItem = new Dictionary<ulong, List<string>>
+        {
+            [seed.ItemEntregaId] = new() { seed.CodigosEntrega[0], seed.CodigosEntrega[1] },
+            [seed.ItemDevolucionId] = new() { seed.CodigoDevolucion },
+        };
+
+        var act = async () => await service.RegistrarCanjePedidoAsync(
+            seed.PedidoId, codigosPorItem, usuarioId: 1);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*ENTREGA_CLIENTE*DEVOLUCION_CLIENTE*");
+
+        // Ningún movimiento se persistió.
+        var total = await ctx.MovimientosGarrafa.CountAsync(m => m.PedidoId == seed.PedidoId);
+        total.Should().Be(0);
+
+        // El pedido sigue en PENDIENTE (la transacción hizo rollback).
+        var pedido = await ctx.Pedidos.IgnoreQueryFilters().FirstAsync(p => p.Id == seed.PedidoId);
+        var pendiente = await ctx.EstadosPedido.FirstAsync(e => e.Codigo == PedidoEstados.Pendiente);
+        pedido.EstadoPedidoId.Should().Be(pendiente.Id);
+    }
+
+    // ====================================================================
+    // Validaciones de items y códigos
+    // ====================================================================
+
+    [Fact]
+    public async Task RegistrarCanjePedidoAsync_ItemNoGarrafaCanjeable_LanzaInvalidOperationException()
+    {
+        // Cubre ValidarItemsSonGarrafaCanjeable: el service rechaza el canje
+        // si el item tiene tipo VENTA (carbón, leña) o si el producto no
+        // maneja garrafas individuales.
+        var ctx = await _fixture.NewDbContextAsync(
+            nameof(RegistrarCanjePedidoAsync_ItemNoGarrafaCanjeable_LanzaInvalidOperationException));
+        var service = NewService(ctx);
+
+        var seed = await SeedPedidoCompletoAsync(ctx, incluirDevolucion: false);
+
+        // Cambiar el tipo del item existente a VENTA (carbón/leña). El item
+        // debe seguir siendo GARRAFA-capaz (ManejaGarrafaIndividual=true),
+        // pero con tipo_linea=VENTA — el service debe rechazar.
+        var item = await ctx.PedidoItems.FirstAsync(i => i.Id == seed.ItemEntregaId);
+        item.TipoLinea = TipoLinea.VENTA;
+        await ctx.SaveChangesAsync();
+
+        var codigosPorItem = new Dictionary<ulong, List<string>>
+        {
+            [seed.ItemEntregaId] = new() { seed.CodigosEntrega[0], seed.CodigosEntrega[1] },
+        };
+
+        var act = async () => await service.RegistrarCanjePedidoAsync(
+            seed.PedidoId, codigosPorItem, usuarioId: 1);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*solo ENTREGA o DEVOLUCION*");
+    }
+
+    [Fact]
+    public async Task RegistrarCanjePedidoAsync_CantidadCodigosNoCoincideConItem_LanzaInvalidOperationException()
+    {
+        // Cubre NormalizarYValidarCodigos: si el operador carga menos (o
+        // más) códigos que la cantidad del item, el service rechaza.
+        var ctx = await _fixture.NewDbContextAsync(
+            nameof(RegistrarCanjePedidoAsync_CantidadCodigosNoCoincideConItem_LanzaInvalidOperationException));
+        var service = NewService(ctx);
+
+        var seed = await SeedPedidoCompletoAsync(ctx, incluirDevolucion: false);
+        // El item pide 2 garrafas pero mandamos solo 1.
+        var codigosPorItem = new Dictionary<ulong, List<string>>
+        {
+            [seed.ItemEntregaId] = new() { seed.CodigosEntrega[0] },
+        };
+
+        var act = async () => await service.RegistrarCanjePedidoAsync(
+            seed.PedidoId, codigosPorItem, usuarioId: 1);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*esperaba 2*código*recibió 1*");
+    }
+
+    [Fact]
+    public async Task RegistrarCanjePedidoAsync_GarrafaNoPerteneceAlCliente_LanzaInvalidOperationException()
+    {
+        // Cubre ValidarCodigosContraInventarioAsync: una DEVOLUCION exige que
+        // la garrafa esté en estado EN_CLIENTE Y sea del cliente del pedido.
+        // Cargamos una garrafa EN_CLIENTE de OTRO cliente y verificamos que
+        // el service rechaza.
+        var ctx = await _fixture.NewDbContextAsync(
+            nameof(RegistrarCanjePedidoAsync_GarrafaNoPerteneceAlCliente_LanzaInvalidOperationException));
+        var service = NewService(ctx);
+
+        var seed = await SeedPedidoCompletoAsync(ctx, incluirDevolucion: true);
+
+        // Crear un cliente extra + una garrafa EN_CLIENTE de ese cliente.
+        var now = DateTime.UtcNow;
+        var fechaCompra = DateOnly.FromDateTime(now);
+
+        var otroCliente = new Cliente
+        {
+            Nombre = "Otro",
+            Apellido = "Cliente",
+            TelefonoPrincipal = "1144449999",
+            FechaAlta = fechaCompra,
+            Activo = true,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+        ctx.Clientes.Add(otroCliente);
+        await ctx.SaveChangesAsync();
+
+        var enClienteEstadoId = (await ctx.EstadosGarrafa.FirstAsync(e => e.Codigo == GarrafaEstados.EnCliente)).Id;
+        var garrafaAjena = new Garrafa
+        {
+            Codigo = "G-DEVOL-AJENA",
+            CapacidadKg = 10,
+            FechaCompra = fechaCompra,
+            EstadoGarrafaId = enClienteEstadoId,
+            ClienteId = otroCliente.Id, // <- del OTRO cliente, no del pedido
+            Activo = true,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+        ctx.Garrafas.Add(garrafaAjena);
+        await ctx.SaveChangesAsync();
+
+        var codigosPorItem = new Dictionary<ulong, List<string>>
+        {
+            [seed.ItemEntregaId] = new() { seed.CodigosEntrega[0], seed.CodigosEntrega[1] },
+            [seed.ItemDevolucionId] = new() { garrafaAjena.Codigo },
+        };
+
+        var act = async () => await service.RegistrarCanjePedidoAsync(
+            seed.PedidoId, codigosPorItem, usuarioId: 1);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*pertenece al cliente*");
+    }
+
+    [Fact]
+    public async Task RegistrarCanjePedidoAsync_CodigoInexistente_LanzaInvalidOperationException()
+    {
+        // Cubre ValidarCodigosContraInventarioAsync cuando el código físico
+        // no existe en la tabla garrafas.
+        var ctx = await _fixture.NewDbContextAsync(
+            nameof(RegistrarCanjePedidoAsync_CodigoInexistente_LanzaInvalidOperationException));
+        var service = NewService(ctx);
+
+        var seed = await SeedPedidoCompletoAsync(ctx, incluirDevolucion: false);
+        var codigosPorItem = new Dictionary<ulong, List<string>>
+        {
+            [seed.ItemEntregaId] = new() { seed.CodigosEntrega[0], "G-NO-EXISTE" },
+        };
+
+        var act = async () => await service.RegistrarCanjePedidoAsync(
+            seed.PedidoId, codigosPorItem, usuarioId: 1);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*G-NO-EXISTE*no existe en el inventario*");
+    }
+
+    // ====================================================================
+    // Helpers
+    // ====================================================================
+
+    private static PedidoService NewService(ExtraGasDbContext context)
+    {
+        var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        var mapper = mapperConfig.CreateMapper();
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var garrafaService = new GarrafaService(context, mapper, NullLogger<GarrafaService>.Instance);
+        return new PedidoService(context, mapper, cache, garrafaService);
+    }
+
+    /// <summary>
+    /// Sembrado mínimo del escenario de canje. Devuelve los IDs y códigos
+    /// físicos necesarios para que cada test arme el diccionario de
+    /// codigosPorItem a su manera.
+    ///
+    /// Estructura del pedido:
+    ///   - estado PENDIENTE
+    ///   - 1 item ENTREGA de GARRAFA 10kg, cantidad 2
+    ///   - (opcional) 1 item DEVOLUCION de GARRAFA 10kg, cantidad 1
+    ///   - 2 garrafas LLENA_DEPOSITO (serán entregadas al cliente)
+    ///   - (opcional) 1 garrafa EN_CLIENTE del cliente del pedido (será devuelta)
+    /// </summary>
+    private async Task<CanjeSeed> SeedPedidoCompletoAsync(
+        ExtraGasDbContext ctx, bool incluirDevolucion)
+    {
+        // Catálogos (idempotente gracias a INSERT IGNORE + ON DUPLICATE KEY).
+        var pendienteId = (await ctx.EstadosPedido.FirstAsync(e => e.Codigo == PedidoEstados.Pendiente)).Id;
+        var confirmadaId = (await ctx.EstadosPedido.FirstAsync(e => e.Codigo == PedidoEstados.Confirmado)).Id;
+
+        var llenaDepositoId = (await ctx.EstadosGarrafa.FirstAsync(e => e.Codigo == GarrafaEstados.LlenaDeposito)).Id;
+        var enClienteId = (await ctx.EstadosGarrafa.FirstAsync(e => e.Codigo == GarrafaEstados.EnCliente)).Id;
+
+        await ctx.TiposMovimientoGarrafa.FirstAsync(t => t.Codigo == "ENTREGA_CLIENTE");
+        await ctx.TiposMovimientoGarrafa.FirstAsync(t => t.Codigo == "DEVOLUCION_CLIENTE");
+
+        var canalVentaId = (await ctx.CanalesVenta.FirstAsync()).Id;
+        var tipoProductoId = (await ctx.TiposProducto.FirstAsync()).Id;
+
+        var now = DateTime.UtcNow;
+        var fechaCompra = DateOnly.FromDateTime(now);
+
+        // Empleado.
+        var empleado = new Empleado
+        {
+            Nombre = "Juan",
+            Apellido = "Empleado",
+            Telefono = "1100000000",
+            FechaIngreso = fechaCompra,
+            Activo = true,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+        ctx.Empleados.Add(empleado);
+        await ctx.SaveChangesAsync();
+
+        // Cliente.
+        var cliente = new Cliente
+        {
+            Nombre = "Pedro",
+            Apellido = "Garcia",
+            Dni = "11222333",
+            TelefonoPrincipal = "1144556677",
+            FechaAlta = fechaCompra,
+            Activo = true,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+        ctx.Clientes.Add(cliente);
+        await ctx.SaveChangesAsync();
+
+        // Producto GARRAFA-capaz (ManejaGarrafaIndividual = true).
+        var producto = new Producto
+        {
+            Codigo = "GAR-10",
+            Nombre = "Garrafa 10kg",
+            TipoProductoId = tipoProductoId,
+            CapacidadKg = 10m,
+            UnidadVenta = "UNIDAD",
+            PrecioActual = 15000m,
+            ManejaGarrafaIndividual = true,
+            Activo = true,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+        ctx.Productos.Add(producto);
+        await ctx.SaveChangesAsync();
+
+        // Pedido PENDIENTE.
+        var pedido = new Pedido
+        {
+            Fecha = now,
+            ClienteId = cliente.Id,
+            EmpleadoId = empleado.Id,
+            EstadoPedidoId = pendienteId,
+            CanalVentaId = canalVentaId,
+            Subtotal = 0m,
+            Descuento = 0m,
+            Total = 0m,
+            MontoPagado = 0m,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+        ctx.Pedidos.Add(pedido);
+        await ctx.SaveChangesAsync();
+
+        // Item ENTREGA cantidad 2.
+        var itemEntrega = new PedidoItem
+        {
+            PedidoId = pedido.Id,
+            ProductoId = producto.Id,
+            TipoLinea = TipoLinea.ENTREGA,
+            Cantidad = 2m,
+            PrecioUnitario = 15000m,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+        ctx.PedidoItems.Add(itemEntrega);
+        await ctx.SaveChangesAsync();
+
+        ulong itemDevolucionId = 0;
+        if (incluirDevolucion)
+        {
+            var itemDevolucion = new PedidoItem
+            {
+                PedidoId = pedido.Id,
+                ProductoId = producto.Id,
+                TipoLinea = TipoLinea.DEVOLUCION,
+                Cantidad = 1m,
+                PrecioUnitario = 15000m,
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            ctx.PedidoItems.Add(itemDevolucion);
+            await ctx.SaveChangesAsync();
+            itemDevolucionId = itemDevolucion.Id;
+        }
+
+        // Garrafas: 2 LLENAS (entrega) + 1 EN_CLIENTE (devolución, si aplica).
+        var codigosEntrega = new List<string> { "G-LLENA-001", "G-LLENA-002" };
+        foreach (var codigo in codigosEntrega)
+        {
+            ctx.Garrafas.Add(new Garrafa
+            {
+                Codigo = codigo,
+                CapacidadKg = 10,
+                FechaCompra = fechaCompra,
+                EstadoGarrafaId = llenaDepositoId,
+                ClienteId = null,
+                Activo = true,
+                CreatedAt = now,
+                UpdatedAt = now,
+            });
+        }
+
+        string codigoDevolucion = "";
+        if (incluirDevolucion)
+        {
+            codigoDevolucion = "G-DEVUELTA-001";
+            ctx.Garrafas.Add(new Garrafa
+            {
+                Codigo = codigoDevolucion,
+                CapacidadKg = 10,
+                FechaCompra = fechaCompra,
+                EstadoGarrafaId = enClienteId,
+                ClienteId = cliente.Id,
+                Activo = true,
+                CreatedAt = now,
+                UpdatedAt = now,
+            });
+        }
+
+        await ctx.SaveChangesAsync();
+
+        return new CanjeSeed(
+            PedidoId: pedido.Id,
+            ClienteId: cliente.Id,
+            ItemEntregaId: itemEntrega.Id,
+            ItemDevolucionId: itemDevolucionId,
+            CodigosEntrega: codigosEntrega,
+            CodigoDevolucion: codigoDevolucion);
+    }
+
+    private sealed record CanjeSeed(
+        ulong PedidoId,
+        ulong ClienteId,
+        ulong ItemEntregaId,
+        ulong ItemDevolucionId,
+        List<string> CodigosEntrega,
+        string CodigoDevolucion);
+}
+
+/// <summary>
+/// Fixture xUnit que arranca un container MySQL via Testcontainers y provee
+/// un método para crear bases frescas con el schema mínimo del módulo
+/// Pedidos + Garrafas (lo necesario para
+/// <see cref="PedidoService.RegistrarCanjePedidoAsync"/>).
+///
+/// Réplica del patrón de <see cref="ClienteMySqlFixture"/>. Se comparte entre
+/// los tests de <see cref="PedidoCanjeIntegrationTests"/> via IClassFixture
+/// — los containers tardan segundos en arrancar, no vale la pena pagar ese
+/// costo por test.
+///
+/// Requiere Docker daemon accesible. Si el CI no tiene Docker, los tests se
+/// pueden saltar con un filtro de xUnit a nivel de pipeline
+/// (ej. <c>dotnet test --filter "FullyQualifiedName!~IntegrationTests"</c>).
+/// </summary>
+public class PedidoCanjeMySqlFixture : IAsyncLifetime
+{
+    private const string MysqlImage = "mysql:8.0";
+    private const string RootPassword = "test_root_pwd";
+    private const string RootUsername = "root";
+    // MySQL limita identificadores a 64 chars. Prefix corto + Guid.NewGuid().ToString("N")
+    // (32 chars hex) = 2 + 32 = 34 chars, lejos del límite.
+    private const string DatabasePrefix = "pc_";
+
+    private MySqlContainer? _container;
+    private string? _rootConnectionString;
+
+    public async Task InitializeAsync()
+    {
+        _container = new MySqlBuilder()
+            .WithImage(MysqlImage)
+            .WithUsername(RootUsername)
+            .WithPassword(RootPassword)
+            .WithDatabase("placeholder_db")
+            .Build();
+        await _container.StartAsync();
+        _rootConnectionString = _container.GetConnectionString();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_container is not null)
+            await _container.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Crea una base nueva con nombre único (prefix + GUID) y aplica el
+    /// schema mínimo necesario para que
+    /// <see cref="PedidoService.RegistrarCanjePedidoAsync"/> funcione contra
+    /// MySQL real: clientes + empleados + lookup tables + pedidos con
+    /// transacción + trigger <c>trg_mov_garrafa_ai</c> que mantiene
+    /// <c>garrafas.estado_garrafa_id</c> sincronizado con los INSERTs en
+    /// <c>movimientos_garrafa</c>.
+    /// </summary>
+    public async Task<ExtraGasDbContext> NewDbContextAsync(string testName)
+    {
+        _ = testName; // reservado para logging futuro; el nombre es GUID.
+        var dbName = DatabasePrefix + Guid.NewGuid().ToString("N");
+
+        // 1) Crear la base vía root connection.
+        await using (var conn = new MySqlConnection(_rootConnectionString))
+        {
+            await conn.OpenAsync();
+            await using var create = conn.CreateCommand();
+            create.CommandText = $"CREATE DATABASE `{dbName}` " +
+                                 "CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;";
+            await create.ExecuteNonQueryAsync();
+        }
+
+        // 2) Conectar a la nueva base y aplicar el schema mínimo.
+        var connString = _rootConnectionString!
+            .Replace("database=placeholder_db", $"database={dbName}", StringComparison.OrdinalIgnoreCase);
+
+        await using (var conn = new MySqlConnection(connString))
+        {
+            await conn.OpenAsync();
+            await using var schema = conn.CreateCommand();
+            schema.CommandText = PedidoCanjeSchemaMinimal;
+            await schema.ExecuteNonQueryAsync();
+        }
+
+        // 3) Armar DbContext con Pomelo contra esa base.
+        var serverVersion = ServerVersion.Create(new Version(8, 0, 0), Pomelo.EntityFrameworkCore.MySql.Infrastructure.ServerType.MySql);
+        var options = new DbContextOptionsBuilder<ExtraGasDbContext>()
+            .UseMySql(connString, serverVersion)
+            .Options;
+        return new ExtraGasDbContext(options);
+    }
+
+    /// <summary>
+    /// Schema mínimo para que <see cref="PedidoService.RegistrarCanjePedidoAsync"/>
+    /// funcione contra MySQL real. Incluye solo las tablas + FKs + el trigger
+    /// <c>trg_mov_garrafa_ai</c> que el flujo ejercita (PR #137). Reproduce
+    /// los DDL relevantes de las migraciones 20260102_000001 / 20260102_000004 /
+    /// 20260102_000006 / 20260102_000007.
+    /// </summary>
+    private const string PedidoCanjeSchemaMinimal = """
+        -- Lookups
+        CREATE TABLE tipos_producto (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            codigo VARCHAR(30) NOT NULL,
+            nombre VARCHAR(100) NOT NULL,
+            descripcion VARCHAR(255) NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            UNIQUE KEY uq_tipos_producto_codigo (codigo)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+        CREATE TABLE estados_pedido (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            codigo VARCHAR(30) NOT NULL,
+            nombre VARCHAR(100) NOT NULL,
+            descripcion VARCHAR(255) NULL,
+            es_final BOOLEAN NOT NULL DEFAULT FALSE,
+            color VARCHAR(7) NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            UNIQUE KEY uq_estados_pedido_codigo (codigo)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+        CREATE TABLE canales_venta (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            codigo VARCHAR(30) NOT NULL,
+            nombre VARCHAR(100) NOT NULL,
+            descripcion VARCHAR(255) NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            UNIQUE KEY uq_canales_venta_codigo (codigo)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+        CREATE TABLE estados_garrafa (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            codigo VARCHAR(30) NOT NULL,
+            nombre VARCHAR(100) NOT NULL,
+            descripcion VARCHAR(255) NULL,
+            es_disponible_para_venta BOOLEAN NOT NULL DEFAULT FALSE,
+            requiere_cliente BOOLEAN NOT NULL DEFAULT FALSE,
+            color VARCHAR(7) NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            UNIQUE KEY uq_estados_garrafa_codigo (codigo)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+        CREATE TABLE tipos_movimiento_garrafa (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            codigo VARCHAR(30) NOT NULL,
+            nombre VARCHAR(100) NOT NULL,
+            descripcion VARCHAR(255) NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            UNIQUE KEY uq_tipos_movimiento_garrafa_codigo (codigo)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+        -- Personas
+        CREATE TABLE empleados (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            nombre VARCHAR(100) NOT NULL,
+            apellido VARCHAR(100) NOT NULL,
+            dni VARCHAR(15) NULL,
+            cuil VARCHAR(15) NULL,
+            telefono VARCHAR(25) NULL,
+            email VARCHAR(150) NULL,
+            calle VARCHAR(150) NULL,
+            numero VARCHAR(10) NULL,
+            piso VARCHAR(10) NULL,
+            depto VARCHAR(10) NULL,
+            ciudad VARCHAR(100) NULL,
+            codigo_postal VARCHAR(10) NULL,
+            provincia_id BIGINT UNSIGNED NULL,
+            fecha_ingreso DATE NULL,
+            fecha_egreso DATE NULL,
+            usuario_id BIGINT UNSIGNED NULL,
+            activo BOOLEAN NOT NULL DEFAULT TRUE,
+            observaciones TEXT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            created_by BIGINT UNSIGNED NULL,
+            updated_by BIGINT UNSIGNED NULL,
+            deleted_at DATETIME NULL,
+            KEY idx_empleados_deleted_at (deleted_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+        CREATE TABLE clientes (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            codigo VARCHAR(20) NULL,
+            nombre VARCHAR(100) NOT NULL,
+            apellido VARCHAR(100) NOT NULL,
+            dni VARCHAR(15) NULL,
+            cuit_cuil VARCHAR(15) NULL,
+            telefono_principal VARCHAR(25) NOT NULL,
+            telefono_secundario VARCHAR(25) NULL,
+            email VARCHAR(150) NULL,
+            calle VARCHAR(150) NULL,
+            numero VARCHAR(10) NULL,
+            piso VARCHAR(10) NULL,
+            depto VARCHAR(10) NULL,
+            ciudad VARCHAR(100) NULL,
+            codigo_postal VARCHAR(10) NULL,
+            provincia_id BIGINT UNSIGNED NULL,
+            referencias TEXT NULL,
+            observaciones TEXT NULL,
+            fecha_alta DATE NOT NULL,
+            activo BOOLEAN NOT NULL DEFAULT 1,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            created_by BIGINT UNSIGNED NULL,
+            updated_by BIGINT UNSIGNED NULL,
+            deleted_at DATETIME NULL,
+            dni_unique VARCHAR(15) GENERATED ALWAYS AS (
+                CASE WHEN deleted_at IS NULL THEN dni ELSE NULL END
+            ) VIRTUAL,
+            UNIQUE KEY idx_clientes_dni_unique (dni_unique),
+            KEY idx_clientes_deleted_at (deleted_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+        -- Productos
+        CREATE TABLE productos (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            codigo VARCHAR(30) NOT NULL,
+            nombre VARCHAR(150) NOT NULL,
+            descripcion VARCHAR(255) NULL,
+            tipo_producto_id BIGINT UNSIGNED NOT NULL,
+            capacidad_kg DECIMAL(8,2) NULL,
+            unidad_venta VARCHAR(20) NOT NULL DEFAULT 'UNIDAD',
+            precio_actual DECIMAL(12,2) NOT NULL DEFAULT 0,
+            maneja_garrafa_individual TINYINT(1) NOT NULL DEFAULT 0,
+            activo TINYINT(1) NOT NULL DEFAULT 1,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            created_by BIGINT UNSIGNED NULL,
+            updated_by BIGINT UNSIGNED NULL,
+            deleted_at DATETIME NULL,
+            CONSTRAINT fk_productos_tipo FOREIGN KEY (tipo_producto_id) REFERENCES tipos_producto(id),
+            UNIQUE KEY uq_productos_codigo (codigo),
+            KEY idx_productos_deleted_at (deleted_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+        -- Pedidos
+        CREATE TABLE pedidos (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            numero VARCHAR(20) NULL,
+            fecha DATETIME NOT NULL,
+            fecha_entrega DATETIME NULL,
+            entregado BOOLEAN NOT NULL DEFAULT FALSE,
+            cliente_id BIGINT UNSIGNED NOT NULL,
+            empleado_id BIGINT UNSIGNED NOT NULL,
+            estado_pedido_id BIGINT UNSIGNED NOT NULL,
+            canal_venta_id BIGINT UNSIGNED NOT NULL,
+            medio_contacto_id BIGINT UNSIGNED NULL,
+            subtotal DECIMAL(12,2) NOT NULL DEFAULT 0,
+            descuento DECIMAL(12,2) NOT NULL DEFAULT 0,
+            total DECIMAL(12,2) NOT NULL DEFAULT 0,
+            monto_pagado DECIMAL(12,2) NOT NULL DEFAULT 0,
+            saldo DECIMAL(12,2) GENERATED ALWAYS AS (total - monto_pagado) STORED,
+            observaciones TEXT NULL,
+            motivo_cancelacion VARCHAR(500) NULL,
+            direccion_entrega VARCHAR(255) NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            created_by BIGINT UNSIGNED NULL,
+            updated_by BIGINT UNSIGNED NULL,
+            deleted_at DATETIME NULL,
+            CONSTRAINT fk_pedidos_cliente FOREIGN KEY (cliente_id) REFERENCES clientes(id),
+            CONSTRAINT fk_pedidos_empleado FOREIGN KEY (empleado_id) REFERENCES empleados(id),
+            CONSTRAINT fk_pedidos_estado FOREIGN KEY (estado_pedido_id) REFERENCES estados_pedido(id),
+            CONSTRAINT fk_pedidos_canal FOREIGN KEY (canal_venta_id) REFERENCES canales_venta(id),
+            CONSTRAINT chk_pedidos_total CHECK (total >= 0),
+            CONSTRAINT chk_pedidos_monto_pagado CHECK (monto_pagado >= 0),
+            UNIQUE KEY idx_pedidos_numero (numero),
+            KEY idx_pedidos_cliente (cliente_id, fecha),
+            KEY idx_pedidos_estado (estado_pedido_id),
+            KEY idx_pedidos_deleted_at (deleted_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+        CREATE TABLE pedido_items (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            pedido_id BIGINT UNSIGNED NOT NULL,
+            producto_id BIGINT UNSIGNED NOT NULL,
+            tipo_linea ENUM('ENTREGA','DEVOLUCION','VENTA') NOT NULL DEFAULT 'VENTA',
+            cantidad DECIMAL(10,2) NOT NULL,
+            precio_unitario DECIMAL(12,2) NOT NULL,
+            subtotal DECIMAL(12,2) GENERATED ALWAYS AS (cantidad * precio_unitario) STORED,
+            observaciones VARCHAR(255) NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            CONSTRAINT fk_pedido_items_pedido FOREIGN KEY (pedido_id) REFERENCES pedidos(id) ON DELETE CASCADE,
+            CONSTRAINT fk_pedido_items_producto FOREIGN KEY (producto_id) REFERENCES productos(id),
+            CONSTRAINT chk_pedido_items_cantidad CHECK (cantidad > 0),
+            CONSTRAINT chk_pedido_items_precio CHECK (precio_unitario >= 0),
+            KEY idx_pedido_items_pedido (pedido_id),
+            KEY idx_pedido_items_producto (producto_id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+        -- Garrafas y movimientos
+        CREATE TABLE garrafas (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            codigo VARCHAR(50) NOT NULL,
+            capacidad_kg TINYINT UNSIGNED NOT NULL,
+            proveedor_id BIGINT UNSIGNED NULL,
+            recepcion_id BIGINT UNSIGNED NULL,
+            fecha_compra DATE NOT NULL,
+            estado_garrafa_id BIGINT UNSIGNED NOT NULL,
+            cliente_id BIGINT UNSIGNED NULL,
+            activo BOOLEAN NOT NULL DEFAULT TRUE,
+            fecha_ultimo_movimiento DATETIME NULL,
+            observaciones TEXT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            created_by BIGINT UNSIGNED NULL,
+            updated_by BIGINT UNSIGNED NULL,
+            deleted_at DATETIME NULL,
+            CONSTRAINT uq_garrafas_codigo UNIQUE (codigo),
+            CONSTRAINT chk_garrafas_capacidad CHECK (capacidad_kg IN (10, 15, 45)),
+            CONSTRAINT fk_garrafas_estado FOREIGN KEY (estado_garrafa_id) REFERENCES estados_garrafa(id),
+            CONSTRAINT fk_garrafas_cliente FOREIGN KEY (cliente_id) REFERENCES clientes(id),
+            KEY idx_garrafas_estado (estado_garrafa_id),
+            KEY idx_garrafas_cliente (cliente_id),
+            KEY idx_garrafas_deleted_at (deleted_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        -- (created_by/updated_by ya incluidos arriba)
+
+        CREATE TABLE movimientos_garrafa (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            garrafa_id BIGINT UNSIGNED NOT NULL,
+            fecha DATETIME NOT NULL,
+            tipo_movimiento_id BIGINT UNSIGNED NOT NULL,
+            pedido_id BIGINT UNSIGNED NULL,
+            recepcion_id BIGINT UNSIGNED NULL,
+            cliente_id BIGINT UNSIGNED NULL,
+            estado_origen_id BIGINT UNSIGNED NULL,
+            estado_destino_id BIGINT UNSIGNED NOT NULL,
+            empleado_id BIGINT UNSIGNED NULL,
+            observaciones VARCHAR(255) NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            created_by BIGINT UNSIGNED NULL,
+            CONSTRAINT fk_mov_garrafa_garrafa FOREIGN KEY (garrafa_id) REFERENCES garrafas(id),
+            CONSTRAINT fk_mov_garrafa_tipo FOREIGN KEY (tipo_movimiento_id) REFERENCES tipos_movimiento_garrafa(id),
+            CONSTRAINT fk_mov_garrafa_pedido FOREIGN KEY (pedido_id) REFERENCES pedidos(id),
+            CONSTRAINT fk_mov_garrafa_cliente FOREIGN KEY (cliente_id) REFERENCES clientes(id),
+            CONSTRAINT fk_mov_garrafa_estado_origen FOREIGN KEY (estado_origen_id) REFERENCES estados_garrafa(id),
+            CONSTRAINT fk_mov_garrafa_estado_destino FOREIGN KEY (estado_destino_id) REFERENCES estados_garrafa(id),
+            KEY idx_mov_garrafa_pedido (pedido_id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+        -- Catálogo sembrado (idempotente gracias a INSERT IGNORE).
+        INSERT IGNORE INTO tipos_producto (codigo, nombre) VALUES ('GAS', 'Gas');
+        INSERT IGNORE INTO estados_pedido (codigo, nombre, es_final) VALUES
+            ('PENDIENTE', 'Pendiente', FALSE),
+            ('CONFIRMADO', 'Confirmado', FALSE),
+            ('EN_PREPARACION', 'En preparación', FALSE),
+            ('ENTREGADO', 'Entregado', TRUE),
+            ('CANCELADO', 'Cancelado', TRUE);
+        INSERT IGNORE INTO canales_venta (codigo, nombre) VALUES ('PRESENCIAL', 'Presencial');
+        INSERT IGNORE INTO estados_garrafa (codigo, nombre, es_disponible_para_venta, requiere_cliente) VALUES
+            ('LLENA_DEPOSITO', 'Llena en depósito', TRUE, FALSE),
+            ('VACIA_DEPOSITO', 'Vacía en depósito', FALSE, FALSE),
+            ('EN_CLIENTE', 'En cliente', FALSE, TRUE),
+            ('EN_TRANSITO', 'En tránsito', FALSE, FALSE),
+            ('DAÑADA', 'Dañada', FALSE, FALSE),
+            ('FUERA_SERVICIO', 'Fuera de servicio', FALSE, FALSE);
+        INSERT IGNORE INTO tipos_movimiento_garrafa (codigo, nombre) VALUES
+            ('ENTREGA_CLIENTE', 'Entrega a cliente'),
+            ('DEVOLUCION_CLIENTE', 'Devolución de cliente');
+
+        -- Trigger crítico: actualiza garrafas.estado_garrafa_id cuando se
+        -- inserta un movimiento. Sin este trigger GarrafaService no podría
+        -- mover garrafas por canje (solo lo hace vía INSERT en
+        -- movimientos_garrafa). Réplica del trigger trg_mov_garrafa_ai de
+        -- la migración 20260102_000007.
+        DROP TRIGGER IF EXISTS trg_mov_garrafa_ai;
+        CREATE TRIGGER trg_mov_garrafa_ai
+        AFTER INSERT ON movimientos_garrafa
+        FOR EACH ROW
+        UPDATE garrafas
+        SET fecha_ultimo_movimiento = NEW.fecha,
+            estado_garrafa_id = NEW.estado_destino_id
+        WHERE id = NEW.garrafa_id;
+        """;
+}

--- a/tests/ExtraGasMVC.Tests/PedidosControllerCommandTests.cs
+++ b/tests/ExtraGasMVC.Tests/PedidosControllerCommandTests.cs
@@ -117,6 +117,135 @@ public class PedidosControllerCommandTests
     }
 
     [Fact]
+    public async Task CambiarEstado_DestinoConfirmadoConCodigos_DelegaEnRegistrarCanjePedidoAsync_TempDataSuccess()
+    {
+        // Branch canje de CambiarEstado POST: destino CONFIRMADO + JSON de
+        // códigos → llama RegistrarCanjePedidoAsync. Si devuelve true,
+        // TempData[Success] con el mensaje canónico y redirect a Details.
+        var fake = new ConfigurablePedidoService
+        {
+            GetEstadosPedidoScenario = ConfigurablePedidoService.GetEstadosScenario.WithConfirmado,
+            RegistrarCanjeScenario = ConfigurablePedidoService.Scenario.ReturnsTrue,
+        };
+        var controller = NewController(fake);
+
+        var result = await controller.CambiarEstado(
+            id: 1, nuevoEstadoId: 2, motivoCancelacion: null,
+            codigosGarrafaJson: "{\"1\":[\"G-001\"]}", ct: default);
+
+        result.Should().BeOfType<RedirectToActionResult>().Subject
+            .ActionName.Should().Be(nameof(PedidosController.Details));
+
+        var tempData = SaveAndReadTempData(controller);
+        tempData.Should().ContainKey(TempDataKeys.Success);
+        tempData[TempDataKeys.Success].Should().Be(
+            "Pedido confirmado y garrafas registradas correctamente.");
+        tempData.Should().NotContainKey(TempDataKeys.Error);
+        fake.RegistrarCanjeLlamadas.Should().Be(1);
+        fake.RegistrarCanjeUltimoPedidoId.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CambiarEstado_DestinoConfirmadoConCodigosJsonInvalido_TempDataErrorMensajeCanonico()
+    {
+        // El Controller delega JSON deserialization al branch canje. Si el
+        // JSON está malformado, no llega a llamar al service y TempData[Error]
+        // tiene el mensaje canónico (sin pasar por el catch genérico).
+        var fake = new ConfigurablePedidoService
+        {
+            GetEstadosPedidoScenario = ConfigurablePedidoService.GetEstadosScenario.WithConfirmado,
+            RegistrarCanjeScenario = ConfigurablePedidoService.Scenario.ReturnsTrue,
+        };
+        var controller = NewController(fake);
+
+        var result = await controller.CambiarEstado(
+            id: 1, nuevoEstadoId: 2, motivoCancelacion: null,
+            codigosGarrafaJson: "{esto no es JSON válido", ct: default);
+
+        result.Should().BeOfType<RedirectToActionResult>().Subject
+            .ActionName.Should().Be(nameof(PedidosController.Edit));
+
+        var tempData = SaveAndReadTempData(controller);
+        tempData.Should().ContainKey(TempDataKeys.Error);
+        tempData[TempDataKeys.Error].Should().Be(
+            "Los códigos de garrafas enviados tienen un formato inválido. Recargue la pantalla e intente nuevamente.");
+        // El service NO se llamó — la deserialización falla antes.
+        fake.RegistrarCanjeLlamadas.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CambiarEstado_DestinoConfirmadoConCodigos_ServiceDevuelveFalse_TempDataErrorPedidoNotFound()
+    {
+        // Service devuelve false (pedido no existe) → TempData[Error] con
+        // PedidoNotFoundMessage y redirect a Edit (no a Details).
+        var fake = new ConfigurablePedidoService
+        {
+            GetEstadosPedidoScenario = ConfigurablePedidoService.GetEstadosScenario.WithConfirmado,
+            RegistrarCanjeScenario = ConfigurablePedidoService.Scenario.ReturnsFalse,
+        };
+        var controller = NewController(fake);
+
+        var result = await controller.CambiarEstado(
+            id: 999999, nuevoEstadoId: 2, motivoCancelacion: null,
+            codigosGarrafaJson: "{\"1\":[\"G-001\"]}", ct: default);
+
+        result.Should().BeOfType<RedirectToActionResult>().Subject
+            .ActionName.Should().Be(nameof(PedidosController.Edit));
+
+        var tempData = SaveAndReadTempData(controller);
+        tempData.Should().ContainKey(TempDataKeys.Error);
+        tempData[TempDataKeys.Error].Should().Be(TempDataKeys.PedidoNotFoundMessage);
+        tempData.Should().NotContainKey(TempDataKeys.Success);
+    }
+
+    [Fact]
+    public async Task CambiarEstado_DestinoConfirmadoConCodigos_ServiceLanzaInvalidOperationException_TempDataErrorConElMensaje()
+    {
+        // El service lanza InvalidOperationException (código inexistente,
+        // ya CONFIRMADO, etc.) → TempData[Error] con el mensaje del service.
+        var fake = new ConfigurablePedidoService
+        {
+            GetEstadosPedidoScenario = ConfigurablePedidoService.GetEstadosScenario.WithConfirmado,
+            RegistrarCanjeScenario = ConfigurablePedidoService.Scenario.ThrowsInvalidOp,
+            InvalidOpMessage = "El código 'G-X' no existe en el inventario de garrafas.",
+        };
+        var controller = NewController(fake);
+
+        var result = await controller.CambiarEstado(
+            id: 1, nuevoEstadoId: 2, motivoCancelacion: null,
+            codigosGarrafaJson: "{\"1\":[\"G-X\"]}", ct: default);
+
+        result.Should().BeOfType<RedirectToActionResult>().Subject
+            .ActionName.Should().Be(nameof(PedidosController.Edit));
+
+        var tempData = SaveAndReadTempData(controller);
+        tempData[TempDataKeys.Error].Should().Be(
+            "El código 'G-X' no existe en el inventario de garrafas.");
+    }
+
+    [Fact]
+    public async Task CambiarEstado_DestinoConfirmadoSinCodigos_CaeAlBranchGenerico()
+    {
+        // codigosGarrafaJson null + destino CONFIRMADO → cae al branch
+        // genérico (CambiarEstadoAsync), NO al de canje. Esto cubre el caso
+        // degenerado de un pedido solo VENTA / carbón / leña.
+        var fake = new ConfigurablePedidoService
+        {
+            GetEstadosPedidoScenario = ConfigurablePedidoService.GetEstadosScenario.WithConfirmado,
+            CambiarEstadoScenario = ConfigurablePedidoService.Scenario.ReturnsTrue,
+        };
+        var controller = NewController(fake);
+
+        var result = await controller.CambiarEstado(
+            id: 1, nuevoEstadoId: 2, motivoCancelacion: null,
+            codigosGarrafaJson: null, ct: default);
+
+        result.Should().BeOfType<RedirectToActionResult>();
+        fake.RegistrarCanjeLlamadas.Should().Be(0, "sin códigos no delega en canje");
+        fake.CambiarEstadoLlamadas.Should().Be(1);
+    }
+
+    [Fact]
     public async Task AddItem_Exitoso_TempDataSuccess()
     {
         var fake = new ConfigurablePedidoService();
@@ -211,7 +340,7 @@ public class PedidosControllerCommandTests
 
     /// <summary>
     /// Fake configurable por escenario. Solo implementa los métodos que los
-    /// tests de PR #137 ejercitan; el resto lanza NotImplementedException.
+    /// tests de PR #137 y #138 ejercitan; el resto lanza NotImplementedException.
     /// </summary>
     private sealed class ConfigurablePedidoService : IPedidoService
     {
@@ -224,14 +353,28 @@ public class PedidosControllerCommandTests
             ThrowsGeneric,
         }
 
+        public enum GetEstadosScenario
+        {
+            Empty,
+            WithConfirmado,
+        }
+
         public Scenario CambiarEstadoScenario { get; set; } = Scenario.Success;
         public Scenario DeleteScenario { get; set; } = Scenario.Success;
         public Scenario AddItemScenario { get; set; } = Scenario.Success;
         public Scenario RemoveItemScenario { get; set; } = Scenario.Success;
+        public Scenario RegistrarCanjeScenario { get; set; } = Scenario.Success;
+        public GetEstadosScenario GetEstadosPedidoScenario { get; set; } = GetEstadosScenario.WithConfirmado;
         public string? InvalidOpMessage { get; set; }
+
+        // Contadores/observabilidad para los tests del branch canje.
+        public int RegistrarCanjeLlamadas { get; private set; }
+        public ulong RegistrarCanjeUltimoPedidoId { get; private set; }
+        public int CambiarEstadoLlamadas { get; private set; }
 
         public Task<bool> CambiarEstadoAsync(ulong id, ulong nuevoEstadoId, string? motivoCancelacion, ulong? usuarioId, CancellationToken ct = default)
         {
+            CambiarEstadoLlamadas++;
             return CambiarEstadoScenario switch
             {
                 Scenario.ThrowsInvalidOp => throw new InvalidOperationException(InvalidOpMessage ?? "InvalidOp"),
@@ -243,16 +386,34 @@ public class PedidosControllerCommandTests
         }
 
         public Task<List<EstadoPedidoDto>> GetEstadosPedidoAsync(CancellationToken ct = default)
-            => Task.FromResult(new List<EstadoPedidoDto>
+        {
+            if (GetEstadosPedidoScenario == GetEstadosScenario.Empty)
+                return Task.FromResult(new List<EstadoPedidoDto>());
+
+            return Task.FromResult(new List<EstadoPedidoDto>
             {
                 new() { Id = 1, Codigo = "PENDIENTE", Nombre = "Pendiente" },
                 new() { Id = 2, Codigo = "CONFIRMADO", Nombre = "Confirmado" },
             });
+        }
 
         public Task<bool> DeleteAsync(ulong id, ulong? usuarioId, CancellationToken ct = default)
         {
             return DeleteScenario switch
             {
+                Scenario.ReturnsTrue => Task.FromResult(true),
+                Scenario.ReturnsFalse => Task.FromResult(false),
+                _ => Task.FromResult(true),
+            };
+        }
+
+        public Task<bool> RegistrarCanjePedidoAsync(ulong pedidoId, Dictionary<ulong, List<string>> codigosPorItem, ulong? usuarioId, CancellationToken ct = default)
+        {
+            RegistrarCanjeLlamadas++;
+            RegistrarCanjeUltimoPedidoId = pedidoId;
+            return RegistrarCanjeScenario switch
+            {
+                Scenario.ThrowsInvalidOp => throw new InvalidOperationException(InvalidOpMessage ?? "InvalidOp"),
                 Scenario.ReturnsTrue => Task.FromResult(true),
                 Scenario.ReturnsFalse => Task.FromResult(false),
                 _ => Task.FromResult(true),
@@ -291,7 +452,6 @@ public class PedidosControllerCommandTests
         public Task<List<CanalVentaDto>> GetCanalesVentaAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<MedioContactoPedidoDto>> GetMediosContactoAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task<IEnumerable<EmpleadoDto>> GetEmpleadosActivosAsync(CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<bool> RegistrarCanjePedidoAsync(ulong pedidoId, Dictionary<ulong, List<string>> codigosPorItem, ulong? usuarioId, CancellationToken ct = default) => throw new NotImplementedException();
     }
 
     private sealed class NotImplementedClienteService : IClienteService


### PR DESCRIPTION
## Resumen

Issue #138: PR #137 cerró las 19 issues SonarQube en new code pero quedó en `new_coverage: 44%` (threshold 80%) porque el flujo de canje (`PedidoService.RegistrarCanjePedidoAsync` + el branch canje de `PedidosController.CambiarEstado`) no tenía tests. Esta PR cierra ese gap end-to-end.

Recomendación #1+2 del issue (escribir los tests ahora + dejar el gate como está, sin bajar el threshold).

## Cambios

### 1. `tests/ExtraGasMVC.Tests/PedidoCanjeIntegrationTests.cs` (nuevo, 9 tests)

Réplica del patrón `ClienteIntegrationTests` (`Testcontainers.MySql` + `IClassFixture` compartido). Schema mínimo del módulo pedidos+garrafas con el trigger `trg_mov_garrafa_ai` para mantener `garrafas.estado_garrafa_id` sincronizado con cada `INSERT` en `movimientos_garrafa`.

Tests que cubren todos los helpers privados del flujo:

- **`HappyPath_EntregaYDevolucion`**: 9 helpers privados en cadena — `LoadPedidoParaCanjeAsync`, `AsegurarNoCanjeadoAsync`, `LoadCatalogosParaCanjeAsync`, `LoadItemsParaCanjeAsync`, `ValidarItemsSonGarrafaCanjeable`, `NormalizarYValidarCodigos`, `ValidarCodigosContraInventarioAsync`, `AplicarCanjeYConfirmarAsync`, `AplicarCanjeDeItemAsync` — más la transacción atómica y el trigger `trg_mov_garrafa_ai`.
- **`SoloEntrega_SinDevolucion`**: rama con un único item ENTREGA.
- **`DosVecesSobreElMismoPedido`**: idempotencia vía estado CONFIRMADO.
- **`PedidoConMovimientosPrevios`**: idempotencia vía `AsegurarNoCanjeadoAsync`.
- **`TipoMovimientoFaltante`**: catálogo incompleto → rollback.
- **`ItemNoGarrafaCanjeable`**: item VENTA rechazado por `ValidarItemsSonGarrafaCanjeable`.
- **`CantidadCodigosNoCoincideConItem`**: `NormalizarYValidarCodigos`.
- **`GarrafaNoPerteneceAlCliente`**: `ValidarCodigosContraInventarioAsync` (DEVOLUCION ajena).
- **`CodigoInexistente`**: `ValidarCodigosContraInventarioAsync` (código inexistente).

### 2. `PedidosControllerCommandTests.cs` (+5 tests, +166 líneas)

Branch canje de `PedidosController.CambiarEstado` (`ConfirmarConCanjeAsync`):

- **`DestinoConfirmadoConCodigos_DelegaEnRegistrarCanjePedidoAsync_TempDataSuccess`**: happy path, redirect a `Details`, `TempData[Success]` canónico.
- **`DestinoConfirmadoConCodigosJsonInvalido_TempDataErrorMensajeCanonico`**: `System.Text.Json.JsonException` → mensaje fijo del controller, service **no** se llama.
- **`DestinoConfirmadoConCodigos_ServiceDevuelveFalse_TempDataErrorPedidoNotFound`**: redirect a `Edit`, `TempData[Error]` = `PedidoNotFoundMessage`.
- **`DestinoConfirmadoConCodigos_ServiceLanzaInvalidOperationException_TempDataErrorConElMensaje`**: `InvalidOp` se mapea al `ex.Message`.
- **`DestinoConfirmadoSinCodigos_CaeAlBranchGenerico`**: `codigosGarrafaJson = null` no delega en canje → cae al `CambiarEstadoGenericoAsync`.

### 3. Fix `GarrafaConfiguration.cs` (2 líneas)

`HasOne<Cliente>()` / `HasOne<Proveedor>()` con `HasForeignKey(g => g.ClienteId)` / `(g => g.ProveedorId)` generaba shadow FKs `ClienteId1` / `ProveedorId1` en el modelo de EF, rompiendo todos los INSERT/UPDATE/SELECT sobre `garrafas` contra MySQL real (el SQL emitido incluía columnas que no existen en la tabla). Migrado a la forma `HasOne(g => g.Nav)` consistente con `PedidoConfiguration` y el resto de las entities.

Sin este fix los integration tests no podían ejercitar `RegistrarMovimientoPorCanjeAsync` ni ningún write path de `GarrafaService`. Afecta también silenciosamente a `GarrafaService.CreateAsync` y al path de creación de garrafas de `RecepcionService` (que estaban rotos contra MySQL real, sin cobertura que lo expusiera — ahora hay cobertura, así que el fix blinda ambos caminos).

## Validación local

- `dotnet build`: OK.
- `dotnet test --filter "PedidoCanjeIntegrationTests"`: 9/9 OK.
- `dotnet test --filter "PedidosControllerCommandTests"`: 12/12 OK.
- `dotnet test` (suite completa): **278/278 OK, 0 regresiones** (264 previos + 14 nuevos).
- `dotnet test --collect:"XPlat Code Coverage"`: cobertura total del proyecto **37.7% → 40.6%**. El `new_coverage` exacto del PR se medirá en el scanner de SonarQube (`./scripts/sonar-analyze.sh`) — la expectativa del issue era ~55-60%.

## Trade-offs explícitos

- No bajo el threshold del Quality Gate (issue #138 listaba esa como opción 3). El gate sigue en `new_coverage >= 80%`. Si el scanner sigue en ERROR por cobertura, queda como follow-up seguir cubriendo `GarrafaService.CreateAsync` y `RecepcionService` con tests análogos (este PR ya fija el bug que impedía esos tests).
- El integration test requiere Docker daemon. Si el CI no tiene Docker, se puede saltar con `dotnet test --filter "FullyQualifiedName!~IntegrationTests"`. Misma condición que `ClienteIntegrationTests`.

## Checklist del issue #138

- [x] Confirmar si se ejecuta opción 1+2 (tests) o 3 (bajar threshold). → 1+2.
- [x] Tests escritos.
- [x] Threshold sin tocar (queda como `>= 80%`).

Closes #138

🤖 Generated with [Gentle AI](https://github.com/elflacoseba/gentle-ai)