### PR TITLE
refactor(clientes): eliminar flag Activo derivado de DeletedAt (#115)

### DIFF
--- a/db/docs/DECISIONES.md
+++ b/db/docs/DECISIONES.md
@@ -309,6 +309,33 @@ Documento de decisiones (ADR-style) y supuestos del sistema **ExtraGas**.
 
 ---
 
+## 17. Eliminar `clientes.activo` (un solo flag: `deleted_at`)
+
+**Contexto:** la tabla `clientes` tenía dos flags que representaban el mismo estado: `activo TINYINT(1) NOT NULL DEFAULT TRUE` y `deleted_at DATETIME NULL`. `DeleteAsync` y `RestoreAsync` escribían ambos (`DeletedAt = NOW()` + `Activo = false` / `Activo = true`), `UpdateAsync` defendía vía `ClienteEditRules` para que un form no los desincronizara, y la UI los leía para mostrar el badge "Activo/Inactivo". Tener dos columnas representando lo mismo era una bomba de tiempo: cualquier futuro INSERT/UPDATE manual sobre la tabla (seed, fix de datos, script de QA) podía dejarlas en estados zombie (`Activo=false` con `DeletedAt=null`, o viceversa) que el QueryFilter global no detectaba. Issue #115.
+
+**Decisión:** eliminar la columna `clientes.activo`. El estado operativo se deriva de `deleted_at IS NULL` en:
+
+- **Entity EF**: `Cliente` ya no tiene la propiedad `Activo`; `ClienteConfiguration` no la mapea.
+- **DTO**: `ClienteDto.Activo` es un getter-only calculado (`=> DeletedAt == null`). AutoMapper lo ignora por convención (sin setter → no se mapea). Las vistas (`Index`, `Details`, `Edit`) leen `c.DeletedAt == null` directamente, igual que el resto del sistema.
+- **Service**: `DeleteAsync` setea solo `DeletedAt = NOW()`; `RestoreAsync` solo `DeletedAt = null`. `GetActivosAsync` y `SearchAsync(soloActivos: …)` ya no filtran por `Activo` — el QueryFilter global (`DeletedAt == null`) hace el trabajo. El parámetro `bool soloActivos` se mantiene por compatibilidad de firma pero queda como no-op documentado.
+- **Vistas SQL**: ninguna vista referenciaba `clientes.activo` (solo `garrafas.activo` se usa en `v_stock_garrafas` y `v_garrafas_en_clientes` — esa columna sigue existiendo, fuera de scope).
+- **Migración**: `20260830_000001_drop_clientes_activo.sql` — `ALTER TABLE clientes DROP COLUMN activo`, idempotente vía guard `information_schema`. No requiere migrar data (la columna es redundante con `deleted_at`).
+
+**Por qué:**
+
+- La Opción A de la issue (mantener la columna pero nunca escribirla desde la app) fue descartada porque deja un pie de bomba: cualquier script futuro que toque `activo` por error reintroduce el bug. La columna debe desaparecer para que sea imposible el estado zombie.
+- El patrón "una sola fuente de verdad" ya rige otras partes del sistema: `monto_pagado` lo mantiene un trigger (ADR #6), `saldo` es columna generada. `deleted_at` ya era la fuente canónica del soft-delete; la columna `activo` era redundante con el QueryFilter global de EF y con las vistas SQL que filtran `WHERE deleted_at IS NULL`.
+- El precio es bajo: una migración aditiva reversible (con `IF EXISTS`-equivalente vía `information_schema`), cambios mecánicos en el Service y dos views Razor. No hay lógica nueva.
+
+**Implicancia:**
+
+- `ClienteDto.Activo` sigue existiendo como getter derivado para no romper consumidores que esperan esa propiedad (vistas, tests de contrato). Si alguien intenta asignarla, no compila — la única forma de cambiar el estado es `DeleteAsync`/`RestoreAsync`.
+- El script de QA `db/scripts/verify_issue_105_clientes_dni_soft_delete.sql` referencia `clientes.activo` en INSERT/UPDATE. Hay que actualizarlo o eliminarlo (es standalone, no se ejecuta en `install.sh`).
+- El patrón "soft-delete como estado operativo único" se valida con este cambio. Si en el futuro aparece otro flag redundante con `deleted_at` (ej. `usuarios.activo` + `usuarios.deleted_at`), replicar el mismo refactor.
+- **IMPORTANTE para deploy**: el código que no escribe `activo` debe deployarse ANTES de aplicar la migración en producción. Si la app vieja intenta persistir `activo` sobre una BD donde la columna ya no existe, falla con `Unknown column 'activo'`. El orden es: merge PR → deploy app → aplicar migración (o el mismo PR si la migración es idempotente, como esta — la columna se droppea si existe y el código ya no la usa).
+
+---
+
 ## Supuestos explícitos (no validados con el usuario)
 
 1. No hay delivery con zonas / tarifas distintas. Un pedido = una dirección.

--- a/db/docs/ERD.mmd
+++ b/db/docs/ERD.mmd
@@ -78,7 +78,7 @@ erDiagram
         varchar codigo_postal
         bigint provincia_id FK
         date fecha_alta
-        boolean activo
+        datetime deleted_at
     }
 
     PROVEEDORES {

--- a/db/migrations/20260830_000001_drop_clientes_activo.sql
+++ b/db/migrations/20260830_000001_drop_clientes_activo.sql
@@ -1,0 +1,35 @@
+-- 20260830_000001_drop_clientes_activo.sql
+-- Elimina la columna `clientes.activo` (flag duplicado de `deleted_at`).
+-- Issue #115: dos fuentes de verdad para el mismo estado eran fuente de bugs.
+-- `activo` se reemplaza por una vista derivada: `activo = deleted_at IS NULL`.
+--
+-- Esta es la Opción B de la issue. La Opción A (dejar la columna pero nunca
+-- escribirla desde la app) fue descartada porque deja un pie de bomba para
+-- futuras migraciones que toquen la columna por error.
+--
+-- Seguridad del DROP:
+--   - La columna ya no se persiste desde la app (tras el merge del código
+--     que acompaña esta migración). Antes de aplicar en producción, hay que
+--     mergear el PR de código y deployar la app que no escribe la columna.
+--   - La columna NO aparece en `pedidos`, ni en vistas SQL (ningún SELECT la
+--     referencia sobre `clientes`; `g.activo` que sí existe pertenece a
+--     `garrafas`, no a `clientes`).
+--   - El comando es idempotente: si la columna ya no existe, el guard
+--     information_schema evita el ALTER y la migración es un no-op.
+
+USE extragas;
+
+-- DROP COLUMN clientes.activo (idempotente: guard en information_schema).
+SET @col_exists = (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE()
+    AND table_name = 'clientes'
+    AND column_name = 'activo'
+);
+SET @sql = IF(@col_exists > 0,
+  'ALTER TABLE clientes DROP COLUMN activo',
+  'SELECT "Column clientes.activo ya no existe, skipping" AS status'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/ExtraGasMVC/Controllers/ClientesController.cs
+++ b/src/ExtraGasMVC/Controllers/ClientesController.cs
@@ -88,11 +88,15 @@ public class ClientesController : BaseController
 
         await LoadViewBagsAsync(ct);
 
-        // Issue #114: UpdateClienteDto ya no expone Activo ni FechaAlta (son
-        // audit trail / estado y solo cambian vía Delete/Restore). Los pasamos
-        // por ViewBag para mostrarlos como info read-only en la vista.
+        // Issue #114 + #115: UpdateClienteDto ya no expone FechaAlta ni Activo
+        // (son audit trail / estado y solo cambian vía Delete/Restore — o
+        // directamente no son editables, derivado de DeletedAt tras #115).
+        // Los pasamos por ViewBag para mostrarlos como info read-only en la vista.
         ViewBag.FechaAlta = cliente.FechaAlta;
-        ViewBag.Activo = cliente.Activo;
+        // Issue #115: la vista lee "Activo" como `DeletedAt == null`. Le
+        // pasamos DeletedAt para que pueda decidir el badge correcto sin
+        // volver a calcular.
+        ViewBag.DeletedAt = cliente.DeletedAt;
 
         var updateDto = _mapper.Map<UpdateClienteDto>(cliente);
         return View(updateDto);

--- a/src/ExtraGasMVC/DTOs/ClienteDto.cs
+++ b/src/ExtraGasMVC/DTOs/ClienteDto.cs
@@ -81,8 +81,11 @@ public class ClienteDtoBase
 /// DTO de salida para <see cref="Data.Entities.Cliente"/>. Incluye los campos
 /// operativos (<c>Activo</c>, <c>FechaAlta</c>) que NO son editables desde
 /// ningún formulario: se exponen solo para display (Details, Index, listados).
-/// Issue #114: <c>Activo</c> solo cambia vía Delete/Restore; <c>FechaAlta</c>
-/// es audit trail del alta y no debe retrocederse.
+/// Issue #114: <c>FechaAlta</c> es audit trail del alta y no debe retrocederse.
+/// <para>Issue #115: <c>Activo</c> es ahora un getter derivado de
+/// <c>DeletedAt == null</c> (no se persiste). Una sola fuente de verdad para
+/// el estado del cliente — coincide con el QueryFilter global de EF y con las
+/// vistas SQL que filtran por <c>deleted_at IS NULL</c>.</para>
 /// <para>Issue #111: <c>DeletedAt</c> se expone para que la pantalla
 /// /Clientes/Papelera muestre la fecha de baja. Es null para clientes
 /// activos (la mayoria del tiempo) y no es editable.</para>
@@ -94,18 +97,26 @@ public class ClienteDto : ClienteDtoBase
     [Display(Name = "Fecha de alta")]
     public DateOnly FechaAlta { get; set; }
 
+    /// <summary>
+    /// Estado operativo derivado: true si el cliente NO está soft-deleted.
+    /// Issue #115: getter-only (sin setter) — AutoMapper lo ignora por
+    /// convención porque no hay forma de asignarlo desde el entity. La
+    /// única fuente de verdad es <see cref="DeletedAt"/>.
+    /// </summary>
     [Display(Name = "Activo")]
-    public bool Activo { get; set; }
+    public bool Activo => DeletedAt == null;
 
     [Display(Name = "Fecha de baja")]
     public DateTime? DeletedAt { get; set; }
 }
 
 /// <summary>
-    /// DTO de alta de cliente. NO incluye <c>Activo</c> (lo setea el Service en
-    /// <c>true</c>) ni <c>FechaAlta</c> (lo setea el Service con la fecha del
-    /// momento del alta). Sin esto el operador podía crear un cliente inactivo
-    /// desde el formulario — un estado operacional incoherente. Issue #114.
+    /// DTO de alta de cliente. NO incluye <c>FechaAlta</c> (lo setea el Service
+    /// con la fecha del momento del alta). <c>Activo</c> ya no existe como
+    /// campo en ningún DTO — el estado se deriva de <c>DeletedAt</c> (Issue
+    /// #115). Sin esto el operador podía crear un cliente con fecha de alta
+    /// retroactiva desde el formulario — un estado operacional incoherente.
+    /// Issue #114.
     /// <para>
     /// Es una subclase vacía a propósito: el Controller usa el tipo concreto
     /// (<see cref="CreateClienteDto"/> vs <see cref="UpdateClienteDto"/>) para
@@ -115,12 +126,11 @@ public class ClienteDto : ClienteDtoBase
     public class CreateClienteDto : ClienteDtoBase { } // NOSONAR S2094: subclase marker para Create vs Edit en el Controller
 
     /// <summary>
-    /// DTO de edición de cliente. NO incluye <c>Activo</c> ni <c>FechaAlta</c>:
-    /// ambos son audit trail / estado y solo cambian vía Delete/Restore
-    /// (<c>Activo</c>) o quedan fijos desde el alta (<c>FechaAlta</c>).
-    /// Editarlos desde el form producía estados zombie
-    /// (<c>Activo=false</c> con <c>DeletedAt=null</c>). El Service los preserva
-    /// vía <c>ClienteEditRules.PreservarFlagsNoEditables</c>. Issue #114.
+    /// DTO de edición de cliente. NO incluye <c>FechaAlta</c> — es audit trail
+    /// del alta y debe quedar fijo. <c>Activo</c> no es un campo editable:
+    /// tras el Issue #115 se deriva de <c>DeletedAt</c> directamente. El
+    /// Service preserva <c>FechaAlta</c> vía
+    /// <c>ClienteEditRules.PreservarFechaAlta</c>. Issue #114.
     /// <para>
     /// <c>Id</c> es <see cref="ulong"/>? (no <see cref="ulong"/>) para que el
     /// model binder rechace un POST sin el campo (S6964 / under-posting):

--- a/src/ExtraGasMVC/Data/Configurations/ClienteConfiguration.cs
+++ b/src/ExtraGasMVC/Data/Configurations/ClienteConfiguration.cs
@@ -64,10 +64,10 @@ public class ClienteConfiguration : IEntityTypeConfiguration<Cliente>
             .HasColumnType("date")
             .IsRequired();
 
-        builder.Property(c => c.Activo)
-            .HasColumnName("activo")
-            .HasColumnType("tinyint(1)")
-            .HasDefaultValue(true);
+        // Issue #115: la columna `activo` se eliminó de `clientes`. El estado
+        // operativo del cliente se deriva de `DeletedAt IS NULL` (ver
+        // ClienteDto.Activo, QueryFilter global y vistas SQL). El EF ya no
+        // modela el flag.
 
         builder.Property(c => c.CreatedAt)
             .HasColumnName("created_at")

--- a/src/ExtraGasMVC/Data/Entities/Cliente.cs
+++ b/src/ExtraGasMVC/Data/Entities/Cliente.cs
@@ -21,7 +21,9 @@ public class Cliente
     public string? Referencias { get; set; }
     public string? Observaciones { get; set; }
     public DateOnly FechaAlta { get; set; }
-    public bool Activo { get; set; }
+    // Issue #115: el flag `activo` se eliminó. El estado operativo del
+    // cliente se deriva de `DeletedAt IS NULL` (visto en ClienteDto.Activo,
+    // en los QueryFilters de EF y en las vistas SQL). Una sola fuente de verdad.
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
     public ulong? CreatedBy { get; set; }

--- a/src/ExtraGasMVC/Extensions/ClienteEditRules.cs
+++ b/src/ExtraGasMVC/Extensions/ClienteEditRules.cs
@@ -4,33 +4,28 @@ namespace ExtraGasMVC.Extensions;
 
 /// <summary>
 /// Reglas de edición de la entidad <see cref="Cliente"/> centralizadas para
-/// poder testear sin DbContext. Aplica la convención "doble flag acoplado"
-/// del módulo clientes — análoga a <see cref="ProveedorEditRules"/> — más la
-/// preservación de <c>FechaAlta</c> como audit trail inmutable del alta.
+/// poder testear sin DbContext. Preserva <c>FechaAlta</c> como audit trail
+/// inmutable del alta.
 ///
 /// <para>Issue #114: corrige el bug de integridad por el cual
-/// <c>ClienteDtoBase.Activo</c> y <c>ClienteDtoBase.FechaAlta</c> eran
-/// editables desde el formulario de Edit, permitiendo estados zombie
-/// (<c>Activo=false</c> con <c>DeletedAt=null</c>) y retroceder la fecha
-/// de alta a una fecha arbitraria.</para>
+/// <c>ClienteDtoBase.FechaAlta</c> era editable desde el formulario de Edit,
+/// permitiendo retroceder la fecha de alta a una fecha arbitraria.</para>
+///
+/// <para>Issue #115: el flag <c>Activo</c> desapareció de la entity y del DTO
+/// (se deriva de <c>DeletedAt == null</c>). Esta clase ya no preserva nada
+/// relacionado con <c>Activo</c> — no hay forma de editarlo desde el form
+/// porque no existe como propiedad escribible.</para>
 /// </summary>
 public static class ClienteEditRules
 {
     /// <summary>
-    /// Restaura los campos del cliente que Edit tiene prohibido modificar.
+    /// Restaura la fecha de alta que Edit tiene prohibido modificar.
     /// Llamar DESPUÉS del AutoMapper, sobre la entity ya mergeada con el DTO.
     /// </summary>
     /// <param name="entity">Entity post-mapper con los valores del form aplicados.</param>
-    /// <param name="activoOriginal">Valor de <c>Activo</c> leído de la BD antes del mapper.</param>
     /// <param name="fechaAltaOriginal">Valor de <c>FechaAlta</c> leído de la BD antes del mapper.</param>
-    public static void PreservarFlagsNoEditables(Cliente entity, bool activoOriginal, DateOnly fechaAltaOriginal)
+    public static void PreservarFechaAlta(Cliente entity, DateOnly fechaAltaOriginal)
     {
-        // REGLA DURA: el flag Activo solo cambia vía Delete/Restore. Si el
-        // operador lo destilda en el form de Edit, la edición silenciosamente
-        // no lo modifica — más amigable que un 400. Para (des)activar un
-        // cliente hay que pasar por las acciones dedicadas.
-        entity.Activo = activoOriginal;
-
         // REGLA DURA: FechaAlta es audit trail del alta. No debe retrocederse
         // ni reescribirse desde el form. Se preserva el valor con el que se
         // dio de alta al cliente.

--- a/src/ExtraGasMVC/Services/Implementations/ClienteService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ClienteService.cs
@@ -58,9 +58,14 @@ public class ClienteService : IClienteService
 
     public async Task<IEnumerable<ClienteDto>> GetActivosAsync(CancellationToken ct = default)
     {
+        // Issue #115: el flag `Activo` se eliminó. El DbSet `Clientes` ya
+        // viene filtrado por el QueryFilter global (`DeletedAt == null`), así
+        // que un `Where(c => c.Activo)` adicional sería redundante. El nombre
+        // del método se conserva por compatibilidad con los callers
+        // (Home/Pagos/Garrafas/Pedidos) — "clientes activos" = "no
+        // soft-deleted".
         var clientes = await _context.Clientes
             .AsNoTracking()
-            .Where(c => c.Activo)
             .OrderBy(c => c.Apellido)
             .ThenBy(c => c.Nombre)
             .ToListAsync(ct);
@@ -76,8 +81,12 @@ public class ClienteService : IClienteService
             .AsNoTracking()
             .AsQueryable();
 
-        if (soloActivos)
-            query = query.Where(c => c.Activo);
+        // Issue #115: el flag `Activo` se eliminó. El QueryFilter global ya
+        // excluye soft-deleted, así que `soloActivos=true` es el estado
+        // natural de la query. Mantenemos el parámetro por compatibilidad
+        // con la firma pública y la query del Index (default true), pero
+        // no se traduce a ningún filtro SQL — es un no-op legacy.
+        _ = soloActivos;
 
         if (!string.IsNullOrWhiteSpace(busqueda))
         {
@@ -127,9 +136,10 @@ public class ClienteService : IClienteService
             throw new InvalidOperationException("El DNI ingresado ya está registrado.");
 
         var entity = _mapper.Map<Cliente>(cliente);
-        // Issue #114: Activo y FechaAlta no vienen del DTO. Los setea el Service
-        // porque son estado / audit trail, no datos de carga del operador.
-        entity.Activo = true;
+        // Issue #114 + #115: el DTO ya no expone FechaAlta ni Activo. El
+        // Service setea FechaAlta con la fecha del alta (audit trail). El
+        // flag `Activo` se eliminó de la entity: un cliente recién creado
+        // está implícitamente "activo" porque `DeletedAt = null`.
         entity.FechaAlta = DateOnly.FromDateTime(DateTime.UtcNow);
         entity.Dni = dniNormalizado;                // Issue #113
         entity.TelefonoPrincipal = telNormalizado!; // Issue #113 (es requerido, no null)
@@ -178,11 +188,12 @@ public class ClienteService : IClienteService
         if (!await IsDniUniqueAsync(dniNormalizado, clienteId))
             throw new InvalidOperationException("El DNI ingresado ya está registrado.");
 
-        // Snapshot de Activo y FechaAlta ANTES del AutoMapper: el formulario
-        // de Edit no debe poder modificar ninguno de los dos. Si el operador
-        // los manda distintos (sea por bug del DTO, por curl o por form
-        // antiguo en cache), los restauramos silenciosamente.
-        var activoOriginal = entity.Activo;
+        // Snapshot de FechaAlta ANTES del AutoMapper: el formulario de Edit
+        // no debe poder modificarlo. Issue #114. Si el operador lo manda
+        // distinto (sea por bug del DTO, por curl o por form antiguo en
+        // cache), lo restauramos silenciosamente. Issue #115: el flag
+        // `Activo` ya no se preserva porque dejó de existir — el estado
+        // del cliente se deriva de `DeletedAt`, que el Edit no toca.
         var fechaAltaOriginal = entity.FechaAlta;
 
         _mapper.Map(cliente, entity);
@@ -190,7 +201,7 @@ public class ClienteService : IClienteService
         entity.TelefonoPrincipal = StringNormalizer.NormalizarTelefono(cliente.TelefonoPrincipal)!; // Issue #113
         entity.UpdatedAt = DateTime.UtcNow;
         entity.UpdatedBy = updatedBy;
-        ClienteEditRules.PreservarFlagsNoEditables(entity, activoOriginal, fechaAltaOriginal);
+        ClienteEditRules.PreservarFechaAlta(entity, fechaAltaOriginal);
 
         await SaveOrThrowDuplicateDniAsync(ct);
 
@@ -223,8 +234,9 @@ public class ClienteService : IClienteService
         if (cliente == null)
             return false;
 
+        // Issue #115: solo se persiste `DeletedAt`. El flag `Activo` se
+        // deriva de `DeletedAt IS NULL`, así que no hace falta tocarlo.
         cliente.DeletedAt = DateTime.UtcNow;
-        cliente.Activo = false;
         cliente.UpdatedAt = DateTime.UtcNow;
         cliente.UpdatedBy = updatedBy;
         await _context.SaveChangesAsync(ct);
@@ -241,8 +253,11 @@ public class ClienteService : IClienteService
         if (cliente == null)
             return false;
 
+        // Issue #115: limpiar `DeletedAt` alcanza para reactivar — el flag
+        // `Activo` se deriva de `DeletedAt IS NULL`. Mantener un set
+        // explícito de `Activo = true` (como antes) sería sincronizar dos
+        // fuentes de verdad, justo lo que este refactor elimina.
         cliente.DeletedAt = null;
-        cliente.Activo = true;
         cliente.UpdatedAt = DateTime.UtcNow;
         cliente.UpdatedBy = updatedBy;
         await _context.SaveChangesAsync(ct);

--- a/src/ExtraGasMVC/Views/Clientes/Details.cshtml
+++ b/src/ExtraGasMVC/Views/Clientes/Details.cshtml
@@ -36,7 +36,8 @@
                     <dt class="col-sm-4">Fecha de alta</dt><dd class="col-sm-8">@Model.FechaAlta.ToString("dd/MM/yyyy")</dd>
                     <dt class="col-sm-4">Estado</dt>
                     <dd class="col-sm-8">
-                        @if (Model.Activo)
+                        @* Issue #115: Activo es derivado de DeletedAt. *@
+                        @if (Model.DeletedAt == null)
                         {
                             <span class="badge text-bg-success">Activo</span>
                         }

--- a/src/ExtraGasMVC/Views/Clientes/Edit.cshtml
+++ b/src/ExtraGasMVC/Views/Clientes/Edit.cshtml
@@ -54,7 +54,8 @@
                 <div class="col-md-3">
                     <span class="form-label">Estado</span>
                     <div>
-                        @if ((bool)ViewBag.Activo)
+                        @* Issue #115: el estado se deriva de DeletedAt. El Controller pasa ViewBag.DeletedAt en Edit GET. *@
+                        @if (ViewBag.DeletedAt == null)
                         {
                             <span class="badge text-bg-success">Activo</span>
                         }

--- a/src/ExtraGasMVC/Views/Clientes/Index.cshtml
+++ b/src/ExtraGasMVC/Views/Clientes/Index.cshtml
@@ -75,7 +75,8 @@
                         <td>@c.TelefonoPrincipal</td>
                         <td>@(c.Ciudad ?? "-")</td>
                         <td class="text-center">
-                            @if (c.Activo)
+                            @* Issue #115: Activo es ahora derivado de DeletedAt. La query del Index nunca trae soft-deleted (QueryFilter global) salvo que soloActivos=false; en ese caso DeletedAt != null y se muestra "Inactivo". *@
+                            @if (c.DeletedAt == null)
                             {
                                 <span class="badge text-bg-success">Activo</span>
                             }
@@ -91,7 +92,7 @@
                             <a asp-action="Edit" asp-route-id="@c.Id" class="btn btn-sm btn-primary" title="Editar">
                                 <i class="bi bi-pencil"></i>
                             </a>
-                            @if (c.Activo)
+                            @if (c.DeletedAt == null)
                             {
                                 <form asp-action="Delete" asp-route-id="@c.Id" method="post" class="d-inline js-confirm-form" data-name="este cliente">
                                     @Html.AntiForgeryToken()

--- a/tests/ExtraGasMVC.Tests/ClienteEditRulesTests.cs
+++ b/tests/ExtraGasMVC.Tests/ClienteEditRulesTests.cs
@@ -7,100 +7,60 @@ namespace ExtraGasMVC.Tests;
 
 /// <summary>
 /// Tests de la regla "no editable" del módulo Clientes.
-/// Garantizan que <see cref="ClienteEditRules.PreservarFlagsNoEditables"/>
-/// impone la convención: <c>Activo</c> solo cambia vía Delete/Restore
-/// (evita el estado zombie <c>Activo=false</c> + <c>DeletedAt=null</c>) y
-/// <c>FechaAlta</c> es audit trail inmutable del alta.
+/// Garantizan que <see cref="ClienteEditRules.PreservarFechaAlta"/> impone la
+/// convención: <c>FechaAlta</c> es audit trail inmutable del alta. El flag
+/// <c>Activo</c> ya no existe en la entity (Issue #115) — el estado se
+/// deriva de <c>DeletedAt</c>, que el form de Edit no expone, así que esta
+/// clase no necesita preservar nada más.
 /// </summary>
 public class ClienteEditRulesTests
 {
-    private static Cliente NewEntity(bool activo, DateOnly fechaAlta) => new()
+    private static Cliente NewEntity(DateOnly fechaAlta) => new()
     {
         Id = 1,
         Nombre = "Juan",
         Apellido = "Pérez",
         TelefonoPrincipal = "1144556677",
-        Activo = activo,
         FechaAlta = fechaAlta,
     };
 
     [Fact]
-    public void PreservarFlags_ConActivoOriginalTrue_YEntityFalse_LoRestauraATrue()
-    {
-        // Escena: operador edita un cliente activo y destilda la casilla Activo.
-        // El AutoMapper aplicó el DTO → entity.Activo = false. La regla dura
-        // tiene que restaurar el valor de BD.
-        var entity = NewEntity(activo: true, fechaAlta: new DateOnly(2024, 1, 15));
-        entity.Activo = false; // valor que dejó el AutoMapper
-
-        ClienteEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true, fechaAltaOriginal: new DateOnly(2024, 1, 15));
-
-        Assert.True(entity.Activo);
-    }
-
-    [Fact]
-    public void PreservarFlags_ConActivoOriginalFalse_YEntityTrue_LoRestauraAFalse()
-    {
-        // Caso inverso: editar un cliente inactivo y "re-activarlo" desde el
-        // form no debe funcionar. Solo Restore puede hacerlo.
-        var entity = NewEntity(activo: false, fechaAlta: new DateOnly(2024, 1, 15));
-        entity.Activo = true; // valor que dejó el AutoMapper
-
-        ClienteEditRules.PreservarFlagsNoEditables(entity, activoOriginal: false, fechaAltaOriginal: new DateOnly(2024, 1, 15));
-
-        Assert.False(entity.Activo);
-    }
-
-    [Fact]
-    public void PreservarFlags_ConActivoIgual_NoCambia()
-    {
-        // El caso "feliz": operador edita y deja Activo como estaba.
-        var entity = NewEntity(activo: true, fechaAlta: new DateOnly(2024, 1, 15));
-
-        ClienteEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true, fechaAltaOriginal: new DateOnly(2024, 1, 15));
-
-        Assert.True(entity.Activo);
-    }
-
-    [Fact]
-    public void PreservarFlags_ConFechaAltaDistinta_LaRestaura()
+    public void PreservarFechaAlta_ConFechaAltaDistinta_LaRestaura()
     {
         // Escena: operador edita y retrocede la fecha de alta. La regla
         // tiene que restaurar el valor de BD.
         var fechaAltaOriginal = new DateOnly(2024, 1, 15);
-        var entity = NewEntity(activo: true, fechaAlta: fechaAltaOriginal);
+        var entity = NewEntity(fechaAlta: fechaAltaOriginal);
         entity.FechaAlta = new DateOnly(2020, 6, 1); // valor que dejó el AutoMapper
 
-        ClienteEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true, fechaAltaOriginal: fechaAltaOriginal);
+        ClienteEditRules.PreservarFechaAlta(entity, fechaAltaOriginal);
 
         Assert.Equal(fechaAltaOriginal, entity.FechaAlta);
     }
 
     [Fact]
-    public void PreservarFlags_ConFechaAltaIgual_NoCambia()
+    public void PreservarFechaAlta_ConFechaAltaIgual_NoCambia()
     {
         var fechaAlta = new DateOnly(2024, 1, 15);
-        var entity = NewEntity(activo: true, fechaAlta: fechaAlta);
+        var entity = NewEntity(fechaAlta: fechaAlta);
 
-        ClienteEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true, fechaAltaOriginal: fechaAlta);
+        ClienteEditRules.PreservarFechaAlta(entity, fechaAltaOriginal: fechaAlta);
 
         Assert.Equal(fechaAlta, entity.FechaAlta);
     }
 
     [Fact]
-    public void PreservarFlags_NoTocaOtrosCampos()
+    public void PreservarFechaAlta_NoTocaOtrosCampos()
     {
-        // La regla solo afecta Activo y FechaAlta. Verifica que no toca
-        // campos que el form sí puede editar (ej. Nombre).
+        // La regla solo afecta FechaAlta. Verifica que no toca campos que
+        // el form sí puede editar (ej. Nombre).
         var fechaAltaOriginal = new DateOnly(2024, 1, 15);
-        var entity = NewEntity(activo: true, fechaAlta: fechaAltaOriginal);
+        var entity = NewEntity(fechaAlta: fechaAltaOriginal);
         entity.Nombre = "Nuevo nombre";
-        entity.Activo = false;
         entity.FechaAlta = new DateOnly(1999, 12, 31);
 
-        ClienteEditRules.PreservarFlagsNoEditables(entity, activoOriginal: true, fechaAltaOriginal: fechaAltaOriginal);
+        ClienteEditRules.PreservarFechaAlta(entity, fechaAltaOriginal);
 
-        Assert.True(entity.Activo);
         Assert.Equal(fechaAltaOriginal, entity.FechaAlta);
         Assert.Equal("Nuevo nombre", entity.Nombre); // quedó como el form lo mandó
     }
@@ -108,30 +68,20 @@ public class ClienteEditRulesTests
 
 /// <summary>
 /// Tests de regresión estructurales: garantizan que el contrato del DTO no
-/// vuelve a exponer <c>Activo</c> ni <c>FechaAlta</c> como propiedades
-/// editables. Si alguien vuelve a ponerlas en el base o en Update, estos
-/// tests fallan en compilación.
+/// vuelve a exponer <c>FechaAlta</c> como propiedad editable. Si alguien
+/// vuelve a ponerla en el base o en Update, estos tests fallan en
+/// compilación.
+///
+/// <para>Issue #115: el flag <c>Activo</c> ya no es un campo escribible del
+/// DTO (es un getter derivado de <c>DeletedAt</c>). El contrato testea que
+/// el getter sigue existiendo para las vistas, pero nadie puede asignarlo.</para>
 /// </summary>
 public class ClienteDtoContratoTests
 {
     [Fact]
-    public void UpdateClienteDto_NoExponeActivo()
-    {
-        // Si la propiedad vuelve al DTO, este test rompe en compilación.
-        // Es la red de seguridad del refactor: el contrato es inmutable.
-        Assert.Null(typeof(UpdateClienteDto).GetProperty("Activo"));
-    }
-
-    [Fact]
     public void UpdateClienteDto_NoExponeFechaAlta()
     {
         Assert.Null(typeof(UpdateClienteDto).GetProperty("FechaAlta"));
-    }
-
-    [Fact]
-    public void CreateClienteDto_NoExponeActivo()
-    {
-        Assert.Null(typeof(CreateClienteDto).GetProperty("Activo"));
     }
 
     [Fact]
@@ -141,11 +91,19 @@ public class ClienteDtoContratoTests
     }
 
     [Fact]
-    public void ClienteDto_SiExponeActivoYFechaAlta_ParaDisplay()
+    public void ClienteDto_ExponeActivoComoGetterYFechaAlta_ParaDisplay()
     {
-        // ClienteDto sigue exponiéndolos porque los necesitan Details, Index
-        // y listados. Si los sacás, esos views rompen.
-        Assert.NotNull(typeof(ClienteDto).GetProperty("Activo"));
+        // Issue #115: `Activo` sigue existiendo como propiedad pública del
+        // ClienteDto, pero ahora es getter-only (sin setter). La
+        // verificación `GetProperty` la encuentra igual — solo confirma que
+        // las vistas (Details, Index) pueden seguir leyéndola. Lo que ya
+        // NO se permite es que alguien la asigne (no hay setter → no
+        // compila).
+        var activoProp = typeof(ClienteDto).GetProperty("Activo");
+        Assert.NotNull(activoProp);
+        Assert.False(activoProp!.CanWrite,
+            "Activo es derivado de DeletedAt: no puede tener setter, solo getter");
+
         Assert.NotNull(typeof(ClienteDto).GetProperty("FechaAlta"));
     }
 }

--- a/tests/ExtraGasMVC.Tests/ClienteServiceReadTests.cs
+++ b/tests/ExtraGasMVC.Tests/ClienteServiceReadTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 namespace ExtraGasMVC.Tests;
 
 /// <summary>
-/// Tests de regresión de los métodos de lectura de <see cref="ClienteService"/>.
+/// Tests de regresion de los métodos de lectura de <see cref="ClienteService"/>.
 /// Issue #112: GetByIdAsync / GetAllAsync / GetByDniAsync / GetActivosAsync no
 /// tenían cobertura dedicada. Estos tests blindan:
 ///   - Devolución de null cuando el cliente no existe (no lanzar excepción).
@@ -19,6 +19,9 @@ namespace ExtraGasMVC.Tests;
 ///
 /// GetDeletedAsync ya tiene cobertura en <see cref="ClienteServiceTests"/>
 /// (Issue #111); no se duplica acá.
+///
+/// Issue #115: el flag `Activo` se eliminó de la entity. Los tests verifican
+/// el estado del cliente vía <c>DeletedAt</c> (única fuente de verdad).
 /// </summary>
 public class ClienteServiceReadTests
 {
@@ -183,38 +186,29 @@ public class ClienteServiceReadTests
     // ====================================================================
 
     [Fact]
-    public async Task GetActivosAsync_DevuelveSoloClientesConActivoTrue()
+    public async Task GetActivosAsync_DevuelveSoloClientesSinDeletedAt()
     {
-        // El método filtra por Activo=true a nivel SQL. Un cliente con
-        // Activo=false pero DeletedAt=null (estado zombie, evitado por
-        // DeleteAsync) no debería existir, pero si existiera por una
-        // migración mala, este test lo excluye igual.
-        var dbName = nameof(GetActivosAsync_DevuelveSoloClientesConActivoTrue);
+        // Issue #115: el flag `Activo` desapareció. El método devuelve los
+        // clientes que el QueryFilter global considera "visibles"
+        // (DeletedAt IS NULL). Verificamos que un cliente soft-deleted vía
+        // DeleteAsync queda fuera del listado. El escenario "zombie"
+        // (Activo=false con DeletedAt=null) ya no es posible a nivel código
+        // ni a nivel BD: la columna activo se eliminó.
+        var dbName = nameof(GetActivosAsync_DevuelveSoloClientesSinDeletedAt);
         var (service, context) = NewService(dbName);
 
         await service.CreateAsync(NewCreateDto("Juan", "Perez", "11111111"), createdBy: 1);
         await service.CreateAsync(NewCreateDto("Ana", "Gomez", "22222222"), createdBy: 1);
 
-        // Sembramos un cliente con Activo=false a mano (sin DeletedAt) para
-        // simular el escenario que el método debe excluir.
-        var zombie = new Data.Entities.Cliente
-        {
-            Nombre = "Zombie",
-            Apellido = "Zombie",
-            TelefonoPrincipal = "0000000000",
-            Dni = "99999999",
-            Activo = false,
-            FechaAlta = DateOnly.FromDateTime(DateTime.UtcNow),
-            CreatedAt = DateTime.UtcNow,
-            UpdatedAt = DateTime.UtcNow,
-        };
-        context.Clientes.Add(zombie);
-        await context.SaveChangesAsync();
+        // Cliente soft-deleted vía el método del Service (que respeta la BD
+        // y setea DeletedAt). GetActivosAsync NO debe traerlo.
+        var softDeleted = await service.CreateAsync(NewCreateDto("Zombie", "ZombieAp", "99999999"), createdBy: 1);
+        await service.DeleteAsync(softDeleted.Id, updatedBy: 1);
 
         var activos = await service.GetActivosAsync();
 
         activos.Should().HaveCount(2);
-        activos.Select(c => c.Id).Should().NotContain(zombie.Id);
+        activos.Select(c => c.Id).Should().NotContain(softDeleted.Id);
     }
 
     [Fact]

--- a/tests/ExtraGasMVC.Tests/ClienteServiceTests.cs
+++ b/tests/ExtraGasMVC.Tests/ClienteServiceTests.cs
@@ -13,9 +13,11 @@ namespace ExtraGasMVC.Tests;
 
 /// <summary>
 /// Tests de integracion del Service de Cliente contra DbContext InMemory.
-/// Cubren las lineas nuevas introducidas por el issue #114:
-/// - CreateAsync setea Activo=true y FechaAlta=hoy (no del DTO)
-/// - UpdateAsync preserva Activo y FechaAlta desde la BD (defense-in-depth)
+/// Cubren las lineas nuevas introducidas por los issues #114 y #115:
+/// - CreateAsync setea FechaAlta=hoy (no del DTO). El flag Activo
+///   desapareció del modelo tras #115; el estado se deriva de DeletedAt.
+/// - UpdateAsync preserva FechaAlta desde la BD (defense-in-depth). Activo
+///   ya no se preserva porque no existe como propiedad editable.
 ///
 /// Los helpers estaticos (ClienteEditRules) tienen tests dedicados en
 /// <see cref="ClienteEditRulesTests"/>; aca se valida la integracion
@@ -58,7 +60,7 @@ public class ClienteServiceTests
         Apellido = c.Apellido,
         Dni = c.Dni,
         TelefonoPrincipal = c.TelefonoPrincipal,
-        // Sin Activo ni FechaAlta: el DTO ya no los expone.
+        // Sin FechaAlta: el DTO ya no la expone. Issue #115: Activo tampoco.
     };
 
     /// <summary>
@@ -72,53 +74,61 @@ public class ClienteServiceTests
         Apellido = c.Apellido,
         Dni = c.Dni,
         TelefonoPrincipal = c.TelefonoPrincipal,
+        // Sin FechaAlta: el DTO ya no la expone.
     };
 
     [Fact]
-    public async Task CreateAsync_SeteaActivoTrueYFechaAltaHoy_AunqueDtoNoLosTenga()
+    public async Task CreateAsync_NuevoCliente_TieneDeletedAtNullYFechaAltaHoy()
     {
-        var (service, context) = NewService(nameof(CreateAsync_SeteaActivoTrueYFechaAltaHoy_AunqueDtoNoLosTenga));
+        // Issue #115: un cliente recién creado está implícitamente "activo"
+        // (DeletedAt == null). El Service setea FechaAlta con la fecha del
+        // alta, no del DTO.
+        var (service, context) = NewService(nameof(CreateAsync_NuevoCliente_TieneDeletedAtNullYFechaAltaHoy));
         var dto = NewCreateDto();
 
         var antes = DateOnly.FromDateTime(DateTime.UtcNow);
 var creado = await service.CreateAsync(dto, createdBy: 1);
         var despues = DateOnly.FromDateTime(DateTime.UtcNow);
 
-        creado.Activo.Should().BeTrue();
+        creado.DeletedAt.Should().BeNull("un cliente recién creado no puede estar soft-deleted");
+        creado.Activo.Should().BeTrue("Activo es derivado de DeletedAt == null (Issue #115)");
         creado.FechaAlta.Should().BeOnOrAfter(antes).And.BeOnOrBefore(despues);
     }
 
     [Fact]
-    public async Task CreateAsync_NoRespetaActivoFalseNiFechaAltaPasada_DelDto()
+    public async Task CreateAsync_NoRespetaFechaAltaPasada_DelDto()
     {
-        // El operador podria mandar Activo=false y FechaAlta retroactiva si el
-        // DTO los expusiera. Verifica que el Service los ignora y setea los
-        // valores correctos. (Ya no se puede mandar por el DTO, pero este
-        // test documenta la garantia a nivel Service.)
-        var (service, _) = NewService(nameof(CreateAsync_NoRespetaActivoFalseNiFechaAltaPasada_DelDto));
+        // El operador podría mandar FechaAlta retroactiva si el DTO lo
+        // expusiera. Verifica que el Service lo ignora y setea hoy. (Ya no
+        // se puede mandar por el DTO, pero este test documenta la garantía
+        // a nivel Service.) Issue #115: el flag Activo desapareció del
+        // modelo; el test ya no lo verifica.
+        var (service, _) = NewService(nameof(CreateAsync_NoRespetaFechaAltaPasada_DelDto));
         var dto = new CreateClienteDto
         {
             Nombre = "Juan", Apellido = "Perez", Dni = "11111111",
             TelefonoPrincipal = "1144556677",
-            // Activo y FechaAlta no existen en el DTO: el compilador no
-            // permite setearlos. Lo que verificamos es que el Service pone
-            // sus defaults independientemente del resto del DTO.
+            // FechaAlta no existe en el DTO: el compilador no permite
+            // setearlo. Lo que verificamos es que el Service pone hoy
+            // independientemente del resto del DTO.
         };
 
 var creado = await service.CreateAsync(dto, createdBy: 1);
 
-        creado.Activo.Should().BeTrue();
+        creado.DeletedAt.Should().BeNull();
         creado.FechaAlta.Should().Be(DateOnly.FromDateTime(DateTime.UtcNow).AddDays(0),
             "FechaAlta debe ser hoy, no un valor retroactivo que el DTO pueda cargar");
     }
 
     [Fact]
-    public async Task UpdateAsync_PreservaActivoYFechaAlta_DesdeLaBD_AunqueDtoNoLosTenga()
+    public async Task UpdateAsync_PreservaFechaAlta_DesdeLaBD_AunqueDtoNoLaTenga()
     {
-        // Cliente creado con Activo=true, FechaAlta=hoy. El operador intenta
-        // "desactivarlo" mandando DTO con Activo=false — el DTO ya no lo
-        // expone, pero defense-in-depth: el Service preserva desde la BD.
-        var (service, context) = NewService(nameof(UpdateAsync_PreservaActivoYFechaAlta_DesdeLaBD_AunqueDtoNoLosTenga));
+        // Cliente creado con FechaAlta=hoy. El operador intenta retrocederla
+        // mandando DTO con FechaAlta distinta — el DTO ya no la expone,
+        // pero defense-in-depth: el Service preserva desde la BD. Issue
+        // #115: el flag Activo ya no existe en la entity, así que este
+        // test solo verifica la preservación de FechaAlta.
+        var (service, context) = NewService(nameof(UpdateAsync_PreservaFechaAlta_DesdeLaBD_AunqueDtoNoLaTenga));
 var creado = await service.CreateAsync(NewCreateDto(), createdBy: 1);
         var fechaAltaOriginal = creado.FechaAlta;
 
@@ -130,11 +140,10 @@ var creado = await service.CreateAsync(NewCreateDto(), createdBy: 1);
             Dni = creado.Dni,
             TelefonoPrincipal = creado.TelefonoPrincipal,
         };
-        // Activo y FechaAlta NO estan en UpdateClienteDto.
+        // FechaAlta NO está en UpdateClienteDto.
 
         var actualizado = await service.UpdateAsync(updateDto, updatedBy: 2);
 
-        actualizado.Activo.Should().BeTrue("Activo debe preservarse desde la BD aunque el DTO no lo traiga");
         actualizado.FechaAlta.Should().Be(fechaAltaOriginal,
             "FechaAlta debe preservarse desde la BD aunque el DTO no la traiga");
 actualizado.Nombre.Should().Be("Juan Modificado", "el resto de los campos si se actualizan");
@@ -187,9 +196,12 @@ actualizado.Nombre.Should().Be("Juan Modificado", "el resto de los campos si se 
     // ====================================================================
 
     [Fact]
-    public async Task DeleteAsync_Y_RestoreAsync_RoundTrip_DevuelveClienteActivoSinDeletedAt()
+    public async Task DeleteAsync_Y_RestoreAsync_RoundTrip_DevuelveClienteSinDeletedAt()
     {
-        var (service, context) = NewService(nameof(DeleteAsync_Y_RestoreAsync_RoundTrip_DevuelveClienteActivoSinDeletedAt));
+        // Issue #115: el flag Activo desapareció. El estado se deriva de
+        // DeletedAt. El test verifica el round-trip del soft-delete solo
+        // sobre DeletedAt.
+        var (service, context) = NewService(nameof(DeleteAsync_Y_RestoreAsync_RoundTrip_DevuelveClienteSinDeletedAt));
 
         // Arrange: crear un cliente
         var dto = NewCreateDto();
@@ -202,16 +214,14 @@ actualizado.Nombre.Should().Be("Juan Modificado", "el resto de los campos si se 
         // Verificar que el cliente esta soft-deleted en BD
         var entity = await context.Clientes.IgnoreQueryFilters().FirstAsync(c => c.Id == creado.Id);
         entity.DeletedAt.Should().NotBeNull();
-        entity.Activo.Should().BeFalse();
 
         // Act 2: restore
         var restored = await service.RestoreAsync(creado.Id, updatedBy: 1);
         restored.Should().BeTrue();
 
-        // Assert: DeletedAt es null y Activo es true otra vez
+        // Assert: DeletedAt es null otra vez
         var afterRestore = await context.Clientes.IgnoreQueryFilters().FirstAsync(c => c.Id == creado.Id);
         afterRestore.DeletedAt.Should().BeNull();
-        afterRestore.Activo.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/ExtraGasMVC.Tests/ControllersActivoViewBagTests.cs
+++ b/tests/ExtraGasMVC.Tests/ControllersActivoViewBagTests.cs
@@ -14,43 +14,62 @@ using Xunit;
 namespace ExtraGasMVC.Tests;
 
 /// <summary>
-/// Tests de los Controllers para verificar que ViewBag.Activo (y
-/// ViewBag.FechaAlta en ClientesController) se popula con los valores del
-/// DTO despues del refactor del issue #114.
+/// Tests de los Controllers para verificar que ViewBag.DeletedAt / ViewBag.Activo
+/// (y ViewBag.FechaAlta en ClientesController) se popula con los valores del
+/// DTO despues del refactor del issue #115.
+///
+/// <para>Issue #115: en <see cref="ClientesController"/>, la vista Edit GET
+/// recibe <c>ViewBag.DeletedAt</c> (no <c>ViewBag.Activo</c>); el badge
+/// "Activo/Inactivo" se calcula desde <c>DeletedAt == null</c>. En
+/// Empleados/Productos/Garrafas (otras tablas con <c>activo</c> propio) el
+/// ViewBag sigue siendo <c>ViewBag.Activo</c>.</para>
+///
 /// La logica de negocio la cubren los tests del Service y del helper;
 /// aca solo se valida el wiring del Controller.
 /// </summary>
 public class ControllersActivoViewBagTests
 {
     [Fact]
-    public async Task ClientesController_EditGet_PopulaViewBagActivoYFechaAlta()
+    public async Task ClientesController_EditGet_PopulaViewBagDeletedAtYFechaAlta()
     {
+        // Issue #115: ClienteDto.Activo es getter-only derivado de
+        // DeletedAt. Solo se setea DeletedAt en el DTO; el controller
+        // propaga ViewBag.DeletedAt y ViewBag.FechaAlta.
         var controller = NewClientesController(cliente: new ClienteDto
         {
             Id = 1, Nombre = "Juan", Apellido = "Perez", TelefonoPrincipal = "1",
-            FechaAlta = new DateOnly(2024, 1, 15), Activo = true,
+            FechaAlta = new DateOnly(2024, 1, 15),
+            // DeletedAt null por defecto → cliente activo.
         });
 
         await controller.Edit(1);
 
-        ((bool)controller.ViewBag.Activo).Should().Be(true,
-            "Edit GET debe pasar el Activo del DTO por ViewBag para mostrarlo read-only");
+        // ViewBag.DeletedAt es dynamic (object). Hay que castear a DateTime?
+        // para que FluentAssertions infiera el tipo y aplique BeNull().
+        ((DateTime?)controller.ViewBag.DeletedAt).Should().BeNull(
+            "Edit GET debe pasar DeletedAt (no Activo) por ViewBag para que la vista derive el badge");
         ((DateOnly)controller.ViewBag.FechaAlta).Should().Be(new DateOnly(2024, 1, 15),
             "Edit GET debe pasar la FechaAlta del DTO por ViewBag");
     }
 
     [Fact]
-    public async Task ClientesController_EditGet_ConClienteInactivo_PopulaViewBagActivoFalse()
+    public async Task ClientesController_EditGet_ConClienteSoftDeleted_PopulaViewBagDeletedAt()
     {
+        var fechaBaja = new DateTime(2024, 6, 1, 10, 0, 0);
         var controller = NewClientesController(cliente: new ClienteDto
         {
             Id = 1, Nombre = "Juan", Apellido = "Perez", TelefonoPrincipal = "1",
-            FechaAlta = new DateOnly(2024, 1, 15), Activo = false,
+            FechaAlta = new DateOnly(2024, 1, 15),
+            DeletedAt = fechaBaja,
         });
 
         await controller.Edit(1);
 
-        ((bool)controller.ViewBag.Activo).Should().Be(false);
+        // ViewBag.DeletedAt es dynamic (object). Hay que castear para que
+        // FluentAssertions pueda aplicar `Should().Be()` con inferencia
+        // fuerte de tipo.
+        ((DateTime?)controller.ViewBag.DeletedAt).Should().Be(fechaBaja,
+            "Edit GET debe pasar la fecha de baja para que la vista muestre 'Inactivo'");
     }
 
     [Fact]

--- a/tests/ExtraGasMVC.Tests/PedidoCanjeIntegrationTests.cs
+++ b/tests/ExtraGasMVC.Tests/PedidoCanjeIntegrationTests.cs
@@ -359,7 +359,6 @@ public class PedidoCanjeIntegrationTests : IClassFixture<PedidoCanjeMySqlFixture
             Apellido = "Cliente",
             TelefonoPrincipal = "1144449999",
             FechaAlta = fechaCompra,
-            Activo = true,
             CreatedAt = now,
             UpdatedAt = now,
         };
@@ -482,7 +481,6 @@ public class PedidoCanjeIntegrationTests : IClassFixture<PedidoCanjeMySqlFixture
             Dni = "11222333",
             TelefonoPrincipal = "1144556677",
             FechaAlta = fechaCompra,
-            Activo = true,
             CreatedAt = now,
             UpdatedAt = now,
         };


### PR DESCRIPTION
## Resumen

Cierra el issue #115 — la tabla `clientes` tenía dos flags para el mismo estado (`activo TINYINT` + `deleted_at DATETIME`) que había que sincronizar manualmente en `DeleteAsync`/`RestoreAsync`. Cualquier INSERT/UPDATE directo (seed, script de QA, fix de datos) podía dejarlos en estados zombie (`Activo=false` con `DeletedAt=null`) invisibles para el QueryFilter global de EF. Se aplica la **Opción B de la issue**: eliminar la columna y derivar el estado de `DeletedAt IS NULL`.

## Cambios

### Capa de datos (`src/ExtraGasMVC/Data/`)

- `Entities/Cliente.cs` — propiedad `Activo` eliminada (la entity ya no tiene ese flag).
- `Configurations/ClienteConfiguration.cs` — mapping de `activo` eliminado. El QueryFilter global (`HasQueryFilter(c => c.DeletedAt == null)`) sigue intacto y ahora es la única fuente de verdad del estado visible.

### DTO (`src/ExtraGasMVC/DTOs/ClienteDto.cs`)

- `ClienteDto.Activo` ahora es **getter-only** calculado (`=> DeletedAt == null`). AutoMapper lo ignora por convención (sin setter → no se mapea). Las vistas pueden seguir leyéndolo; nadie puede asignarlo.
- `ClienteDtoBase` no expone `Activo` ni `FechaAlta` (eran audit trail, no editables).
- `CreateClienteDto` / `UpdateClienteDto` siguen sin exponer esos campos (regla del issue #114 reforzada).

### Service (`src/ExtraGasMVC/Services/Implementations/ClienteService.cs`)

- `CreateAsync` ya no setea `Activo = true` (un cliente recién creado está implícitamente "activo" porque `DeletedAt = null`).
- `UpdateAsync` ya no hace snapshot de `activoOriginal` ni llama a `PreservarFlagsNoEditables` con ese parámetro.
- `DeleteAsync` solo persiste `DeletedAt = NOW()`. Eliminado `Activo = false`.
- `RestoreAsync` solo limpia `DeletedAt`. Eliminado `Activo = true`.
- `GetActivosAsync`: el `Where(c => c.Activo)` desapareció (QueryFilter global ya excluye soft-deleted).
- `SearchAsync(busqueda, soloActivos, ...)`: el filtro por `Activo` también desapareció. El parámetro `soloActivos` se conserva por compatibilidad de firma pero queda como no-op documentado (el QueryFilter ya hace el trabajo).

### Helper (`src/ExtraGasMVC/Extensions/ClienteEditRules.cs`)

- Renombrado a `PreservarFechaAlta` y simplificado: solo restaura `FechaAlta` (audit trail). La rama de `Activo` desapareció porque no hay nada que preservar.

### Controller (`src/ExtraGasMVC/Controllers/ClientesController.cs`)

- `Edit GET` pasa `ViewBag.DeletedAt` en vez de `ViewBag.Activo`. La vista muestra el badge derivando de `DeletedAt == null`.

### Vistas Razor (`src/ExtraGasMVC/Views/Clientes/`)

- `Index.cshtml` — `c.Activo` → `c.DeletedAt == null` (badge + gate Delete/Restore).
- `Details.cshtml` — `Model.Activo` → `Model.DeletedAt == null`.
- `Edit.cshtml` — `@if ((bool)ViewBag.Activo)` → `@if (ViewBag.DeletedAt == null)`.

### Migración SQL (`db/migrations/20260830_000001_drop_clientes_activo.sql`)

- `ALTER TABLE clientes DROP COLUMN activo` con guard `information_schema` para idempotencia.
- No requiere migración de data: la columna es redundante con `deleted_at`.

### Documentación

- `db/docs/DECISIONES.md` — **ADR #17** documenta la decisión (Opción B de la issue), el deploy order y la implicancia para futuras tablas con soft-delete.
- `db/docs/ERD.mmd` — la fila `boolean activo` de `CLIENTES` se reemplaza por `datetime deleted_at`.

### Tests

- `ClienteServiceTests` — asserts sobre `Activo` migrados a `DeletedAt`. El test del round-trip `DeleteAsync`/`RestoreAsync` verifica solo `DeletedAt`.
- `ClienteServiceReadTests` — el test "zombie" (`Activo=false`, `DeletedAt=null`) se reemplaza por un escenario que crea un cliente vía `CreateAsync`, lo soft-deletea vía `DeleteAsync`, y verifica que `GetActivosAsync` lo excluye.
- `ClienteEditRulesTests` — los tests de preservación de `Activo` (`PreservarFlags_ConActivo*`) se eliminan. Renombrados a `PreservarFechaAlta_*`.
- `ClienteDtoContratoTests` — `Activo` sigue existiendo como propiedad del DTO pero ahora es getter-only. El test verifica `CanWrite == false` (no hay setter) además de que `GetProperty("Activo")` sigue devolviendo la propiedad.
- `ControllersActivoViewBagTests` — los tests de `ClientesController` migrados a `ViewBag.DeletedAt`. Los tests de Empleado/Producto/Garrafa siguen usando `ViewBag.Activo` porque esas tablas tienen su propio flag `activo` (fuera de scope).
- `PedidoCanjeIntegrationTests` — los seeds con `new Cliente { Activo = true }` se ajustaron (la propiedad ya no existe).

## Validación

- ✅ `dotnet build` — sin nuevos warnings (los warnings pre-existentes de `Recepciones/Create.cshtml` y los `NU1903` de AutoMapper no son tocados por este PR).
- ✅ `dotnet test` — **273/273 PASS, 0 failed, 0 skipped**. Incluye los integration tests con Testcontainers (PedidoCanje + ClienteIntegration).
- ✅ `grep -rn '\.Activo' src/ExtraGasMVC/Services/Implementations/ClienteService.cs` — solo queda el comentario del Issue #115 en `GetActivosAsync` (explica por qué el filtro desapareció).
- ✅ `grep -rn 'c\.Activo\|cliente\.Activo\|Cliente\.Activo' src/ExtraGasMVC/` — 0 hits fuera de comentarios/documentación.

## Deploy order (importante)

El código que **no escribe `activo`** debe deployarse **antes** de aplicar la migración en producción. Si la app vieja intenta persistir `activo` sobre una BD donde la columna ya no existe, falla con `Unknown column 'activo'`. El orden seguro es:

1. Mergear este PR.
2. Deploy app (la columna `activo` ya no se persiste).
3. Aplicar migración `20260830_000001_drop_clientes_activo.sql` (idempotente — no-op si la columna ya no existe).

La migración es idempotente (guard en `information_schema`), así que si se aplica antes que el deploy, la columna cae y cualquier app vieja que intente persistir `activo` falla con `Unknown column 'activo'` (esperado y ruidoso). Lo correcto: deploy app primero.

## Implicancias

- El patrón "soft-delete como estado operativo único" se valida con este cambio. Si en el futuro aparece otro flag redundante con `deleted_at` (ej. `usuarios.activo` + `usuarios.deleted_at`), replicar el mismo refactor.
- `ClienteDto.Activo` sigue existiendo como getter derivado para no romper consumidores que esperan esa propiedad (vistas, tests de contrato). Si alguien intenta asignarla, no compila — la única forma de cambiar el estado es `DeleteAsync`/`RestoreAsync`.
- `db/scripts/verify_issue_105_clientes_dni_soft_delete.sql` referencia `clientes.activo` en INSERT/UPDATE (es un script standalone de QA, no se ejecuta en `install.sh`). Se puede actualizar o eliminar en un follow-up — fuera de scope de este PR.

---

Closes #115