### PR TITLE
refactor(clientes): blindar auditoría en MappingProfile con .Ignore() explicito (#118)

### DIFF
--- a/src/ExtraGasMVC/Mappings/MappingProfile.cs
+++ b/src/ExtraGasMVC/Mappings/MappingProfile.cs
@@ -32,11 +32,32 @@ public class MappingProfile : Profile
         CreateMap<VSaldoCliente, VSaldoClienteDto>().ReverseMap();
     }
 
+    // Issue #118: auditoría es responsabilidad del Service, no del mapeo.
+    // Los miembros FechaAlta / CreatedAt / UpdatedAt / CreatedBy / UpdatedBy /
+    // DeletedAt NO se exponen en los DTOs de escritura (CreateClienteDto /
+    // UpdateClienteDto), así que AutoMapper hoy no los pisa "por accidente".
+    // Pero esa salvaguarda es implícita: si mañana alguien agrega uno de esos
+    // campos al DTO o un `.MapFrom(...)` acá, el Service pierde la auditoría
+    // silenciosamente. El `.Ignore()` explícito documenta el contrato y bloquea
+    // el camino. El Service setea esos campos después del Map (ClienteService
+    // líneas 160-166 en CreateAsync y 233-234 + ClienteEditRules en UpdateAsync).
     private void ConfigureCliente()
     {
         CreateMap<Cliente, ClienteDto>().ReverseMap();
-        CreateMap<CreateClienteDto, Cliente>();
-        CreateMap<UpdateClienteDto, Cliente>();
+        CreateMap<CreateClienteDto, Cliente>()
+            .ForMember(d => d.FechaAlta, o => o.Ignore())
+            .ForMember(d => d.CreatedAt, o => o.Ignore())
+            .ForMember(d => d.UpdatedAt, o => o.Ignore())
+            .ForMember(d => d.CreatedBy, o => o.Ignore())
+            .ForMember(d => d.UpdatedBy, o => o.Ignore())
+            .ForMember(d => d.DeletedAt, o => o.Ignore());
+        CreateMap<UpdateClienteDto, Cliente>()
+            .ForMember(d => d.FechaAlta, o => o.Ignore())
+            .ForMember(d => d.CreatedAt, o => o.Ignore())
+            .ForMember(d => d.UpdatedAt, o => o.Ignore())
+            .ForMember(d => d.CreatedBy, o => o.Ignore())
+            .ForMember(d => d.UpdatedBy, o => o.Ignore())
+            .ForMember(d => d.DeletedAt, o => o.Ignore());
         CreateMap<ClienteDto, UpdateClienteDto>();
     }
 

--- a/tests/ExtraGasMVC.Tests/MappingProfileClienteTests.cs
+++ b/tests/ExtraGasMVC.Tests/MappingProfileClienteTests.cs
@@ -1,0 +1,131 @@
+using AutoMapper;
+using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Mappings;
+using FluentAssertions;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Contract tests para el <see cref="MappingProfile"/>: verifican que los
+/// miembros de auditoría NO se mapean desde los DTOs de escritura
+/// (<see cref="CreateClienteDto"/>, <see cref="UpdateClienteDto"/>) hacia la
+/// entity <see cref="Cliente"/>.
+///
+/// Issue #118: hoy la auditoría sobrevive porque los DTOs no exponen los
+/// campos y AutoMapper los ignora por convención. Eso es frágil: si alguien
+/// agrega uno de esos miembros a un DTO o un <c>.MapFrom(...)</c> al profile,
+/// el Service pierde auditoría silenciosamente. Estos tests blindan el
+/// contrato en el plano observable:
+///   1. Update preserva auditoría real (merge sobre entity cargada de BD).
+///   2. Create produce auditoría en default (obliga al Service a setearla).
+///
+/// El <c>.ForMember(..., o => o.Ignore())</c> en el profile es defensa en
+/// profundidad: si un futuro refactor agrega un campo de auditoría al DTO
+/// por error, AutoMapper lo silenciaría igual por convención (el DTO source
+/// no tiene ese miembro), pero el <c>Ignore()</c> explícito documenta el
+/// contrato y bloquea intentos de <c>.MapFrom(...)</c> en el profile.
+/// </summary>
+public class MappingProfileClienteTests
+{
+    private static IMapper NewMapper()
+    {
+        // No llamamos AssertConfigurationIsValid() porque el MappingProfile tiene
+        // unmapped properties intencionales en otros entities (Usuario, Empleado)
+        // fuera del scope de este test — la auditoría de #118 es local a Cliente.
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        return config.CreateMapper();
+    }
+
+    [Fact]
+    public void Update_Map_NoPisaAuditoria_SobreEntityExistente()
+    {
+        // Arrange: entity ya cargada de BD con timestamps y autores reales.
+        // Simula lo que hace UpdateAsync después de FindAsync.
+        var mapper = NewMapper();
+        var fechaOriginal = DateTime.UtcNow.AddDays(-30);
+        var updatedOriginal = DateTime.UtcNow.AddDays(-1);
+        var entity = new Cliente
+        {
+            Id = 42,
+            Nombre = "Vacio",
+            Apellido = "Antes",
+            TelefonoPrincipal = "1100000000",
+            FechaAlta = DateOnly.FromDateTime(fechaOriginal),
+            CreatedAt = fechaOriginal,
+            UpdatedAt = updatedOriginal,
+            CreatedBy = 7,
+            UpdatedBy = 8,
+            DeletedAt = null
+        };
+
+        var dto = new UpdateClienteDto
+        {
+            Id = 42,
+            Nombre = "Juan",
+            Apellido = "Perez",
+            Dni = "12345678",
+            TelefonoPrincipal = "1144556677"
+            // Sin FechaAlta / CreatedAt / UpdatedAt / CreatedBy / UpdatedBy /
+            // DeletedAt: el DTO no los expone.
+        };
+
+        // Act: merge del DTO sobre la entity (mismo flujo que UpdateAsync).
+        mapper.Map(dto, entity);
+
+        // Assert: los datos del DTO se aplican...
+        entity.Nombre.Should().Be("Juan");
+        entity.Apellido.Should().Be("Perez");
+        entity.Dni.Should().Be("12345678");
+        entity.TelefonoPrincipal.Should().Be("1144556677");
+
+        // ...pero la auditoría queda intacta. El Service es el único que
+        // toca UpdatedAt/UpdatedBy después del Map (ver ClienteService.UpdateAsync).
+        entity.FechaAlta.Should().Be(DateOnly.FromDateTime(fechaOriginal),
+            "FechaAlta es audit trail del alta y no debe cambiar en un Edit");
+        entity.CreatedAt.Should().Be(fechaOriginal, "CreatedAt solo lo setea CreateAsync");
+        entity.UpdatedAt.Should().Be(updatedOriginal, "UpdatedAt lo pisará el Service después");
+        entity.CreatedBy.Should().Be(7, "CreatedBy solo lo setea CreateAsync");
+        entity.UpdatedBy.Should().Be(8, "UpdatedBy lo pisará el Service después");
+        entity.DeletedAt.Should().BeNull("DeletedAt lo manejan Delete/Restore, no el mapeo");
+    }
+
+    [Fact]
+    public void Create_Map_DevuelveAuditoriaEnDefault()
+    {
+        // Arrange: CreateAsync parte de un CreateClienteDto. El Service espera
+        // setear CreatedAt/UpdatedAt/CreatedBy/UpdatedBy/FechaAlta él mismo,
+        // por lo que la entity resultante del Map debe tener esos miembros en
+        // default — si vinieran con valores del profile, el Service todavía
+        // ganaría (es la última escritura), pero el contrato "la auditoría la
+        // maneja el Service" se rompe.
+        var mapper = NewMapper();
+        var dto = new CreateClienteDto
+        {
+            Nombre = "Juan",
+            Apellido = "Perez",
+            Dni = "12345678",
+            TelefonoPrincipal = "1144556677"
+        };
+
+        // Act
+        var entity = mapper.Map<Cliente>(dto);
+
+        // Assert
+        entity.Nombre.Should().Be("Juan");
+        entity.Apellido.Should().Be("Perez");
+        entity.Dni.Should().Be("12345678");
+        entity.TelefonoPrincipal.Should().Be("1144556677");
+
+        entity.FechaAlta.Should().Be(default(DateOnly),
+            "FechaAlta la setea el Service con la fecha del alta");
+        entity.CreatedAt.Should().Be(default(DateTime),
+            "CreatedAt lo setea CreateAsync, no el mapeo");
+        entity.UpdatedAt.Should().Be(default(DateTime),
+            "UpdatedAt lo setea CreateAsync/UpdateAsync, no el mapeo");
+        entity.CreatedBy.Should().BeNull("CreatedBy lo setea CreateAsync desde el caller");
+        entity.UpdatedBy.Should().BeNull("UpdatedBy lo setea CreateAsync/UpdateAsync desde el caller");
+        entity.DeletedAt.Should().BeNull("DeletedAt lo setean Delete/Restore, no el mapeo");
+    }
+}


### PR DESCRIPTION
## Issue

Closes #118

## Resumen

`MappingProfile.ConfigureCliente()` confiaba en una salvaguarda implícita de AutoMapper: como `CreateClienteDto` y `UpdateClienteDto` no exponen los miembros de auditoría (`FechaAlta`, `CreatedAt`, `UpdatedAt`, `CreatedBy`, `UpdatedBy`, `DeletedAt`), AutoMapper los ignoraba por convención y el Service terminaba seteando los valores correctamente al sobrescribir después del `Map`.

Esa salvaguarda es **frágil**: si mañana alguien agrega uno de esos miembros a un DTO o un `.MapFrom(...)` al profile, el Service pierde auditoría silenciosamente (sin error de compilación ni test que lo detecte).

## Fix

Agrega `.ForMember(d => …, o => o.Ignore())` explícito a ambos type maps:

```csharp
CreateMap<CreateClienteDto, Cliente>()
    .ForMember(d => d.FechaAlta, o => o.Ignore())
    .ForMember(d => d.CreatedAt, o => o.Ignore())
    .ForMember(d => d.UpdatedAt, o => o.Ignore())
    .ForMember(d => d.CreatedBy, o => o.Ignore())
    .ForMember(d => d.UpdatedBy, o => o.Ignore())
    .ForMember(d => d.DeletedAt, o => o.Ignore());
CreateMap<UpdateClienteDto, Cliente>()
    .ForMember(d => d.FechaAlta, o => o.Ignore())
    .ForMember(d => d.CreatedAt, o => o.Ignore())
    .ForMember(d => d.UpdatedAt, o => o.Ignore())
    .ForMember(d => d.CreatedBy, o => o.Ignore())
    .ForMember(d => d.UpdatedBy, o => o.Ignore())
    .ForMember(d => d.DeletedAt, o => o.Ignore());
```

Más un comentario en `ConfigureCliente()` que documenta que **la auditoría es responsabilidad del Service** (no del mapeo) y referencia las líneas exactas de `ClienteService` que setean cada miembro.

## Tests nuevos

`tests/ExtraGasMVC.Tests/MappingProfileClienteTests.cs`:

- **`Update_Map_NoPisaAuditoria_SobreEntityExistente`**: simula el flujo de `UpdateAsync` cargando una entity con audit fields reales (`CreatedAt=−30d`, `UpdatedBy=8`, etc.) y haciendo merge de un `UpdateClienteDto`. Verifica que los audit fields quedan intactos.
- **`Create_Map_DevuelveAuditoriaEnDefault`**: mapea `CreateClienteDto → Cliente` y verifica que los audit fields quedan en `default`. Esto obliga al Service a setearlos (el contrato "auditoría la maneja el Service" se mantiene).

Ambos tests serían válidos también sin el `.Ignore()` (porque los DTOs no exponen esos miembros), así que el verdadero valor del `.Ignore()` es **defensa en profundidad + documentación**: si alguien rompe el contrato agregando audit fields al DTO o un `.MapFrom(...)` al profile, el `.Ignore()` lo bloquea explícitamente y queda como rastro visible en el código de que el contrato es intencional.

## Validación

- `dotnet build`: OK (0 errores)
- `dotnet test`: **304/304 pasan**, 0 regresiones (302 existentes + 2 nuevos)

## Alcance

Cambio **mínimo y focal**: solo `Cliente` en el `MappingProfile`, como pide la issue. Las entidades `Proveedor` / `Producto` / `Usuario` / `Empleado` tienen el mismo anti-patrón latente — queda como follow-up si se quiere sistematizar.

## Archivos

- `src/ExtraGasMVC/Mappings/MappingProfile.cs` — `ConfigureCliente()` blindado con `.Ignore()` + comentario de contrato
- `tests/ExtraGasMVC.Tests/MappingProfileClienteTests.cs` — 2 tests de contrato (Update preserva, Create devuelve default)