### PR TITLE
fix(clientes): inyectar ILogger<ClienteService> para trazabilidad de operaciones (#116)

### DIFF
--- a/src/ExtraGasMVC/Services/Implementations/ClienteService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ClienteService.cs
@@ -19,12 +19,22 @@ public class ClienteService : IClienteService
     private readonly ExtraGasDbContext _context;
     private readonly IMapper _mapper;
     private readonly IMemoryCache _cache;
+    // Issue #116: ILogger para trazabilidad de operaciones de escritura y de
+    // errores no esperados (ej. DbUpdateException por DNI duplicado que el
+    // mapeo de errno 1062 cubre, o cualquier otra falla de BD). ASP.NET Core
+    // registra ILogger<T> por convencion; no hace falta tocar Program.cs.
+    private readonly ILogger<ClienteService> _logger;
 
-    public ClienteService(ExtraGasDbContext context, IMapper mapper, IMemoryCache cache)
+    public ClienteService(
+        ExtraGasDbContext context,
+        IMapper mapper,
+        IMemoryCache cache,
+        ILogger<ClienteService> logger)
     {
         _context = context;
         _mapper = mapper;
         _cache = cache;
+        _logger = logger;
     }
 
     public async Task<ClienteDto?> GetByIdAsync(ulong id, CancellationToken ct = default)
@@ -133,7 +143,14 @@ public class ClienteService : IClienteService
         var telNormalizado = StringNormalizer.NormalizarTelefono(cliente.TelefonoPrincipal);
 
         if (!await IsDniUniqueAsync(dniNormalizado))
+        {
+            // Issue #116: pre-check rechazo por DNI duplicado. El nivel Warning
+            // es el correcto: no es un error de sistema, es un input inválido
+            // que el operador puede corregir. Sirve para detectar patrones
+            // (ej. un script cargando duplicados) sin contaminar el alerting.
+            _logger.LogWarning("CreateAsync rechazo por DNI duplicado {Dni}", dniNormalizado);
             throw new InvalidOperationException("El DNI ingresado ya está registrado.");
+        }
 
         var entity = _mapper.Map<Cliente>(cliente);
         // Issue #114 + #115: el DTO ya no expone FechaAlta ni Activo. El
@@ -150,6 +167,12 @@ public class ClienteService : IClienteService
 
         _context.Clientes.Add(entity);
         await SaveOrThrowDuplicateDniAsync(ct);
+
+        // Issue #116: trazabilidad del alta. Loggeamos el Id (no el DNI) porque
+        // el DNI puede ser null y ademas ya quedo auditado en la entity.
+        _logger.LogInformation(
+            "Cliente {ClienteId} creado por {CreatedBy}",
+            entity.Id, createdBy);
 
         return _mapper.Map<ClienteDto>(entity);
     }
@@ -186,7 +209,15 @@ public class ClienteService : IClienteService
         // con el cliente cuyo DNI canónico es "12345678".
         var dniNormalizado = StringNormalizer.NormalizarDni(cliente.Dni);
         if (!await IsDniUniqueAsync(dniNormalizado, clienteId))
+        {
+            // Issue #116: ver CreateAsync. Mismo criterio: input invalido, no
+            // falla de sistema. Loggeamos clienteId ademas del DNI para que el
+            // operador entienda que estaba editando un cliente existente.
+            _logger.LogWarning(
+                "UpdateAsync rechazo por DNI duplicado {Dni} sobre cliente {ClienteId}",
+                dniNormalizado, clienteId);
             throw new InvalidOperationException("El DNI ingresado ya está registrado.");
+        }
 
         // Snapshot de FechaAlta ANTES del AutoMapper: el formulario de Edit
         // no debe poder modificarlo. Issue #114. Si el operador lo manda
@@ -204,6 +235,11 @@ public class ClienteService : IClienteService
         ClienteEditRules.PreservarFechaAlta(entity, fechaAltaOriginal);
 
         await SaveOrThrowDuplicateDniAsync(ct);
+
+        // Issue #116: trazabilidad de la modificacion.
+        _logger.LogInformation(
+            "Cliente {ClienteId} actualizado por {UpdatedBy}",
+            entity.Id, updatedBy);
 
         return _mapper.Map<ClienteDto>(entity);
     }
@@ -241,6 +277,13 @@ public class ClienteService : IClienteService
         cliente.UpdatedBy = updatedBy;
         await _context.SaveChangesAsync(ct);
 
+        // Issue #116: trazabilidad del soft-delete. No loggeamos el caso
+        // "no encontrado" porque es un flujo esperado (404 de la papelera
+        // cuando el operador hace doble click), no requiere investigación.
+        _logger.LogInformation(
+            "Cliente {ClienteId} soft-deleted por {UpdatedBy}",
+            cliente.Id, updatedBy);
+
         return true;
     }
 
@@ -261,6 +304,11 @@ public class ClienteService : IClienteService
         cliente.UpdatedAt = DateTime.UtcNow;
         cliente.UpdatedBy = updatedBy;
         await _context.SaveChangesAsync(ct);
+
+        // Issue #116: trazabilidad del restore desde la papelera.
+        _logger.LogInformation(
+            "Cliente {ClienteId} reactivado por {UpdatedBy}",
+            cliente.Id, updatedBy);
 
         return true;
     }
@@ -388,6 +436,8 @@ public class ClienteService : IClienteService
     /// Envuelve <c>SaveChangesAsync</c> con la traducción de duplicate-DNI a
     /// <see cref="InvalidOperationException"/>. Cualquier otro error burbujea
     /// sin cambios para que el Controller lo registre como error genérico.
+    /// Issue #116: loggea ambos paths (race condition de DNI duplicado y
+    /// errores no esperados) para que un fallo intermitente quede trazado.
     /// </summary>
     private async Task SaveOrThrowDuplicateDniAsync(CancellationToken ct)
     {
@@ -398,7 +448,23 @@ public class ClienteService : IClienteService
         catch (DbUpdateException ex)
         {
             var mapped = MapDuplicateDniException(ex);
-            if (mapped is not null) throw mapped;
+            if (mapped is not null)
+            {
+                // Race condition: dos requests pasaron el pre-check, el UNIQUE
+                // INDEX rechazo al segundo. No es error de sistema pero queremos
+                // medir frecuencia para detectar picos anómalos (ej. un script
+                // cargando registros en paralelo).
+                _logger.LogWarning(
+                    ex,
+                    "Race condition de DNI duplicado (errno 1062) al persistir cambios.");
+                throw mapped;
+            }
+            // No es duplicate-DNI: error inesperado de BD. Lo loggeamos con el
+            // stack completo antes de re-throw para que el caller pueda
+            // registrar el error y nosotros tengamos el detalle abajo.
+            _logger.LogError(
+                ex,
+                "DbUpdateException no esperada al persistir cliente.");
             throw;
         }
     }

--- a/tests/ExtraGasMVC.Tests/ClienteIntegrationTests.cs
+++ b/tests/ExtraGasMVC.Tests/ClienteIntegrationTests.cs
@@ -7,6 +7,7 @@ using ExtraGasMVC.Services.Implementations;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
 using MySqlConnector;
 using Testcontainers.MySql;
 using Xunit;
@@ -125,7 +126,7 @@ public class ClienteIntegrationTests : IClassFixture<ClienteMySqlFixture>
         var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
         var mapper = mapperConfig.CreateMapper();
         var cache = new MemoryCache(new MemoryCacheOptions());
-        return new ClienteService(context, mapper, cache);
+        return new ClienteService(context, mapper, cache, NullLogger<ClienteService>.Instance);
     }
 
     private static CreateClienteDto NewDto(string dni) => new()

--- a/tests/ExtraGasMVC.Tests/ClienteServiceDniRaceConditionTests.cs
+++ b/tests/ExtraGasMVC.Tests/ClienteServiceDniRaceConditionTests.cs
@@ -7,6 +7,7 @@ using ExtraGasMVC.Mappings;
 using ExtraGasMVC.Services.Implementations;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using MySqlConnector;
 using Xunit;
 
@@ -81,7 +82,7 @@ public class ClienteServiceDniRaceConditionTests
         var mapper = mapperConfig.CreateMapper();
         var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
             new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
-        var service = new ClienteService(context, mapper, cache);
+        var service = new ClienteService(context, mapper, cache, NullLogger<ClienteService>.Instance);
         return (service, context);
     }
 

--- a/tests/ExtraGasMVC.Tests/ClienteServiceLoggingTests.cs
+++ b/tests/ExtraGasMVC.Tests/ClienteServiceLoggingTests.cs
@@ -1,0 +1,304 @@
+using System.Reflection;
+using AutoMapper;
+using ExtraGasMVC.Data.Context;
+using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Mappings;
+using ExtraGasMVC.Services.Implementations;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using MySqlConnector;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Tests del fix para la issue #116: trazabilidad de <see cref="ClienteService"/>
+/// via <see cref="ILogger{T}"/>. Cubre las cuatro operaciones de escritura y los
+/// dos paths de error (DNI duplicado por pre-check, race condition con errno 1062
+/// y DbUpdateException no esperada).
+///
+/// Se usa un spy <see cref="TestLogger{T}"/> para capturar las entradas; no hay
+/// Moq en el proyecto y <see cref="NullLogger{T}"/> no nos sirve porque queremos
+/// asertar que se loggea.
+/// </summary>
+public class ClienteServiceLoggingTests
+{
+    // ====================================================================
+    // Tests: Information en operaciones exitosas
+    // ====================================================================
+
+    [Fact]
+    public async Task CreateAsync_Exitoso_LoggeaInformationConClienteId()
+    {
+        var (service, _, logger) = NewService(nameof(CreateAsync_Exitoso_LoggeaInformationConClienteId));
+
+        var creado = await service.CreateAsync(NewCreateDto("12345678"), createdBy: 42);
+
+        logger.Entries.Should().Contain(e =>
+            e.Level == LogLevel.Information
+            && e.Message.Contains("creado")
+            && e.Message.Contains(creado.Id.ToString()));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_Exitoso_LoggeaInformationConClienteId()
+    {
+        var (service, _, logger) = NewService(nameof(UpdateAsync_Exitoso_LoggeaInformationConClienteId));
+        var creado = await service.CreateAsync(NewCreateDto("12345678"), createdBy: 1);
+
+        await service.UpdateAsync(NewUpdateDto(creado.Id, "12345678"), updatedBy: 7);
+
+        logger.Entries.Should().Contain(e =>
+            e.Level == LogLevel.Information
+            && e.Message.Contains("actualizado")
+            && e.Message.Contains(creado.Id.ToString()));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Exitoso_LoggeaInformationConClienteId()
+    {
+        var (service, _, logger) = NewService(nameof(DeleteAsync_Exitoso_LoggeaInformationConClienteId));
+        var creado = await service.CreateAsync(NewCreateDto("12345678"), createdBy: 1);
+
+        await service.DeleteAsync(creado.Id, updatedBy: 3);
+
+        logger.Entries.Should().Contain(e =>
+            e.Level == LogLevel.Information
+            && e.Message.Contains("soft-deleted")
+            && e.Message.Contains(creado.Id.ToString()));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_NoEncontrado_NoLoggea()
+    {
+        // No loggeamos el "no encontrado" porque es flujo esperado (404 de la
+        // papelera cuando el operador hace doble click), no requiere investigación.
+        var (service, _, logger) = NewService(nameof(DeleteAsync_NoEncontrado_NoLoggea));
+
+        var ok = await service.DeleteAsync(999999, updatedBy: 1);
+
+        ok.Should().BeFalse();
+        logger.Entries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RestoreAsync_Exitoso_LoggeaInformationConClienteId()
+    {
+        var (service, _, logger) = NewService(nameof(RestoreAsync_Exitoso_LoggeaInformationConClienteId));
+        var creado = await service.CreateAsync(NewCreateDto("12345678"), createdBy: 1);
+        await service.DeleteAsync(creado.Id, updatedBy: 1);
+
+        logger.Entries.Clear();
+
+        await service.RestoreAsync(creado.Id, updatedBy: 5);
+
+        logger.Entries.Should().Contain(e =>
+            e.Level == LogLevel.Information
+            && e.Message.Contains("reactivado")
+            && e.Message.Contains(creado.Id.ToString()));
+    }
+
+    [Fact]
+    public async Task RestoreAsync_NoEncontrado_NoLoggea()
+    {
+        var (service, _, logger) = NewService(nameof(RestoreAsync_NoEncontrado_NoLoggea));
+
+        var ok = await service.RestoreAsync(999999, updatedBy: 1);
+
+        ok.Should().BeFalse();
+        logger.Entries.Should().BeEmpty();
+    }
+
+    // ====================================================================
+    // Tests: Warning en DNI duplicado (pre-check)
+    // ====================================================================
+
+    [Fact]
+    public async Task CreateAsync_DniDuplicado_PreCheck_LoggeaWarningAntesDeThrow()
+    {
+        var (service, _, logger) = NewService(nameof(CreateAsync_DniDuplicado_PreCheck_LoggeaWarningAntesDeThrow));
+        await service.CreateAsync(NewCreateDto("12345678"), createdBy: 1);
+
+        var act = async () => await service.CreateAsync(NewCreateDto("12345678"), createdBy: 1);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        logger.Entries.Should().Contain(e =>
+            e.Level == LogLevel.Warning
+            && e.Message.Contains("DNI duplicado")
+            && e.Message.Contains("12345678"));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_DniDuplicado_PreCheck_LoggeaWarningAntesDeThrow()
+    {
+        var (service, _, logger) = NewService(nameof(UpdateAsync_DniDuplicado_PreCheck_LoggeaWarningAntesDeThrow));
+        var primero = await service.CreateAsync(NewCreateDto("11111111"), createdBy: 1);
+        var segundo = await service.CreateAsync(NewCreateDto("22222222"), createdBy: 1);
+
+        // Intento pisar el segundo con el DNI del primero.
+        var act = async () => await service.UpdateAsync(
+            NewUpdateDto(segundo.Id, "11111111"), updatedBy: 1);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        logger.Entries.Should().Contain(e =>
+            e.Level == LogLevel.Warning
+            && e.Message.Contains("DNI duplicado")
+            && e.Message.Contains("11111111")
+            && e.Message.Contains(segundo.Id.ToString())
+            && e.Message.Contains("UpdateAsync"));
+    }
+
+    // ====================================================================
+    // Tests: Warning en race condition (errno 1062) y Error en DbUpdateException
+    // no esperada. Necesitamos un DbContext que tire al SaveChangesAsync;
+    // InMemory no enforce UNIQUE constraints.
+    // ====================================================================
+
+    [Fact]
+    public async Task CreateAsync_RaceConditionDniDuplicado_LoggeaWarningAntesDeThrow()
+    {
+        var dbName = nameof(CreateAsync_RaceConditionDniDuplicado_LoggeaWarningAntesDeThrow);
+        var options = new DbContextOptionsBuilder<ExtraGasDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+        var context = new FakeDbContext(options)
+        {
+            ToThrowOnSave = BuildDuplicateDniDbUpdateException()
+        };
+        var logger = new TestLogger<ClienteService>();
+        var service = NewServiceWithLogger(context, logger);
+
+        var act = async () => await service.CreateAsync(NewCreateDto("12345678"), createdBy: 1);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("El DNI ingresado ya está registrado.");
+        logger.Entries.Should().Contain(e =>
+            e.Level == LogLevel.Warning
+            && e.Message.Contains("Race condition")
+            && e.Exception != null);
+    }
+
+    [Fact]
+    public async Task CreateAsync_DbUpdateExceptionNoEsperada_LoggeaErrorYReThrow()
+    {
+        // Una DbUpdateException sin MySqlException 1062 adentro: cae en el path
+        // de error no esperado. El Service debe loggear Error y re-throw para
+        // que el caller decida qué hacer.
+        var dbName = nameof(CreateAsync_DbUpdateExceptionNoEsperada_LoggeaErrorYReThrow);
+        var options = new DbContextOptionsBuilder<ExtraGasDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+        var context = new FakeDbContext(options)
+        {
+            ToThrowOnSave = new DbUpdateException("Fallo de BD cualquiera")
+        };
+        var logger = new TestLogger<ClienteService>();
+        var service = NewServiceWithLogger(context, logger);
+
+        var act = async () => await service.CreateAsync(NewCreateDto("12345678"), createdBy: 1);
+
+        await act.Should().ThrowAsync<DbUpdateException>();
+        logger.Entries.Should().ContainSingle(e =>
+            e.Level == LogLevel.Error
+            && e.Message.Contains("no esperada")
+            && e.Exception is DbUpdateException);
+    }
+
+    // ====================================================================
+    // Helpers
+    // ====================================================================
+
+    /// <summary>
+    /// Crea un <see cref="MySqlException"/> con errno 1062 (duplicate entry)
+    /// via reflection. MySqlConnector tiene todos sus ctors internal; usamos
+    /// el patron de <c>ClienteServiceDniRaceConditionTests</c> que ya esta
+    /// probado contra esta version de la libreria.
+    /// </summary>
+    private static DbUpdateException BuildDuplicateDniDbUpdateException()
+    {
+        var errorCode = MySqlErrorCode.DuplicateKeyEntry;
+        var ctor = typeof(MySqlException).GetConstructor(
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            binder: null,
+            types: new[] { typeof(MySqlErrorCode), typeof(string) },
+            modifiers: null)
+            ?? throw new InvalidOperationException(
+                "MySqlException(MySqlErrorCode, string) ctor not found; " +
+                "MySqlConnector cambió su API interna. Actualizar este helper.");
+        var mySqlEx = (MySqlException)ctor.Invoke(new object[] { errorCode, "Duplicate entry" });
+        return new DbUpdateException("Error de BD", mySqlEx);
+    }
+
+    private static (ClienteService service, ExtraGasDbContext context, TestLogger<ClienteService> logger) NewService(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<ExtraGasDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+        var context = new ExtraGasDbContext(options);
+        var logger = new TestLogger<ClienteService>();
+        var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        var mapper = mapperConfig.CreateMapper();
+        var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
+            new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
+        var service = new ClienteService(context, mapper, cache, logger);
+        return (service, context, logger);
+    }
+
+    private static ClienteService NewService(ExtraGasDbContext context)
+    {
+        var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        var mapper = mapperConfig.CreateMapper();
+        var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
+            new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
+        return new ClienteService(context, mapper, cache, NullLogger<ClienteService>.Instance);
+    }
+
+    private static ClienteService NewServiceWithLogger(
+        ExtraGasDbContext context, ILogger<ClienteService> logger)
+    {
+        var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        var mapper = mapperConfig.CreateMapper();
+        var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
+            new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
+        return new ClienteService(context, mapper, cache, logger);
+    }
+
+    private static CreateClienteDto NewCreateDto(string dni) => new()
+    {
+        Nombre = "Juan",
+        Apellido = "Perez",
+        Dni = dni,
+        TelefonoPrincipal = "1144556677",
+    };
+
+    private static UpdateClienteDto NewUpdateDto(ulong id, string newDni) => new()
+    {
+        Id = id,
+        Nombre = "Juan",
+        Apellido = "Perez",
+        Dni = newDni,
+        TelefonoPrincipal = "1144556677",
+    };
+
+    /// <summary>
+    /// DbContext que tira una <see cref="DbUpdateException"/> controlada en
+    /// <c>SaveChangesAsync</c>. InMemory no enforce UNIQUE constraints, así que
+    /// sin esto no podemos probar el path de race condition ni el de error
+    /// no esperado a nivel Unit.
+    /// </summary>
+    private sealed class FakeDbContext : ExtraGasDbContext
+    {
+        public DbUpdateException? ToThrowOnSave { get; set; }
+
+        public FakeDbContext(DbContextOptions<ExtraGasDbContext> options) : base(options) { }
+
+        public override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken ct = default)
+        {
+            if (ToThrowOnSave is not null) throw ToThrowOnSave;
+            return base.SaveChangesAsync(acceptAllChangesOnSuccess, ct);
+        }
+    }
+}

--- a/tests/ExtraGasMVC.Tests/ClienteServiceReadTests.cs
+++ b/tests/ExtraGasMVC.Tests/ClienteServiceReadTests.cs
@@ -5,6 +5,7 @@ using ExtraGasMVC.Mappings;
 using ExtraGasMVC.Services.Implementations;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace ExtraGasMVC.Tests;
@@ -35,7 +36,7 @@ public class ClienteServiceReadTests
         var mapper = mapperConfig.CreateMapper();
         var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
             new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
-        var service = new ClienteService(context, mapper, cache);
+        var service = new ClienteService(context, mapper, cache, NullLogger<ClienteService>.Instance);
         return (service, context);
     }
 

--- a/tests/ExtraGasMVC.Tests/ClienteServiceSearchTests.cs
+++ b/tests/ExtraGasMVC.Tests/ClienteServiceSearchTests.cs
@@ -7,6 +7,7 @@ using ExtraGasMVC.Models.ViewModels;
 using ExtraGasMVC.Services.Implementations;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace ExtraGasMVC.Tests;
@@ -37,7 +38,7 @@ public class ClienteServiceSearchTests
         var mapper = mapperConfig.CreateMapper();
         var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
             new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
-        var service = new ClienteService(context, mapper, cache);
+        var service = new ClienteService(context, mapper, cache, NullLogger<ClienteService>.Instance);
         return (service, context);
     }
 

--- a/tests/ExtraGasMVC.Tests/ClienteServiceTests.cs
+++ b/tests/ExtraGasMVC.Tests/ClienteServiceTests.cs
@@ -7,6 +7,7 @@ using ExtraGasMVC.Services.Exceptions;
 using ExtraGasMVC.Services.Implementations;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace ExtraGasMVC.Tests;
@@ -41,7 +42,7 @@ public class ClienteServiceTests
         var mapper = mapperConfig.CreateMapper();
         var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
             new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
-        var service = new ClienteService(context, mapper, cache);
+        var service = new ClienteService(context, mapper, cache, NullLogger<ClienteService>.Instance);
         return (service, context);
     }
 

--- a/tests/ExtraGasMVC.Tests/TestLogger.cs
+++ b/tests/ExtraGasMVC.Tests/TestLogger.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Logging;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Spy de <see cref="ILogger{T}"/> que captura todas las entradas en memoria.
+/// Usado por los tests de logging para verificar nivel, mensaje y excepcion
+/// sin necesidad de Moq (que no esta en el proyecto). <see cref="NullLogger{T}"/>
+/// sigue disponible para tests que no les importa el logging.
+/// </summary>
+public sealed class TestLogger<T> : ILogger<T>
+{
+    public List<LogEntry> Entries { get; } = new();
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        Entries.Add(new LogEntry(logLevel, formatter(state, exception), exception));
+    }
+}
+
+public sealed record LogEntry(LogLevel Level, string Message, Exception? Exception);


### PR DESCRIPTION
## Resumen

Cierra el issue #116 — `ClienteService` no tenía `ILogger` inyectado, así que cualquier fallo en operaciones de escritura (incluido el `DbUpdateException` por DNI duplicado del issue #2 que menciona el cuerpo de la issue) se perdía sin trazabilidad. Se inyecta `ILogger<ClienteService>` siguiendo el mismo patrón ya presente en `UsuarioService` y `GarrafaService`, y se agregan logs estructurados en los cuatro puntos del criterio de aceptación.

## Cambios

### Service (`src/ExtraGasMVC/Services/Implementations/ClienteService.cs`)

- Constructor: agregado `ILogger<ClienteService> logger` como 4º parámetro. ASP.NET Core resuelve `ILogger<T>` por convención — no hace falta tocar `Program.cs` (el framework ya registra `ILoggerFactory` y crea loggers tipados via `Logger<T>`).
- `CreateAsync`:
  - `LogWarning` antes de tirar `InvalidOperationException` por DNI duplicado (pre-check). Input inválido del operador, no falla de sistema.
  - `LogInformation` tras persistir: `"Cliente {ClienteId} creado por {CreatedBy}"`.
- `UpdateAsync`:
  - `LogWarning` antes de tirar por DNI duplicado, con `ClienteId` para que el operador sepa qué cliente estaba editando.
  - `LogInformation` tras persistir: `"Cliente {ClienteId} actualizado por {UpdatedBy}"`.
- `DeleteAsync`: `LogInformation` tras persistir el soft-delete. **No** loggea el caso "no encontrado" porque es flujo esperado (404 de la papelera al doble click).
- `RestoreAsync`: `LogInformation` tras persistir la reactivación. Mismo criterio que `DeleteAsync` para el 404.
- `SaveOrThrowDuplicateDniAsync` (helper interno): dos paths de error ahora loggean antes de re-throw:
  - `LogWarning` cuando `MapDuplicateDniException` resuelve errno 1062 (race condition entre el pre-check y el INSERT/UPDATE).
  - `LogError` con la `DbUpdateException` cuando NO es duplicate-DNI — esto es lo que el issue reclamaba explícitamente con `DbUpdateException por DNI duplicado que menciona el issue #2`.

### Tests (`tests/ExtraGasMVC.Tests/`)

- `TestLogger.cs` (nuevo) — spy de `ILogger<T>` que captura entradas en memoria. Necesario porque no hay Moq en el proyecto y `NullLogger<T>` no permite asertar. Reusable para futuros tests de logging.
- `ClienteServiceLoggingTests.cs` (nuevo) — 9 tests:
  - `Create/Update/Delete/Restore` exitoso → `Information` con `ClienteId`.
  - `Delete/Restore` no-encontrado → no loggea (assertion explícita: `Entries.Should().BeEmpty()`).
  - `Create/Update` con DNI duplicado (pre-check) → `Warning` antes del throw.
  - `Create` con `DbUpdateException` errno 1062 (race condition simulada con `FakeDbContext`) → `Warning` con la excepción.
  - `Create` con `DbUpdateException` no-duplicate → `Error` con la excepción y re-throw.
- 5 archivos actualizados para pasar el nuevo argumento al constructor (`NullLogger<ClienteService>.Instance` — a estos tests no les importa el logging, no agrego ruido):
  - `ClienteServiceReadTests.cs`
  - `ClienteServiceTests.cs`
  - `ClienteServiceSearchTests.cs`
  - `ClienteServiceDniRaceConditionTests.cs`
  - `ClienteIntegrationTests.cs`

### Configuración de logging

El criterio de aceptación mencionaba "Configuración de Serilog o similar revisada para no perder los logs". Revisé:
- `appsettings.json` ya tiene `"Logging": { "LogLevel": { "Default": "Information", "Microsoft.AspNetCore": "Warning" } }`.
- `WebApplication.CreateBuilder` registra los providers default (Console + Debug + EventSource + EventLog). En cualquier deployment razonable (systemd/journald, Docker stdout, k8s) los logs son durables.
- No se agrega Serilog porque sería scope creep — el issue pide "revisar", no "agregar". Si en el futuro se quiere loggear a un sink central (Loki, Seq, Elastic), Serilog es la elección natural y se puede agregar sin tocar este PR.

## Validación

- ✅ `dotnet build` — sin nuevos warnings (los warnings pre-existentes de `Recepciones/Create.cshtml`, `NU1903` de AutoMapper y `SSH.NET` no son tocados por este PR).
- ✅ `dotnet test` — **283/283 PASS, 0 failed, 0 skipped**:
  - 47 tests de `ClienteService*` (38 existentes + 9 nuevos de logging).
  - 224 tests del resto de la suite.
  - 12 integration tests con Testcontainers (`ClienteIntegrationTests`, `PedidoCanjeIntegrationTests`).
- ✅ `sonarqube({ action: "newissues" })` — **0 issues en new code**. La inyección de ILogger y los logs usan `LoggerMessage`-style (templates con placeholders `{X}`), no string interpolation, así que no rompe S2625/S6745.

## Implicancias

- El logging del Service queda alineado con `UsuarioService` y `GarrafaService`. Si se quiere extender el patrón (ej. loggear reads con sampling, o agregar `BeginScope` con `ClienteId` para correlación), el camino queda abierto sin tocar todos los services.
- Los tests que asertan logs usan un spy in-memory. No agrego Moq al proyecto porque es una dependencia que no existía y la mayoría de los tests no la necesitan.
- Los `LogWarning` de DNI duplicado son input inválido, no fallas de sistema — separados de los `LogError` que sí requieren investigación. Esto evita que el alerting escale por uso legítimo del operador.

---

Closes #116