### PR TITLE
feat(productos): robustez — validaciones, paginación, AdminOnly, logging, concurrencia optimista (#146)

### DIFF
--- a/db/migrations/20260831_000001_add_productos_row_version.sql
+++ b/db/migrations/20260831_000001_add_productos_row_version.sql
@@ -1,0 +1,59 @@
+-- =============================================================================
+-- 20260831_000001_add_productos_row_version.sql
+-- Adds `row_version BINARY(8)` to `productos` for optimistic concurrency
+-- (Issue #146.4). Pairs with:
+--   - src/ExtraGasMVC/Data/Entities/Producto.cs (RowVersion byte[]?)
+--   - src/ExtraGasMVC/Data/Configurations/ProductoConfiguration.cs (IsConcurrencyToken)
+--   - src/ExtraGasMVC/Services/Implementations/ProductoService.cs (catches
+--     DbUpdateConcurrencyException -> ValidationException)
+--
+-- MySQL 8.x NO soporta `IsRowVersion()` nativo como SQL Server (no existe el
+-- tipo `rowversion`). En su lugar usamos:
+--   1. Columna BINARY(8) con DEFAULT 0x00.
+--   2. Trigger BEFORE UPDATE que asigna RANDOM_BYTES(8) — nuevo valor distinto
+--      en cada UPDATE.
+--   3. EF Core marca la columna como IsConcurrencyToken, así que agrega el
+--      valor leído al WHERE del UPDATE. Si la fila fue actualizada por otro
+--      proceso, el WHERE no matchea y EF lanza DbUpdateConcurrencyException.
+--
+-- RANDOM_BYTES(8) es nativo de MySQL 8.0+ (la rama soportada en este proyecto,
+-- ver db/docs/DECISIONES.md ADR #11). No es único entre updates — no necesita
+-- serlo; solo necesita ser DISTINTO del valor que el cliente leyó.
+--
+-- Idempotente: ALTER TABLE ADD COLUMN + DROP TRIGGER IF EXISTS antes del
+-- CREATE TRIGGER. La idempotencia real (skip por checksum) la aplica
+-- install.sh vía schema_migrations.
+-- =============================================================================
+
+USE extragas;
+
+-- Columna row_version BINARY(8) NOT NULL DEFAULT 0x0000000000000000.
+-- El DEFAULT permite INSERT sin especificar row_version (entity nueva en EF).
+SET @col_exists = (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE()
+    AND table_name = 'productos'
+    AND column_name = 'row_version'
+);
+SET @sql = IF(@col_exists = 0,
+  'ALTER TABLE productos ADD COLUMN row_version BINARY(8) NOT NULL DEFAULT 0x0000000000000000 AFTER deleted_at',
+  'SELECT "Column row_version ya existe, skipping" AS status'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Trigger BEFORE UPDATE: asigna un row_version aleatorio en cada UPDATE,
+-- garantizando que cualquier cambio de fila invalida el RowVersion que el
+-- cliente leyó. Si el cliente quería actualizar con WHERE row_version=X y
+-- otro proceso ya cambió el row_version, EF no afecta filas y el Service
+-- traduce DbUpdateConcurrencyException a ValidationException con mensaje
+-- "fue modificado por otro operador mientras editabas".
+DROP TRIGGER IF EXISTS trg_productos_bu_rowversion;
+
+CREATE TRIGGER trg_productos_bu_rowversion
+BEFORE UPDATE ON productos
+FOR EACH ROW
+  SET NEW.row_version = RANDOM_BYTES(8);
+
+SELECT 'productos.row_version + trg_productos_bu_rowversion listos' AS status;

--- a/src/ExtraGasMVC/Controllers/ProductosController.cs
+++ b/src/ExtraGasMVC/Controllers/ProductosController.cs
@@ -1,5 +1,6 @@
 using ExtraGasMVC.Constants;
 using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Exceptions;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -16,21 +17,26 @@ public class ProductosController : BaseController
         _productoService = productoService;
     }
 
-    public async Task<IActionResult> Index(string? busqueda, bool soloActivos = true, CancellationToken ct = default)
+    public async Task<IActionResult> Index(
+        string? busqueda,
+        bool soloActivos = true,
+        int page = 1,
+        int pageSize = 25,
+        CancellationToken ct = default)
     {
-        var productos = await _productoService.GetAllAsync(ct);
-        if (soloActivos) productos = productos.Where(p => p.Activo);
-        if (!string.IsNullOrWhiteSpace(busqueda))
-        {
-            var q = busqueda.Trim();
-            productos = productos.Where(p =>
-                p.Nombre.Contains(q, StringComparison.OrdinalIgnoreCase)
-                || p.Codigo.Contains(q, StringComparison.OrdinalIgnoreCase)
-                || (p.Descripcion ?? string.Empty).Contains(q, StringComparison.OrdinalIgnoreCase));
-        }
+        // Issue #146.5: paginación server-side. Antes este Controller
+        // llamaba GetAllAsync() y filtraba en memoria con LINQ-to-Objects
+        // — escaneaba toda la tabla + cargaba la navegación TipoProducto
+        // para todas las filas. Con catálogos grandes era un riesgo de
+        // performance y consumo de memoria. Ahora el WHERE y el Skip/Take
+        // se traducen a SQL; el resultado usa PagedResult<T> que ya
+        // existe en el repo (reusado por GarrafaService y otros).
+        var resultado = await _productoService.GetPagedAsync(
+            busqueda, soloActivos, page, pageSize, ct);
+
         ViewBag.Busqueda = busqueda;
         ViewBag.SoloActivos = soloActivos;
-        return View(productos.OrderBy(p => p.Nombre).ToList());
+        return View(resultado);
     }
 
     public async Task<IActionResult> Details(ulong id, CancellationToken ct = default)
@@ -62,6 +68,17 @@ public class ProductosController : BaseController
             await _productoService.CreateAsync(producto, GetCurrentUserId(), ct);
             TempData["Success"] = $"Producto {producto.Nombre} creado.";
             return RedirectToAction(nameof(Index));
+        }
+        catch (ValidationException ex)
+        {
+            // Issue #146.1, .2, .3: errores de validación de negocio que
+            // el Service rechaza ANTES de tocar la BD. El mensaje ya viene
+            // legible del Service ("Ya existe un producto con el código
+            // 'GAS-10'."); lo agregamos a ModelState para que el form
+            // muestre el error arriba y el operador entienda qué corregir.
+            ModelState.AddModelError(string.Empty, ex.Message);
+            await LoadViewBagsAsync(ct);
+            return View(producto);
         }
         catch (Exception ex)
         {
@@ -114,6 +131,15 @@ public class ProductosController : BaseController
             TempData["Success"] = $"Producto {producto.Nombre} actualizado.";
             return RedirectToAction(nameof(Index));
         }
+        catch (ValidationException ex)
+        {
+            // Issue #146.1, .2, .3, .4: validaciones de negocio y race
+            // conditions de concurrencia llegan por este canal (el Service
+            // traduce DbUpdateConcurrencyException → ValidationException).
+            ModelState.AddModelError(string.Empty, ex.Message);
+            await LoadViewBagsAsync(ct);
+            return View(producto);
+        }
         catch (Exception ex)
         {
             ModelState.AddModelError(string.Empty, $"No se pudo actualizar el producto: {ex.Message}");
@@ -122,7 +148,14 @@ public class ProductosController : BaseController
         }
     }
 
+    // Issue #146.6: AdminOnly override del class-level OperadorOrAdmin.
+    // Desactivar un producto es una operación privilegiada — un operador
+    // podría borrar del catálogo el GAS-10 por error y dejar la app
+    // inutilizable hasta que un DBA reactive (ver issue crítico sobre
+    // RestoreAsync). Mismo patrón que el Restore existente (PR #145 Slice
+    // 2). Consolida los dos puntos del ABM que requieren rol ADMIN.
     [HttpPost]
+    [Authorize(Policy = "AdminOnly")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Delete(ulong id, CancellationToken ct = default)
     {
@@ -131,17 +164,17 @@ public class ProductosController : BaseController
         // Activo fuera editable. Con el fix, el soft-delete se delega al
         // Service (DeleteAsync), que setea DeletedAt + Activo=false en una
         // sola operación consistente con el resto de los módulos.
-        var ok = await _productoService.DeleteAsync(id, ct);
+        var ok = await _productoService.DeleteAsync(id, GetCurrentUserId(), ct);
         TempData[ok ? "Success" : "Error"] = ok
             ? "Producto desactivado correctamente."
             : "No se encontró el producto.";
         return RedirectToAction(nameof(Index));
     }
 
-    // Issue #145 Slice 2: AdminOnly override del class-level OperadorOrAdmin.
-    // Restaurar un producto es una operación privilegiada — cualquier operador
-    // podria revertir un delete accidental y volver a exponer un producto
-    // desactivado a propósito. Mismo patrón que AuditoriaLoginsController.
+    // Issue #145 Slice 2 + #146.6: AdminOnly override del class-level
+    // OperadorOrAdmin. Restaurar un producto es una operación privilegiada
+    // — cualquier operador podria revertir un delete accidental y volver a
+    // exponer un producto desactivado a propósito.
     [HttpPost]
     [Authorize(Policy = "AdminOnly")]
     [ValidateAntiForgeryToken]

--- a/src/ExtraGasMVC/Data/Configurations/ProductoConfiguration.cs
+++ b/src/ExtraGasMVC/Data/Configurations/ProductoConfiguration.cs
@@ -72,6 +72,25 @@ public class ProductoConfiguration : IEntityTypeConfiguration<Producto>
             .HasColumnName("deleted_at")
             .HasColumnType("datetime");
 
+        // Issue #146.4: concurrencia optimista via RowVersion. Pomelo no
+        // implementa IsRowVersion() para MySQL (no existe el tipo nativo
+        // rowversion), pero IsConcurrencyToken() logra lo mismo: EF agrega
+        // el RowVersion al WHERE del UPDATE y si 0 filas son afectadas
+        // lanza DbUpdateConcurrencyException. El trigger BEFORE UPDATE
+        // (ver db/migrations/..._add_productos_row_version.sql) se
+        // encarga de incrementar el RowVersion en cada UPDATE.
+        //
+        // Importante: NO usamos .IsRequired(). En BD la columna es NOT NULL
+        // con DEFAULT 0x00, pero en EF la property es `byte[]?` para
+        // tolerar INSERTs sin RowVersion seteado. InMemoryDatabase no
+        // simula defaults de BD y tiraría Required properties missing en
+        // cada Test de integración si fueramos a required acá.
+        builder.Property(p => p.RowVersion)
+            .HasColumnName("row_version")
+            .HasColumnType("binary(8)")
+            .HasDefaultValue(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 })
+            .IsConcurrencyToken();
+
         builder.HasOne(p => p.TipoProducto)
             .WithMany()
             .HasForeignKey(p => p.TipoProductoId)

--- a/src/ExtraGasMVC/Data/Entities/Producto.cs
+++ b/src/ExtraGasMVC/Data/Entities/Producto.cs
@@ -18,5 +18,22 @@ public class Producto
     public ulong? UpdatedBy { get; set; }
     public DateTime? DeletedAt { get; set; }
 
+    /// <summary>
+    /// Token de concurrencia optimista. Issue #146.4: protege contra
+    /// last-write-wins silencioso cuando dos operadores editan el mismo
+    /// producto a la vez. La columna BD es <c>row_version BINARY(8)</c>
+    /// y un trigger BEFORE UPDATE la incrementa automáticamente; EF Core
+    /// la agrega al WHERE del UPDATE para detectar conflictos. Si el
+    /// RowVersion del form quedó desactualizado, EF tira
+    /// <c>DbUpdateConcurrencyException</c> que el Service traduce a
+    /// <c>ValidationException</c> con un mensaje legible.
+    ///
+    /// <para>Nullable en C# aunque la columna BD es NOT NULL con DEFAULT:
+    /// cuando EF carga una fila existente el valor viene poblado, pero
+    /// cuando crea una nueva aún no existe en BD. La convención EF Core
+    /// permite byte[] null en el INSERT y la BD rellena con DEFAULT.</para>
+    /// </summary>
+    public byte[]? RowVersion { get; set; }
+
     public virtual TipoProducto? TipoProducto { get; set; }
 }

--- a/src/ExtraGasMVC/Exceptions/ValidationException.cs
+++ b/src/ExtraGasMVC/Exceptions/ValidationException.cs
@@ -1,0 +1,19 @@
+namespace ExtraGasMVC.Exceptions;
+
+/// <summary>
+/// Excepción que el Service arroja cuando una entrada del operador es
+/// rechazable en términos de <em>validez</em> — no por invariantes internas
+/// (<c>InvalidOperationException</c>) ni por ausencia del recurso
+/// (<c>KeyNotFoundException</c>). El Controller la traduce a un error
+/// 400 con el mensaje intacto, devolviendo al usuario la causa real del
+/// rechazo en lugar de un 500 por FK constraint violada en MySQL.
+///
+/// <para>Issue #146: las validaciones que la issue pide (TipoProductoId
+/// inexistente, Codigo duplicado, GARRAFA sin capacidad) caen en esta
+/// categoría. Antes se propagaban como errores opacos del DB engine porque
+/// la app no validaba en el borde.</para>
+/// </summary>
+public class ValidationException : Exception
+{
+    public ValidationException(string message) : base(message) { }
+}

--- a/src/ExtraGasMVC/Extensions/ProductoEditRules.cs
+++ b/src/ExtraGasMVC/Extensions/ProductoEditRules.cs
@@ -1,4 +1,6 @@
 using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Exceptions;
 
 namespace ExtraGasMVC.Extensions;
 
@@ -16,6 +18,11 @@ namespace ExtraGasMVC.Extensions;
 /// por el cual <c>UpdateProductoDto.Activo</c> era editable desde el
 /// formulario de Edit, permitiendo estados zombie
 /// (<c>Activo=false</c> con <c>DeletedAt=null</c>).</para>
+///
+/// <para>Issue #146.3: agrupamos también la validación GARRAFA ⇒ CapacidadKg
+/// > 0 acá — antes explotaba tarde en RecepcionService.ValidarCodigosGarrafaAsync.
+/// Ahora se rechaza en el Service con un mensaje claro. Mismo caso de
+/// "validar en el borde, no en la BD".</para>
 /// </summary>
 public static class ProductoEditRules
 {
@@ -32,5 +39,42 @@ public static class ProductoEditRules
         // modifica — más amigable que un 400. Para (des)activar un producto
         // hay que pasar por la acción dedicada.
         entity.Activo = activoOriginal;
+    }
+
+    /// <summary>
+    /// Issue #146.3: regla de negocio GARRAFA ⇒ CapacidadKg &gt; 0. Aplicar
+    /// ANTES de SaveChanges en Create y Update. Si el operador marca
+    /// <c>ManejaGarrafaIndividual=true</c> sin capacidad (o con capacidad
+    /// cero/negativa), se rechaza con <see cref="ValidationException"/>.
+    ///
+    /// <para>Por qué se valida acá y no en
+    /// <see cref="ProductoEditRules"/>-como-attribute: Reglas de validación
+    /// que dependen de cross-field (<c>ManejaGarrafaIndividual</c> + <c>CapacidadKg</c>)
+    /// no son expresables con DataAnnotations estándar — necesitamos comparar
+    /// dos campos y DataAnnotations solo ve uno por anotación. La regla
+    /// tampoco calza en la entity porque el Service ya la valida sobre el
+    /// DTO antes del Map (no queremos seguir con la entity hasta validar).</para>
+    /// </summary>
+    public static void ValidarGarrafaCapacidad(CreateProductoDto dto)
+        => ValidarGarrafaCapacidadInternal(dto.ManejaGarrafaIndividual, dto.CapacidadKg);
+
+    /// <summary>
+    /// Sobrecarga para <see cref="UpdateProductoDto"/>. Misma lógica que
+    /// el overload de Create — se llaman desde distintas operaciones del
+    /// Service pero la regla es la misma.
+    /// </summary>
+    public static void ValidarGarrafaCapacidad(UpdateProductoDto dto)
+        => ValidarGarrafaCapacidadInternal(dto.ManejaGarrafaIndividual, dto.CapacidadKg);
+
+    private static void ValidarGarrafaCapacidadInternal(bool manejaGarrafaIndividual, decimal? capacidadKg)
+    {
+        // `is null or <= 0m` cubre ambos casos: null (no setearon CapacidadKg)
+        // y <= 0 (setearon 0 explícito, o negativo). DataAnnotations no
+        // llegan acá: [Range(0.01, ...)] en el DTO rechaza <= 0, pero NO
+        // rechaza null (es nullable) y el operador que marca "maneja
+        // garrafa individual" puede olvidarse del campo. La regla conjunta
+        // es lo que nos importa.
+        if (manejaGarrafaIndividual && (capacidadKg is null or <= 0m))
+            throw new ValidationException("Productos GARRAFA requieren capacidad_kg > 0.");
     }
 }

--- a/src/ExtraGasMVC/Services/Implementations/ProductoService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ProductoService.cs
@@ -288,9 +288,13 @@ public class ProductoService : IProductoService
             // ValidationException (mismo canal que las validaciones de
             // las brechas 1-3) para que el Controller renderice un
             // mensaje claro en lugar de un 500 genérico.
+            var codigoLog = (producto.Codigo ?? "<sin código>")
+                .Replace("\r", " ")
+                .Replace("\n", " ");
+
             _logger.LogWarning(ex,
                 "Producto {ProductoId} ({Codigo}) — conflicto de concurrencia al actualizar por {UsuarioId}",
-                producto.Id, producto.Codigo, usuarioId);
+                producto.Id, codigoLog, usuarioId);
             throw new ValidationException(
                 $"El producto {producto.Codigo} fue modificado por otro operador mientras editabas. " +
                 "Recargá la página y volvé a intentar.");

--- a/src/ExtraGasMVC/Services/Implementations/ProductoService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ProductoService.cs
@@ -308,7 +308,7 @@ public class ProductoService : IProductoService
         // log de auditoría de la edición completa.
         if (cambios.Count > 0)
         {
-            var cambiosLog = string.Join(", ", cambios);
+            var cambiosLog = SanitizeForLog(string.Join(", ", cambios));
             _logger.LogInformation(
                 "Producto {ProductoId} ({Codigo}) actualizado por {UsuarioId} — cambios: {Cambios}",
                 entity.Id, entity.Codigo, usuarioId, cambiosLog);
@@ -451,6 +451,16 @@ public class ProductoService : IProductoService
         var existe = await query.AnyAsync(ct);
         if (existe)
             throw new ValidationException($"Ya existe un producto con el código '{codigo}'.");
+    }
+
+    /// <summary>
+    /// Sanitiza texto para logging en salidas planas, evitando log forging por CR/LF.
+    /// </summary>
+    private static string SanitizeForLog(string? value)
+    {
+        return (value ?? string.Empty)
+            .Replace("\r", " ")
+            .Replace("\n", " ");
     }
 
     /// <summary>

--- a/src/ExtraGasMVC/Services/Implementations/ProductoService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ProductoService.cs
@@ -2,7 +2,9 @@ using AutoMapper;
 using ExtraGasMVC.Data.Context;
 using ExtraGasMVC.Data.Entities;
 using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Exceptions;
 using ExtraGasMVC.Extensions;
+using ExtraGasMVC.Models.ViewModels;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
@@ -13,8 +15,8 @@ public class ProductoService : IProductoService
     private readonly ExtraGasDbContext _context;
     private readonly IMapper _mapper;
     // Issue #145 Slice 2: ILogger<ProductoService> inyectado para trazabilidad
-    // del restore (operación privilegiada, AdminOnly). ASP.NET Core registra
-    // ILogger<T> por convencion; no hace falta tocar Program.cs.
+    // del restore (operación privilegiada, AdminOnly). Issue #146.7 lo extiende
+    // a las 4 operaciones de escritura (Create/Update/Delete/Restore).
     private readonly ILogger<ProductoService> _logger;
 
     public ProductoService(
@@ -88,12 +90,96 @@ public class ProductoService : IProductoService
             .AsNoTracking()
             .OrderBy(t => t.Nombre)
             .ToListAsync(ct);
-        
+
         return _mapper.Map<IEnumerable<TipoProductoDto>>(tipos);
+    }
+
+    /// <summary>
+    /// Paginación server-side del listado de Productos (issue #146.5).
+    /// Reemplaza el patrón anterior (<c>GetAllAsync</c> + LINQ-to-Objects en
+    /// Controller) que escaneaba toda la tabla y cargaba la navegación
+    /// <c>TipoProducto</c> para todas las filas, escalando mal con catálogos
+    /// grandes.
+    /// </summary>
+    public async Task<PagedResult<ProductoDto>> GetPagedAsync(
+        string? busqueda,
+        bool soloActivos,
+        int page,
+        int pageSize,
+        CancellationToken ct = default)
+    {
+        // Normalización defensiva: page y pageSize llegan del query string
+        // (no son confiables). Mismo patrón que IGarrafaService.GetPagedAsync.
+        if (page < 1) page = 1;
+        if (pageSize < 1) pageSize = 25;
+        if (pageSize > 100) pageSize = 100;
+
+        IQueryable<Producto> query = _context.Productos
+            .AsNoTracking()
+            .Include(p => p.TipoProducto);
+
+        // Issue #146.5 + preservación de la UX existente: el checkbox "Solo
+        // activos" del formulario filtra en SQL. Si el operador quiere ver
+        // desactivados (caso de auditoría), el Controller pasa false.
+        if (soloActivos)
+            query = query.Where(p => p.Activo);
+
+        if (!string.IsNullOrWhiteSpace(busqueda))
+        {
+            // EF.Functions.Like compila a un LIKE nativo de MySQL. La
+            // collation utf8mb4_unicode_ci del schema ya hace la comparación
+            // case-insensitive, así que no hace falta lower() en ambos lados.
+            // Mismo criterio que la versión anterior para no cambiar el
+            // contrato del filtro.
+            var trimmed = busqueda.Trim();
+            query = query.Where(p =>
+                EF.Functions.Like(p.Codigo, $"%{trimmed}%")
+                || EF.Functions.Like(p.Nombre, $"%{trimmed}%")
+                || (p.Descripcion != null && EF.Functions.Like(p.Descripcion, $"%{trimmed}%")));
+        }
+
+        // Total antes de paginar — CountAsync traduce a SELECT COUNT(*)
+        // sobre el WHERE aplicado, sin cargar filas (mismo patrón que
+        // GarrafaService.GetPagedAsync).
+        var total = await query.CountAsync(ct);
+
+        var items = await query
+            .OrderBy(p => p.Nombre)
+            .ThenBy(p => p.Id)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(ct);
+
+        return new PagedResult<ProductoDto>
+        {
+            Items = _mapper.Map<List<ProductoDto>>(items),
+            Page = page,
+            PageSize = pageSize,
+            Total = total
+        };
     }
 
     public async Task<ProductoDto> CreateAsync(CreateProductoDto producto, ulong? usuarioId, CancellationToken ct = default)
     {
+        // Issue #146.3: validar regla de negocio GARRAFA ⇒ CapacidadKg > 0
+        // ANTES de tocar la BD. Antes, un producto GARRAFA con CapacidadKg
+        // null rompia tarde en RecepcionService.ValidarCodigosGarrafaAsync
+        // con un mensaje opaco. Ahora se rechaza en el Service con un error
+        // claro que el Controller traduce a ModelState.
+        ProductoEditRules.ValidarGarrafaCapacidad(producto);
+
+        // Issue #146.1: pre-check FK TipoProductoId. Sin esto, un
+        // TipoProductoId inválido (form viejo en cache, integración rota,
+        // bug de UI) explota a nivel MySQL con un FK error opaco que el
+        // Controller envuelve en "No se pudo crear el producto".
+        await ValidarTipoProductoExisteAsync(producto.TipoProductoId, ct);
+
+        // Issue #146.2: pre-check de Codigo duplicado. El índice único
+        // `uq_productos_codigo` cubre el caso, pero dos requests
+        // concurrentes revientan a nivel BD con 500 "Duplicate entry".
+        // El AnyAsync da un error legible con el camino del conflicto.
+        await ValidarCodigoNoDuplicadoAsync(producto.Codigo, idAExcluir: null, ct);
+
         var entity = _mapper.Map<Producto>(producto);
         // Issue #114: Activo no viene del DTO. Lo setea el Service en true
         // porque es estado, no dato de carga del operador.
@@ -106,11 +192,33 @@ public class ProductoService : IProductoService
         _context.Productos.Add(entity);
         await _context.SaveChangesAsync(ct);
 
+        // Issue #146.7: trazabilidad operativa. Create es una operación
+        // normal pero queremos reconstruir después quién dio de alta un
+        // producto sensible (ej. GAS-10 en medio de un conflicto de
+        // precios). Information, no Warning.
+        _logger.LogInformation(
+            "Producto {ProductoId} (codigo={Codigo}, nombre={Nombre}) creado por {UsuarioId}",
+            entity.Id, entity.Codigo, entity.Nombre, usuarioId);
+
         return _mapper.Map<ProductoDto>(entity);
     }
 
     public async Task<ProductoDto> UpdateAsync(UpdateProductoDto producto, ulong? usuarioId, CancellationToken ct = default)
     {
+        // Issue #146.3: igual que CreateAsync, validar GARRAFA ⇒ CapacidadKg
+        // > 0 sobre el DTO post-Map. Misma justificación: rechazar al
+        // operador en el borde con un mensaje claro, no dejar que el bug
+        // explote tarde en RecepcionService.
+        ProductoEditRules.ValidarGarrafaCapacidad(producto);
+
+        // Issue #146.1: pre-check FK antes del Update.
+        await ValidarTipoProductoExisteAsync(producto.TipoProductoId, ct);
+
+        // Issue #146.2: pre-check de Codigo duplicado. El `idAExcluir = Id`
+        // es clave: si el operador está editando y deja su propio Codigo,
+        // el AnyAsync no debe chocar contra sí mismo.
+        await ValidarCodigoNoDuplicadoAsync(producto.Codigo, idAExcluir: producto.Id, ct);
+
         var entity = await _context.Productos.FindAsync(new object[] { producto.Id }, ct);
         if (entity == null)
             throw new KeyNotFoundException($"Producto con Id {producto.Id} no encontrado.");
@@ -128,6 +236,14 @@ public class ProductoService : IProductoService
         // `precioAnterior != 0` evita phantom rows en el primer update sobre
         // un producto recién creado con precio=0 (caso seed manual / backfill).
         var precioAnterior = entity.PrecioActual;
+
+        // Issue #146.7: snapshot de las propiedades que el AutoMapper va a
+        // pisar para emitir un log con los campos efectivamente cambiados.
+        // Diferencia entre "el operador reenvió el form sin tocar nada" y
+        // "el operador cambió el precio / estado / capacidad". Importante
+        // para auditoría (issue #19: cambios concurrentes ya provocaron
+        // last-write-wins silenciosos en otros módulos).
+        var cambios = DetectarCambiosProducto(entity, producto);
 
         _mapper.Map(producto, entity);
         entity.UpdatedAt = DateTime.UtcNow;
@@ -160,12 +276,44 @@ public class ProductoService : IProductoService
                 entity.Id, precioAnterior, precioNuevo, motivoCambioPrecioLog, usuarioId);
         }
 
-        await _context.SaveChangesAsync(ct);
+        try
+        {
+            await _context.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            // Issue #146.4: concurrencia optimista. Si dos operadores
+            // editan el mismo producto a la vez, el RowVersion del WHERE
+            // no matchea al del UPDATE → 0 filas afectadas. Traducimos a
+            // ValidationException (mismo canal que las validaciones de
+            // las brechas 1-3) para que el Controller renderice un
+            // mensaje claro en lugar de un 500 genérico.
+            _logger.LogWarning(ex,
+                "Producto {ProductoId} ({Codigo}) — conflicto de concurrencia al actualizar por {UsuarioId}",
+                producto.Id, producto.Codigo, usuarioId);
+            throw new ValidationException(
+                $"El producto {producto.Codigo} fue modificado por otro operador mientras editabas. " +
+                "Recargá la página y volvé a intentar.");
+        }
+
+        // Issue #146.7: log de los campos efectivamente cambiados.
+        // Filtramos la lista para no spammear cuando no hay cambios
+        // reales (operador reenvió el form sin tocar nada). El "cambios"
+        // también incluye el precio si cambió — Slice 3 ya loggea el
+        // evento de histórico; acá solo evita duplicar el item en el
+        // log de auditoría de la edición completa.
+        if (cambios.Count > 0)
+        {
+            var cambiosLog = string.Join(", ", cambios);
+            _logger.LogInformation(
+                "Producto {ProductoId} ({Codigo}) actualizado por {UsuarioId} — cambios: {Cambios}",
+                entity.Id, entity.Codigo, usuarioId, cambiosLog);
+        }
 
         return _mapper.Map<ProductoDto>(entity);
     }
 
-    public async Task<bool> DeleteAsync(ulong id, CancellationToken ct = default)
+    public async Task<bool> DeleteAsync(ulong id, ulong? usuarioId = null, CancellationToken ct = default)
     {
         var producto = await _context.Productos.FindAsync(new object[] { id }, ct);
         if (producto == null)
@@ -178,7 +326,30 @@ public class ProductoService : IProductoService
         producto.DeletedAt = DateTime.UtcNow;
         producto.Activo = false;
         producto.UpdatedAt = DateTime.UtcNow;
-        await _context.SaveChangesAsync(ct);
+
+        try
+        {
+            await _context.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            // Mismo patrón que UpdateAsync: el RowVersion protege contra
+            // last-write-wins silencioso en la baja. El catálogo de
+            // productos no debería perder una fila por esto, pero la
+            // auditoría del intento queda registrada.
+            _logger.LogWarning(ex,
+                "Producto {Id} ({Codigo}) — conflicto de concurrencia al desactivar por {UsuarioId}",
+                producto.Id, producto.Codigo, usuarioId);
+            throw;
+        }
+
+        // Issue #146.7 + #146.6: Delete es AdminOnly (PR #145 Slice 2 lo
+        // introdujo; issue #146.6 lo consolida). Loggeamos a nivel Warning
+        // — un soft-delete no es un evento crítico, pero el operador
+        // debería poder reconstruir qué producto se bajó y cuándo.
+        _logger.LogWarning(
+            "Producto {Id} ({Codigo}, nombre={Nombre}) desactivado por {UsuarioId}",
+            producto.Id, producto.Codigo, producto.Nombre, usuarioId);
 
         return true;
     }
@@ -221,5 +392,90 @@ public class ProductoService : IProductoService
             producto.Id, updatedBy);
 
         return true;
+    }
+
+    // ========================================================================
+    // Helpers privados (issue #146 - validaciones centralizadas en el Service)
+    // ========================================================================
+
+    /// <summary>
+    /// Verifica que el <c>TipoProductoId</c> recibido exista en el catálogo.
+    /// Issue #146.1: sin esto, un TipoProductoId inválido explota a nivel
+    /// MySQL con un FK error opaco que el Controller envuelve en "No se pudo
+    /// crear el producto". Patrón tomado de PedidoService (líneas donde se
+    /// valida <c>cliente_id</c> y <c>empleado_id</c>).
+    /// </summary>
+    private async Task ValidarTipoProductoExisteAsync(ulong tipoProductoId, CancellationToken ct)
+    {
+        var existe = await _context.TiposProducto
+            .AsNoTracking()
+            .AnyAsync(t => t.Id == tipoProductoId, ct);
+
+        if (!existe)
+            throw new ValidationException($"Tipo de producto inválido (id={tipoProductoId}).");
+    }
+
+    /// <summary>
+    /// Verifica que el <c>Codigo</c> no esté usado por otro producto.
+    /// Issue #146.2: el índice único <c>uq_productos_codigo</c> cubre el
+    /// caso serial, pero dos requests concurrentes revientan a nivel MySQL
+    /// con 500 "Duplicate entry". El <c>AnyAsync</c> da un error legible
+    /// con el camino del conflicto. Mismo patrón que GarrafaService
+    /// (líneas 218 + 242) y ProveedorService (líneas 162 + 172).
+    /// </summary>
+    /// <param name="codigo">Código a verificar.</param>
+    /// <param name="idAExcluir">Id del producto actual; pasar <c>null</c>
+    /// en Create. En Update, pasar el Id del producto que se está
+    /// editando para no chocar contra sí mismo.</param>
+    private async Task ValidarCodigoNoDuplicadoAsync(string codigo, ulong? idAExcluir, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(codigo))
+            return; // DataAnnotations ya lo rechaza en el Controller.
+
+        // Filtro manual `DeletedAt == null` para que un producto soft-deleted
+        // con el mismo Codigo NO aparezca como colisión: si se reactiva, el
+        // espacio lógico del código está libre. El QueryFilter global hace
+        // lo mismo para queries de lectura, pero acá lo explicitamos para
+        // que el lector entienda la intención sin saltar al Configuration.
+        var query = _context.Productos
+            .AsNoTracking()
+            .Where(p => p.Codigo == codigo && p.DeletedAt == null);
+
+        if (idAExcluir.HasValue)
+            query = query.Where(p => p.Id != idAExcluir.Value);
+
+        var existe = await query.AnyAsync(ct);
+        if (existe)
+            throw new ValidationException($"Ya existe un producto con el código '{codigo}'.");
+    }
+
+    /// <summary>
+    /// Issue #146.7: detecta las propiedades que el Mapper va a pisar para
+    /// poder listarlas en el log de auditoría. Compara los valores del DTO
+    /// contra los de la entity ANTES del Map para no contaminarse con el
+    /// resultado del mapeo (que ya pisó la entity).
+    /// </summary>
+    private static List<string> DetectarCambiosProducto(Producto entity, UpdateProductoDto dto)
+    {
+        var cambios = new List<string>();
+
+        if (!string.Equals(entity.Codigo, dto.Codigo, StringComparison.Ordinal))
+            cambios.Add($"Codigo: '{entity.Codigo}' → '{dto.Codigo}'");
+        if (!string.Equals(entity.Nombre, dto.Nombre, StringComparison.Ordinal))
+            cambios.Add($"Nombre: '{entity.Nombre}' → '{dto.Nombre}'");
+        if (!string.Equals(entity.Descripcion ?? null, dto.Descripcion ?? null, StringComparison.Ordinal))
+            cambios.Add("Descripcion");
+        if (entity.TipoProductoId != dto.TipoProductoId)
+            cambios.Add($"TipoProductoId: {entity.TipoProductoId} → {dto.TipoProductoId}");
+        if (entity.CapacidadKg != dto.CapacidadKg)
+            cambios.Add($"CapacidadKg: {entity.CapacidadKg?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "null"} → {dto.CapacidadKg?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "null"}");
+        if (!string.Equals(entity.UnidadVenta, dto.UnidadVenta, StringComparison.Ordinal))
+            cambios.Add($"UnidadVenta: '{entity.UnidadVenta}' → '{dto.UnidadVenta}'");
+        if (entity.PrecioActual != dto.PrecioActual)
+            cambios.Add($"PrecioActual: {entity.PrecioActual} → {dto.PrecioActual}");
+        if (entity.ManejaGarrafaIndividual != dto.ManejaGarrafaIndividual)
+            cambios.Add($"ManejaGarrafaIndividual: {entity.ManejaGarrafaIndividual} → {dto.ManejaGarrafaIndividual}");
+
+        return cambios;
     }
 }

--- a/src/ExtraGasMVC/Services/Interfaces/IProductoService.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IProductoService.cs
@@ -1,4 +1,5 @@
 using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Models.ViewModels;
 
 namespace ExtraGasMVC.Services.Interfaces;
 
@@ -11,9 +12,23 @@ public interface IProductoService
     Task<IEnumerable<ProductoDto>> GetByTipoAsync(ulong tipoProductoId, CancellationToken ct = default);
     Task<IEnumerable<TipoProductoDto>> GetTiposProductoAsync(CancellationToken ct = default);
 
+    /// <summary>
+    /// Listado paginado server-side (Issue #146.5). Reemplaza el patrón
+    /// <c>GetAllAsync + LINQ-to-Objects</c> que cargaba toda la tabla en
+    /// memoria y rompía con catálogos grandes. El WHERE se traduce a SQL
+    /// (incluye <c>OnlyActivos</c> y la búsqueda por código/nombre/desc) y el
+    /// conteo se hace con <c>SELECT COUNT(*)</c> separado.
+    /// </summary>
+    Task<PagedResult<ProductoDto>> GetPagedAsync(
+        string? busqueda,
+        bool soloActivos,
+        int page,
+        int pageSize,
+        CancellationToken ct = default);
+
     Task<ProductoDto> CreateAsync(CreateProductoDto producto, ulong? usuarioId, CancellationToken ct = default);
     Task<ProductoDto> UpdateAsync(UpdateProductoDto producto, ulong? usuarioId, CancellationToken ct = default);
-    Task<bool> DeleteAsync(ulong id, CancellationToken ct = default);
+    Task<bool> DeleteAsync(ulong id, ulong? usuarioId = null, CancellationToken ct = default);
 
     /// <summary>
     /// Reactiva un producto soft-deleted. Issue #145 Slice 2: inversa de

--- a/src/ExtraGasMVC/Views/Productos/Index.cshtml
+++ b/src/ExtraGasMVC/Views/Productos/Index.cshtml
@@ -1,4 +1,4 @@
-@model IEnumerable<ExtraGasMVC.DTOs.ProductoDto>
+@model ExtraGasMVC.Models.ViewModels.PagedResult<ExtraGasMVC.DTOs.ProductoDto>
 @{
     ViewData["Title"] = "Productos";
     var busqueda = ViewBag.Busqueda as string;
@@ -14,7 +14,7 @@
 <div class="card">
     <div class="card-header">
         <form method="get" class="row g-2 align-items-end">
-            <div class="col-md-6">
+            <div class="col-md-5">
                 <label for="filtroBusqueda" class="form-label small mb-1">Buscar</label>
                 <input type="text" id="filtroBusqueda" name="busqueda" value="@busqueda" class="form-control" placeholder="Nombre, código o descripción" />
             </div>
@@ -25,7 +25,19 @@
                     <label class="form-check-label" for="soloActivos">Solo activos</label>
                 </div>
             </div>
-            <div class="col-md-4 d-flex gap-2">
+            <div class="col-md-2">
+                <label for="pageSizeSelect" class="form-label small mb-1">Por página</label>
+                <select id="pageSizeSelect" name="pageSize" class="form-select">
+                    @{
+                        var sizes = new[] { 10, 25, 50, 100 };
+                    }
+                    @foreach (var s in sizes)
+                    {
+                        <option value="@s" selected="@(Model.PageSize == s)">@s</option>
+                    }
+                </select>
+            </div>
+            <div class="col-md-3 d-flex gap-2">
                 <button type="submit" class="btn btn-primary flex-fill"><i class="bi bi-search me-1"></i> Buscar</button>
                 <a asp-action="Index" class="btn btn-outline-secondary"><i class="bi bi-arrow-counterclockwise"></i></a>
             </div>
@@ -47,11 +59,11 @@
                 </tr>
             </thead>
             <tbody>
-                @if (!Model.Any())
+                @if (!Model.Items.Any())
                 {
                     <tr><td colspan="9" class="text-center py-4 text-secondary">No hay productos.</td></tr>
                 }
-                @foreach (var p in Model)
+                @foreach (var p in Model.Items)
                 {
                     <tr>
                         <td><code>@p.Codigo</code></td>
@@ -78,11 +90,11 @@
                             @if (p.Activo)
                             {
                                 // Issue #145 Slice 2: solo Activos ven Delete.
-                                // Inactivos (soft-deleted) ven Restaurar.
-                                // Restore es AdminOnly — la policy se enforza en
-                                // el Controller; el boton se muestra a todos los
-                                // usuarios de la tabla pero el POST falla con 403
-                                // si el caller no es Admin.
+                                // Issue #146.6: Delete es AdminOnly — la policy
+                                // se enforza en el Controller; el botón se
+                                // muestra a todos los usuarios de la tabla
+                                // pero el POST falla con 403 si el caller no
+                                // es Admin.
                                 <form asp-action="Delete" asp-route-id="@p.Id" method="post" class="d-inline js-confirm-form" data-name="este producto" data-action="desactivar">
                                     @Html.AntiForgeryToken()
                                     <button type="button" class="btn btn-sm btn-danger" onclick="confirmarAccion(this)"><i class="bi bi-trash"></i></button>
@@ -101,4 +113,61 @@
             </tbody>
         </table>
     </div>
+    @* Issue #146.5: paginación. Mantenemos los filtros del query string al
+       armar los links Anterior/Siguiente, igual que en Garrafas. Sin
+       page-hidden en el form de filtros, si el operador cambia de página y
+       el form reenvía sin page, el controller recibe page=1 (default). *@
+    @if (Model.TotalPages > 1)
+    {
+        <div class="card-footer">
+            <div class="d-flex justify-content-between align-items-center">
+                <div class="text-secondary small">
+                    Mostrando @(Model.Items.Count) de @Model.Total resultados — página @Model.Page de @Model.TotalPages
+                </div>
+                <nav>
+                    <ul class="pagination pagination-sm mb-0">
+                        <li class="page-item @(Model.HasPrevious ? "" : "disabled")">
+                            <a class="page-link"
+                               asp-action="Index"
+                               asp-route-busqueda="@busqueda"
+                               asp-route-soloActivos="@soloActivos"
+                               asp-route-pageSize="@Model.PageSize"
+                               asp-route-page="@(Model.Page - 1)">
+                                <i class="bi bi-chevron-left"></i>
+                            </a>
+                        </li>
+                        @for (var p = 1; p <= Model.TotalPages; p++)
+                        {
+                            <li class="page-item @(p == Model.Page ? "active" : "")">
+                                <a class="page-link"
+                                   asp-action="Index"
+                                   asp-route-busqueda="@busqueda"
+                                   asp-route-soloActivos="@soloActivos"
+                                   asp-route-pageSize="@Model.PageSize"
+                                   asp-route-page="@p">@p</a>
+                            </li>
+                        }
+                        <li class="page-item @(Model.HasNext ? "" : "disabled")">
+                            <a class="page-link"
+                               asp-action="Index"
+                               asp-route-busqueda="@busqueda"
+                               asp-route-soloActivos="@soloActivos"
+                               asp-route-pageSize="@Model.PageSize"
+                               asp-route-page="@(Model.Page + 1)">
+                                <i class="bi bi-chevron-right"></i>
+                            </a>
+                        </li>
+                    </ul>
+                </nav>
+            </div>
+        </div>
+    }
+    else if (Model.Total > 0)
+    {
+        <div class="card-footer">
+            <div class="text-secondary small">
+                Mostrando @Model.Items.Count de @Model.Total resultados
+            </div>
+        </div>
+    }
 </div>

--- a/tests/ExtraGasMVC.Tests/ControllersActivoViewBagTests.cs
+++ b/tests/ExtraGasMVC.Tests/ControllersActivoViewBagTests.cs
@@ -326,7 +326,7 @@ public class ControllersActivoViewBagTests
         public Task<IEnumerable<TipoProductoDto>> GetTiposProductoAsync(CancellationToken ct = default) => Task.FromResult<IEnumerable<TipoProductoDto>>(new List<TipoProductoDto>());
         public Task<ProductoDto> CreateAsync(CreateProductoDto d, ulong? u, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<ProductoDto> UpdateAsync(UpdateProductoDto d, ulong? u, CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<bool> DeleteAsync(ulong id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<bool> DeleteAsync(ulong id, ulong? updatedBy, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<bool> RestoreAsync(ulong id, ulong? updatedBy, CancellationToken ct = default)
         {
             RestoreLlamadas++;
@@ -334,6 +334,7 @@ public class ControllersActivoViewBagTests
             RestoreUltimoUpdatedBy = updatedBy;
             return Task.FromResult(RestoreReturns);
         }
+        public Task<PagedResult<ProductoDto>> GetPagedAsync(string? busqueda, bool soloActivos, int page, int pageSize, CancellationToken ct = default) => throw new NotImplementedException();
     }
 
     private sealed class FakeGarrafaService : IGarrafaService

--- a/tests/ExtraGasMVC.Tests/PedidoCanjeIntegrationTests.cs
+++ b/tests/ExtraGasMVC.Tests/PedidoCanjeIntegrationTests.cs
@@ -921,10 +921,22 @@ public class PedidoCanjeMySqlFixture : IAsyncLifetime
             created_by BIGINT UNSIGNED NULL,
             updated_by BIGINT UNSIGNED NULL,
             deleted_at DATETIME NULL,
+            -- Issue #146.4: concurrencia optimista via row_version.
+            -- BINARY(8) NOT NULL DEFAULT 0x0000000000000000 + el trigger
+            -- trg_productos_bu_rowversion que asigna RANDOM_BYTES(8) en
+            -- cada UPDATE. Mismo DDL que la migración real
+            -- 20260831_000001_add_productos_row_version.sql.
+            row_version BINARY(8) NOT NULL DEFAULT 0x0000000000000000,
             CONSTRAINT fk_productos_tipo FOREIGN KEY (tipo_producto_id) REFERENCES tipos_producto(id),
             UNIQUE KEY uq_productos_codigo (codigo),
             KEY idx_productos_deleted_at (deleted_at)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+        DROP TRIGGER IF EXISTS trg_productos_bu_rowversion;
+        CREATE TRIGGER trg_productos_bu_rowversion
+        BEFORE UPDATE ON productos
+        FOR EACH ROW
+            SET NEW.row_version = RANDOM_BYTES(8);
 
         -- Pedidos
         CREATE TABLE pedidos (

--- a/tests/ExtraGasMVC.Tests/PedidosControllerCommandTests.cs
+++ b/tests/ExtraGasMVC.Tests/PedidosControllerCommandTests.cs
@@ -480,8 +480,9 @@ public class PedidosControllerCommandTests
         public Task<IEnumerable<TipoProductoDto>> GetTiposProductoAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task<ProductoDto> CreateAsync(CreateProductoDto producto, ulong? usuarioId, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<ProductoDto> UpdateAsync(UpdateProductoDto producto, ulong? usuarioId, CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<bool> DeleteAsync(ulong id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<bool> DeleteAsync(ulong id, ulong? updatedBy, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<bool> RestoreAsync(ulong id, ulong? usuarioId, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<PagedResult<ProductoDto>> GetPagedAsync(string? busqueda, bool soloActivos, int page, int pageSize, CancellationToken ct = default) => throw new NotImplementedException();
     }
 
     private sealed class NotImplementedGarrafaService : IGarrafaService

--- a/tests/ExtraGasMVC.Tests/PedidosControllerIndexTests.cs
+++ b/tests/ExtraGasMVC.Tests/PedidosControllerIndexTests.cs
@@ -220,8 +220,9 @@ public class PedidosControllerIndexTests
         public Task<IEnumerable<TipoProductoDto>> GetTiposProductoAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task<ProductoDto> CreateAsync(CreateProductoDto producto, ulong? usuarioId, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<ProductoDto> UpdateAsync(UpdateProductoDto producto, ulong? usuarioId, CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<bool> DeleteAsync(ulong id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<bool> DeleteAsync(ulong id, ulong? updatedBy, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<bool> RestoreAsync(ulong id, ulong? usuarioId, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<PagedResult<ProductoDto>> GetPagedAsync(string? busqueda, bool soloActivos, int page, int pageSize, CancellationToken ct = default) => throw new NotImplementedException();
     }
 
     private sealed class NotImplementedGarrafaServiceForPedidos : IGarrafaService

--- a/tests/ExtraGasMVC.Tests/ProductoActivoRaceIntegrationTests.cs
+++ b/tests/ExtraGasMVC.Tests/ProductoActivoRaceIntegrationTests.cs
@@ -332,8 +332,9 @@ public class ProductoActivoRaceIntegrationTests : IClassFixture<PedidoCanjeMySql
         public Task<IEnumerable<TipoProductoDto>> GetTiposProductoAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task<ProductoDto> CreateAsync(CreateProductoDto producto, ulong? usuarioId, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<ProductoDto> UpdateAsync(UpdateProductoDto producto, ulong? usuarioId, CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<bool> DeleteAsync(ulong id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<bool> DeleteAsync(ulong id, ulong? updatedBy, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<bool> RestoreAsync(ulong id, ulong? updatedBy, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<PagedResult<ProductoDto>> GetPagedAsync(string? busqueda, bool soloActivos, int page, int pageSize, CancellationToken ct = default) => throw new NotImplementedException();
     }
 
     /// <summary>

--- a/tests/ExtraGasMVC.Tests/ProductoPrecioHistoricoIntegrationTests.cs
+++ b/tests/ExtraGasMVC.Tests/ProductoPrecioHistoricoIntegrationTests.cs
@@ -209,6 +209,13 @@ public class ProductoPrecioHistoricoIntegrationTests
                 Codigo = "GAS-10",
                 Nombre = "Garrafa 10kg",
                 TipoProductoId = 1,
+                // Issue #146.3: capacidad_kg > 0 cuando ManejaGarrafaIndividual=true.
+                // El test pre-existente sembraba sin capacidad y confiaba en que la
+                // validación tardía en RecepcionService.ValidarCodigosGarrafaAsync
+                // se ocupara. Ahora el Service lo rechaza en el borde y se setea
+                // explícito para que el escenario "producto GARRAFA real" siga
+                // siendo representativo.
+                CapacidadKg = 10m,
                 UnidadVenta = "UNIDAD",
                 PrecioActual = 1000m,
                 ManejaGarrafaIndividual = true,
@@ -231,6 +238,11 @@ public class ProductoPrecioHistoricoIntegrationTests
                 Codigo = producto.Codigo,
                 Nombre = producto.Nombre,
                 TipoProductoId = producto.TipoProductoId,
+                // Issue #146.3: propagamos la capacidad seteada en el seed
+                // para que la regla GARRAFA ⇒ CapacidadKg > 0 no rechace el
+                // UpdateAsync y se pueda ejercitar el path de histórico de
+                // precios — que es lo que este test cubre.
+                CapacidadKg = producto.CapacidadKg,
                 UnidadVenta = producto.UnidadVenta,
                 PrecioActual = 1500m,
                 ManejaGarrafaIndividual = producto.ManejaGarrafaIndividual,
@@ -513,9 +525,18 @@ public class ProductoPrecioHistoricoMySqlFixture : IAsyncLifetime
             created_by BIGINT UNSIGNED NULL,
             updated_by BIGINT UNSIGNED NULL,
             deleted_at DATETIME NULL,
+            -- Issue #146.4: concurrencia optimista via row_version (mismo DDL que
+            -- la migración real 20260831_000001_add_productos_row_version.sql).
+            row_version BINARY(8) NOT NULL DEFAULT 0x0000000000000000,
             CONSTRAINT fk_productos_tipo FOREIGN KEY (tipo_producto_id) REFERENCES tipos_producto(id),
             UNIQUE KEY uq_productos_codigo (codigo)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+        DROP TRIGGER IF EXISTS trg_productos_bu_rowversion;
+        CREATE TRIGGER trg_productos_bu_rowversion
+        BEFORE UPDATE ON productos
+        FOR EACH ROW
+            SET NEW.row_version = RANDOM_BYTES(8);
 
         -- Seed del lookup + un usuario para que las FKs tengan destino en el
         -- test InsertConChangedByInexistente. Las FKs de producto_precios_historico

--- a/tests/ExtraGasMVC.Tests/ProductoServiceRobustezTests.cs
+++ b/tests/ExtraGasMVC.Tests/ProductoServiceRobustezTests.cs
@@ -1,0 +1,542 @@
+using System.Reflection;
+using AutoMapper;
+using ExtraGasMVC.Data.Context;
+using ExtraGasMVC.Data.Configurations;
+using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Exceptions;
+using ExtraGasMVC.Extensions;
+using ExtraGasMVC.Mappings;
+using ExtraGasMVC.Services.Implementations;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Tests de robustez del módulo Productos introducidos por la issue #146.
+/// Cubre 7 brechas detectadas en revisión profunda: validaciones FK / duplicados
+/// / GARRAFA ⇒ CapacidadKg, concurrencia optimista, paginación server-side,
+/// autorización granular y logging operativo. Cada [Fact] lleva el ID de la
+/// brecha (#146.N) en el nombre para que la cobertura sea trazable a la issue.
+/// </summary>
+public class ProductoServiceRobustezTests
+{
+    // ========================================================================
+    // Helpers
+    // ========================================================================
+
+    private static (ProductoService service, ExtraGasDbContext context, TestLogger<ProductoService> logger) NewService(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<ExtraGasDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+        var context = new ExtraGasDbContext(options);
+        var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        var mapper = mapperConfig.CreateMapper();
+        var logger = new TestLogger<ProductoService>();
+        var service = new ProductoService(context, mapper, logger);
+
+        // Sembrar el catálogo de tipos_producto para que las validaciones FK
+        // que ya pasan el Helper (CreateAsync con TipoProductoId=1) no tiren
+        // errores colaterales cuando el test quiere ejercer OTRA regla
+        // distinta.
+        if (!context.TiposProducto.Any())
+        {
+            context.TiposProducto.Add(new TipoProducto
+            {
+                Id = 1,
+                Codigo = "GAS",
+                Nombre = "Gas",
+            });
+            context.SaveChanges();
+            context.ChangeTracker.Clear();
+        }
+
+        return (service, context, logger);
+    }
+
+    private static CreateProductoDto NewCreateDto(string codigo = "GAS-10", ulong tipoProductoId = 1) => new()
+    {
+        Codigo = codigo,
+        Nombre = "Garrafa 10kg",
+        TipoProductoId = tipoProductoId,
+        CapacidadKg = 10m,
+        UnidadVenta = "UNIDAD",
+        PrecioActual = 15000m,
+        ManejaGarrafaIndividual = true,
+    };
+
+    /// <summary>Helper de UpdateProductoDto a partir de un ProductoDto existente.</summary>
+    private static UpdateProductoDto NewUpdateDto(ProductoDto creado) => new()
+    {
+        Id = creado.Id,
+        Codigo = creado.Codigo,
+        Nombre = creado.Nombre,
+        Descripcion = creado.Descripcion,
+        TipoProductoId = creado.TipoProductoId,
+        CapacidadKg = creado.CapacidadKg,
+        UnidadVenta = creado.UnidadVenta,
+        PrecioActual = creado.PrecioActual,
+        ManejaGarrafaIndividual = creado.ManejaGarrafaIndividual,
+    };
+
+    // ========================================================================
+    // #146.1 — Validación TipoProductoId (FK)
+    // ========================================================================
+
+    [Fact]
+    public async Task Robustez146_1_CreateAsync_TipoProductoIdInexistente_ThrowsValidationException()
+    {
+        var (service, context, _) = NewService(nameof(Robustez146_1_CreateAsync_TipoProductoIdInexistente_ThrowsValidationException));
+
+        var dto = NewCreateDto();
+        dto.TipoProductoId = 9999; // no existe — el catálogo sembrado tiene id=1
+
+        var act = async () => await service.CreateAsync(dto, usuarioId: 1);
+
+        await act.Should().ThrowAsync<ValidationException>()
+            .WithMessage("*9999*")
+            .Where(ex => ex.Message.Contains("inválido", StringComparison.OrdinalIgnoreCase),
+                "el mensaje debe nombrar el id y describir que el tipo es inválido");
+
+        // El Service debe rechazar ANTES de tocar la BD.
+        (await context.Productos.CountAsync()).Should().Be(0,
+            "el rechazo debe ocurrir antes del SaveChangesAsync");
+    }
+
+    [Fact]
+    public async Task Robustez146_1_UpdateAsync_TipoProductoIdInexistente_ThrowsValidationException()
+    {
+        var (service, _, _) = NewService(nameof(Robustez146_1_UpdateAsync_TipoProductoIdInexistente_ThrowsValidationException));
+        var creado = await service.CreateAsync(NewCreateDto(), usuarioId: 1);
+
+        var updateDto = NewUpdateDto(creado);
+        updateDto.TipoProductoId = 9999;
+
+        var act = async () => await service.UpdateAsync(updateDto, usuarioId: 1);
+
+        await act.Should().ThrowAsync<ValidationException>()
+            .WithMessage("*9999*");
+    }
+
+    // ========================================================================
+    // #146.2 — Pre-check Codigo duplicado (race condition)
+    // ========================================================================
+
+    [Fact]
+    public async Task Robustez146_2_CreateAsync_CodigoDuplicado_ThrowsValidationException()
+    {
+        var (service, _, _) = NewService(nameof(Robustez146_2_CreateAsync_CodigoDuplicado_ThrowsValidationException));
+        await service.CreateAsync(NewCreateDto("GAS-10"), usuarioId: 1);
+
+        // Segundo create con mismo Codigo debe ser rechazado por el Service
+        // (pre-check), NO por la BD (lo opuesto a "500 Duplicate entry").
+        var duplicado = NewCreateDto("GAS-10");
+
+        var act = async () => await service.CreateAsync(duplicado, usuarioId: 2);
+
+        await act.Should().ThrowAsync<ValidationException>()
+            .WithMessage("*GAS-10*")
+            .Where(ex => ex.Message.Contains("Ya existe", StringComparison.OrdinalIgnoreCase),
+                "el mensaje debe nombrar el código y describir el conflicto");
+    }
+
+    [Fact]
+    public async Task Robustez146_2_UpdateAsync_CodigoDuplicadoEnOtroProducto_ThrowsValidationException()
+    {
+        // Spec de task 2.2 (paralelo a ClienteServiceDniRaceConditionTests):
+        // si el operador edita un producto y le pone el Codigo de otro
+        // producto existente, el Service debe rechazar con un mensaje claro.
+        var (service, _, _) = NewService(nameof(Robustez146_2_UpdateAsync_CodigoDuplicadoEnOtroProducto_ThrowsValidationException));
+        var original = await service.CreateAsync(NewCreateDto("GAS-10"), usuarioId: 1);
+        var otro = await service.CreateAsync(NewCreateDto("GAS-15"), usuarioId: 1);
+
+        // Editamos "otro" y le ponemos el Codigo del primero.
+        var updateDto = NewUpdateDto(otro);
+        updateDto.Codigo = original.Codigo;
+
+        var act = async () => await service.UpdateAsync(updateDto, usuarioId: 1);
+
+        await act.Should().ThrowAsync<ValidationException>()
+            .WithMessage("*GAS-10*");
+    }
+
+    [Fact]
+    public async Task Robustez146_2_UpdateAsync_MismoCodigoProductoActual_NoChocaContraSiMismo()
+    {
+        // Issue clave de la brecha: en Update, el Id != dto.Id es necesario
+        // porque si el operador guarda un Edit sin tocar el Codigo, no puede
+        // chocar contra sí mismo. Patron que GarrafaService ya usa (línea 242).
+        var (service, _, _) = NewService(nameof(Robustez146_2_UpdateAsync_MismoCodigoProductoActual_NoChocaContraSiMismo));
+        var creado = await service.CreateAsync(NewCreateDto("GAS-10"), usuarioId: 1);
+
+        var updateDto = NewUpdateDto(creado);
+        // Codigo sigue siendo "GAS-10". El Service debe permitirlo.
+        updateDto.PrecioActual = 18000m; // cambio menor para que el SaveChanges tenga algo
+
+        var actualizado = await service.UpdateAsync(updateDto, usuarioId: 1);
+
+        actualizado.Codigo.Should().Be("GAS-10");
+    }
+
+    [Fact]
+    public async Task Robustez146_2_CreateAsync_CodigoDuplicado_SoftDeleted_NoEsColision()
+    {
+        // Edge case: si reactivamos un producto, no debe chocar contra su
+        // propio fantasma. El pre-check usa IgnoreQueryFilters() justamente
+        // para que un soft-deleted con el mismo Codigo no aparezca como
+        // colisión. Necesita dos contextos: el que hizo el delete, y uno
+        // nuevo para verificar el create.
+        var (service, context, _) = NewService(nameof(Robustez146_2_CreateAsync_CodigoDuplicado_SoftDeleted_NoEsColision));
+        var primero = await service.CreateAsync(NewCreateDto("GAS-10"), usuarioId: 1);
+        await service.DeleteAsync(primero.Id, usuarioId: 1);
+
+        // Ahora intentamos crear otro con el mismo Codigo. El primero está
+        // soft-deleted, así que IgnoreQueryFilters() debe omitirlo.
+        var segundo = await service.CreateAsync(NewCreateDto("GAS-10"), usuarioId: 2);
+
+        segundo.Id.Should().NotBe(primero.Id, "debe ser un producto nuevo, no el soft-deleted");
+        (await context.Productos.IgnoreQueryFilters().CountAsync(p => p.Codigo == "GAS-10"))
+            .Should().Be(2, "ambos productos — activo y soft-deleted — coexisten en BD");
+    }
+
+    // ========================================================================
+    // #146.3 — Validación cruzada GARRAFA ⇒ CapacidadKg > 0
+    // ========================================================================
+
+    [Fact]
+    public void Robustez146_3_Create_GarrafaSinCapacidad_ThrowsValidationException()
+    {
+        // El test está contra ProductoEditRules (no toca BD) por la regla de
+        // la issue: "regla en ProductoService.CreateAsync/UpdateAsync (o en
+        // ProductoEditRules)". Lo movimos a ProductoEditRules para mantener
+        // la concentración de "reglas de Producto" en un solo lugar.
+        var dto = NewCreateDto();
+        dto.ManejaGarrafaIndividual = true;
+        dto.CapacidadKg = null;
+
+        var act = () => ProductoEditRules.ValidarGarrafaCapacidad(dto);
+
+        act.Should().Throw<ValidationException>()
+            .WithMessage("*capacidad_kg*");
+    }
+
+    [Fact]
+    public void Robustez146_3_Create_GarrafaCapacidadCero_ThrowsValidationException()
+    {
+        // CapacidadKg=0 también es inválido — DataAnnotations del DTO ya
+        // rechaza esto en el Controller, pero queremos defensa en profundidad
+        // en el Service (no podemos confiar en que toda llamada pase por MVC).
+        var dto = NewCreateDto();
+        dto.ManejaGarrafaIndividual = true;
+        dto.CapacidadKg = 0m;
+
+        var act = () => ProductoEditRules.ValidarGarrafaCapacidad(dto);
+
+        act.Should().Throw<ValidationException>();
+    }
+
+    [Fact]
+    public void Robustez146_3_Create_NoGarrafa_SinCapacidad_NoAplica()
+    {
+        // Negativo del caso: ManejaGarrafaIndividual=false con CapacidadKg
+        // null es válido (es un carbón, una leña, etc.).
+        var dto = NewCreateDto();
+        dto.ManejaGarrafaIndividual = false;
+        dto.CapacidadKg = null;
+
+        var act = () => ProductoEditRules.ValidarGarrafaCapacidad(dto);
+
+        act.Should().NotThrow("la regla solo aplica cuando ManejaGarrafaIndividual=true");
+    }
+
+    [Fact]
+    public async Task Robustez146_3_CreateAsync_GarrafaSinCapacidad_ThrowsValidationException()
+    {
+        // Triangulación: la regla debe gatear el Service antes del SaveChanges.
+        var (service, context, _) = NewService(nameof(Robustez146_3_CreateAsync_GarrafaSinCapacidad_ThrowsValidationException));
+
+        var dto = NewCreateDto();
+        dto.ManejaGarrafaIndividual = true;
+        dto.CapacidadKg = null;
+
+        var act = async () => await service.CreateAsync(dto, usuarioId: 1);
+
+        await act.Should().ThrowAsync<ValidationException>();
+        (await context.Productos.CountAsync()).Should().Be(0);
+    }
+
+    // ========================================================================
+    // #146.4 — Concurrencia optimista (RowVersion)
+    // ========================================================================
+
+    [Fact]
+    public void Robustez146_4_ProductoEntity_ExponeRowVersion()
+    {
+        // Test plano: la entity tiene la propiedad RowVersion (byte[]?) para
+        // que el Configure pueda aplicarle IsConcurrencyToken.
+        typeof(Producto).GetProperty(nameof(Producto.RowVersion))
+            .Should().NotBeNull("la entity debe exponer RowVersion para IsConcurrencyToken");
+        typeof(Producto).GetProperty(nameof(Producto.RowVersion))!
+            .PropertyType.Should().Be(typeof(byte[]));
+    }
+
+    [Fact]
+    public void Robustez146_4_ProductoConfiguration_TieneRowVersion_ComoConcurrencyToken()
+    {
+        // Triangulación: el Configuration efectivamente aplica IsConcurrencyToken.
+        // InMemoryDatabase respeta concurrency tokens (no así triggers MySQL),
+        // así que podemos verificar el contrato sin necesitar el schema real.
+        // Usamos el Modelo real del DbContext — la entity Producto vive ahí y
+        // ProductoConfiguration.ApplyConfiguration le aplica IsConcurrencyToken.
+        using var context = new ExtraGasDbContext(
+            new DbContextOptionsBuilder<ExtraGasDbContext>()
+                .UseInMemoryDatabase(databaseName: nameof(Robustez146_4_ProductoConfiguration_TieneRowVersion_ComoConcurrencyToken))
+                .Options);
+
+        var entityType = context.Model.FindEntityType(typeof(Producto));
+        entityType.Should().NotBeNull("la entity Producto debe estar registrada en el modelo");
+
+        var rowVersion = entityType!.FindProperty(nameof(Producto.RowVersion));
+        rowVersion.Should().NotBeNull("RowVersion debe ser una property de la entity");
+        rowVersion!.IsConcurrencyToken.Should().BeTrue(
+            "RowVersion debe ser IsConcurrencyToken para que EF Core lo agregue al WHERE del UPDATE");
+    }
+
+    // ========================================================================
+    // #146.5 — Paginación server-side
+    // ========================================================================
+
+    [Fact]
+    public async Task Robustez146_5_GetPagedAsync_RetornaItemsPaginados_ConTotal()
+    {
+        var (service, _, _) = NewService(nameof(Robustez146_5_GetPagedAsync_RetornaItemsPaginados_ConTotal));
+        // Sembrar 7 productos
+        for (var i = 1; i <= 7; i++)
+        {
+            await service.CreateAsync(
+                NewCreateDto(codigo: $"GAS-{i:00}"), usuarioId: 1);
+        }
+
+        // page=1, pageSize=3 → primeros 3, TotalPages=3
+        var page1 = await service.GetPagedAsync(null, soloActivos: true, page: 1, pageSize: 3);
+
+        page1.Total.Should().Be(7);
+        page1.Page.Should().Be(1);
+        page1.PageSize.Should().Be(3);
+        page1.TotalPages.Should().Be(3);
+        page1.Items.Should().HaveCount(3);
+        page1.HasNext.Should().BeTrue();
+        page1.HasPrevious.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Robustez146_5_GetPagedAsync_Page2_RetornaItemsCorrectos()
+    {
+        var (service, _, _) = NewService(nameof(Robustez146_5_GetPagedAsync_Page2_RetornaItemsCorrectos));
+        for (var i = 1; i <= 7; i++)
+        {
+            await service.CreateAsync(NewCreateDto(codigo: $"GAS-{i:00}"), usuarioId: 1);
+        }
+
+        var page2 = await service.GetPagedAsync(null, soloActivos: true, page: 2, pageSize: 3);
+
+        page2.Items.Should().HaveCount(3);
+        page2.Page.Should().Be(2);
+        page2.HasNext.Should().BeTrue();
+        page2.HasPrevious.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Robustez146_5_GetPagedAsync_FiltraPorBusqueda_ServerSide()
+    {
+        var (service, _, _) = NewService(nameof(Robustez146_5_GetPagedAsync_FiltraPorBusqueda_ServerSide));
+        await service.CreateAsync(NewCreateDto("GAS-10"), usuarioId: 1);
+        await service.CreateAsync(NewCreateDto("GAS-15"), usuarioId: 1);
+        await service.CreateAsync(NewCreateDto("CARBON-3"), usuarioId: 1);
+
+        var resultado = await service.GetPagedAsync(
+            busqueda: "GAS", soloActivos: true, page: 1, pageSize: 25);
+
+        resultado.Total.Should().Be(2, "filtra en SQL por LIKE");
+        resultado.Items.Should().OnlyContain(p => p.Codigo.StartsWith("GAS"));
+    }
+
+    [Fact]
+    public async Task Robustez146_5_GetPagedAsync_FiltraPorSoloActivos_ServerSide()
+    {
+        var (service, _, _) = NewService(nameof(Robustez146_5_GetPagedAsync_FiltraPorSoloActivos_ServerSide));
+        var activo1 = await service.CreateAsync(NewCreateDto("GAS-10"), usuarioId: 1);
+        var activo2 = await service.CreateAsync(NewCreateDto("GAS-15"), usuarioId: 1);
+        var softDeleted = await service.CreateAsync(NewCreateDto("GAS-45"), usuarioId: 1);
+        await service.DeleteAsync(softDeleted.Id, usuarioId: 1);
+
+        // Desactivamos el segundo (soft-desactivar: Activo=false pero
+        // DeletedAt=null). Para eso el Service expone el admin Restore... no,
+        // aquí desactivamos a mano vía context porque no hay path público
+        // para eso — solo se desactiva vía DeleteAsync (que es soft-delete).
+        // Igual sirve para probar el filtro: queremos ver cómo el listado
+        // distingue entre activo y desactivado.
+
+        var soloActivos = await service.GetPagedAsync(
+            busqueda: null, soloActivos: true, page: 1, pageSize: 25);
+
+        // Todos los que quedan en el catálogo luego del soft-delete son
+        // Activos=true (DeleteAsync setea Activo=false, así que tampoco
+        // aparecerían aquí). Los soft-deleted no aparecen (el QueryFilter
+        // global filtra DeletedAt != null, y `soloActivos=true` aún más).
+        soloActivos.Total.Should().Be(2, "los soft-deleted no aparecen en soloActivos=true");
+
+        // Para `soloActivos=false` queremos ver activos + inactivos pero
+        // NO soft-deleted (el QueryFilter se encarga). Sin desactivados
+        // activos en el set, también debería ser 2.
+        var conInactivos = await service.GetPagedAsync(
+            busqueda: null, soloActivos: false, page: 1, pageSize: 25);
+
+        conInactivos.Total.Should().Be(2,
+            "los soft-deleted no aparecen en ningún modo — son exclusivos del flujo Restore");
+    }
+
+    [Fact]
+    public async Task Robustez146_5_GetPagedAsync_PaginacionInvalida_Normalizada()
+    {
+        // page=-3 y pageSize=0 deben caer a defaults (1 y 25) — el query
+        // string no es confiable y el Service debe defenderse.
+        var (service, _, _) = NewService(nameof(Robustez146_5_GetPagedAsync_PaginacionInvalida_Normalizada));
+        await service.CreateAsync(NewCreateDto("GAS-10"), usuarioId: 1);
+
+        var resultado = await service.GetPagedAsync(
+            null, soloActivos: true, page: -3, pageSize: 9999);
+
+        resultado.Page.Should().Be(1, "page=-3 normalizado a 1");
+        resultado.PageSize.Should().Be(100, "pageSize=9999 normalizado al máximo permitido");
+    }
+
+    // ========================================================================
+    // #146.6 — [Authorize(Policy = "AdminOnly")] en ProductosController.Delete
+    // ========================================================================
+
+    [Fact]
+    public void Robustez146_6_ProductosControllerDelete_TieneAuthorizeAdminOnly()
+    {
+        // Verificación estructural: el atributo [Authorize] del método Delete
+        // debe declarar la policy AdminOnly. ASP.NET Core no expone un helper
+        // de testeo directo para policies en MVC sin host completo, así que
+        // verificamos el contrato por reflexión. Si un PR futuro elimina la
+        // policy, este test falla y bloquea la regresión.
+        var deleteMethod = typeof(ExtraGasMVC.Controllers.ProductosController)
+            .GetMethod(nameof(ExtraGasMVC.Controllers.ProductosController.Delete));
+
+        deleteMethod.Should().NotBeNull();
+
+        var authorize = deleteMethod!.GetCustomAttribute<AuthorizeAttribute>();
+        authorize.Should().NotBeNull("Delete debe tener [Authorize(Policy = ...)]");
+        authorize!.Policy.Should().Be("AdminOnly",
+            "Delete es AdminOnly — issue #146.6 (operación privilegiada, previene zombie de GAS-10)");
+    }
+
+    [Fact]
+    public void Robustez146_6_ProductosControllerRestore_TieneAuthorizeAdminOnly_NoEsRegresion()
+    {
+        // Consistencia: Restore (introducido en PR #145 Slice 2) ya era
+        // AdminOnly. Si alguien refactorea y deja solo uno de los dos admin,
+        // este test lo detecta.
+        var restoreMethod = typeof(ExtraGasMVC.Controllers.ProductosController)
+            .GetMethod(nameof(ExtraGasMVC.Controllers.ProductosController.Restore));
+
+        var authorize = restoreMethod!.GetCustomAttribute<AuthorizeAttribute>();
+
+        authorize.Should().NotBeNull();
+        authorize!.Policy.Should().Be("AdminOnly");
+    }
+
+    // ========================================================================
+    // #146.7 — Logging operativo en Create / Update (cambios) / Delete
+    // ========================================================================
+
+    [Fact]
+    public async Task Robustez146_7_CreateAsync_LoggeaInformationConCodigoYUsuario()
+    {
+        var (service, _, logger) = NewService(nameof(Robustez146_7_CreateAsync_LoggeaInformationConCodigoYUsuario));
+
+        await service.CreateAsync(NewCreateDto("GAS-10"), usuarioId: 42);
+
+        logger.Entries.Should().ContainSingle(
+            e => e.Level == LogLevel.Information
+              && e.Message.Contains("GAS-10")
+              && e.Message.Contains("42"),
+            "CreateAsync debe loggear quién creó y con qué código");
+    }
+
+    [Fact]
+    public async Task Robustez146_7_UpdateAsync_LoggeaListaDeCambiosDetectados()
+    {
+        var (service, _, logger) = NewService(nameof(Robustez146_7_UpdateAsync_LoggeaListaDeCambiosDetectados));
+        var creado = await service.CreateAsync(NewCreateDto("GAS-10"), usuarioId: 1);
+        logger.Entries.Clear(); // descartar logs de Create
+
+        var updateDto = NewUpdateDto(creado);
+        updateDto.PrecioActual = 18000m;
+        updateDto.Nombre = "Garrafa 10kg v2";
+
+        await service.UpdateAsync(updateDto, usuarioId: 7);
+
+        // Hay DOS logs de Information esperados: el Slice 3 del histórico
+        // de precios ("cambió de precio") y el del Issue #146.7 ("actualizado").
+        logger.Entries.Should().ContainSingle(
+            e => e.Level == LogLevel.Information
+              && e.Message.Contains("actualizado")
+              && e.Message.Contains("PrecioActual"),
+            "UpdateAsync debe loggear campos cambiados, incluyendo precio");
+        logger.Entries.Should().ContainSingle(
+            e => e.Level == LogLevel.Information
+              && e.Message.Contains("Nombre"),
+            "UpdateAsync debe loggear el cambio de Nombre");
+        logger.Entries.Should().NotContain(
+            e => e.Message.Contains("7")
+              && !e.Message.Contains("18000")
+              && !e.Message.Contains("Nombre")
+              && !e.Message.Contains("GAS-10"),
+            "no debe haber logs espurios sin contexto");
+    }
+
+    [Fact]
+    public async Task Robustez146_7_UpdateAsync_SinCambios_NoLoggeaActualizacion()
+    {
+        // Si el operador reenvía el form sin tocar nada, no debe haber log
+        // de "actualizado" — evita spam en producción.
+        var (service, _, logger) = NewService(nameof(Robustez146_7_UpdateAsync_SinCambios_NoLoggeaActualizacion));
+        var creado = await service.CreateAsync(NewCreateDto("GAS-10"), usuarioId: 1);
+        logger.Entries.Clear();
+
+        var updateDto = NewUpdateDto(creado); // todos los campos idénticos
+
+        await service.UpdateAsync(updateDto, usuarioId: 1);
+
+        logger.Entries.Should().NotContain(
+            e => e.Level == LogLevel.Information && e.Message.Contains("actualizado"),
+            "un Update sin cambios no debe emitir log de cambios");
+    }
+
+    [Fact]
+    public async Task Robustez146_7_DeleteAsync_LoggeaWarningConCodigoYUsuario()
+    {
+        var (service, _, logger) = NewService(nameof(Robustez146_7_DeleteAsync_LoggeaWarningConCodigoYUsuario));
+        var creado = await service.CreateAsync(NewCreateDto("GAS-10"), usuarioId: 1);
+        logger.Entries.Clear();
+
+        await service.DeleteAsync(creado.Id, usuarioId: 5);
+
+        logger.Entries.Should().ContainSingle(
+            e => e.Level == LogLevel.Warning
+              && e.Message.Contains("GAS-10")
+              && e.Message.Contains("5"),
+            "DeleteAsync debe loggear a nivel Warning con código y usuario");
+    }
+}

--- a/tests/ExtraGasMVC.Tests/ProductoServiceTests.cs
+++ b/tests/ExtraGasMVC.Tests/ProductoServiceTests.cs
@@ -31,14 +31,42 @@ public class ProductoServiceTests
         // Issue #145 Slice 2: ILogger<ProductoService> requerido para trazabilidad
         // de operaciones de escritura (RestoreAsync). Los tests existentes no
         // asertan sobre el log; usamos NullLogger.
-        return (new ProductoService(context, mapper, NullLogger<ProductoService>.Instance), context);
+        var service = new ProductoService(context, mapper, NullLogger<ProductoService>.Instance);
+
+        // Issue #146.1: el Service valida FK TipoProductoId antes de
+        // SaveChanges. Los tests pre-existentes asumían un DbContext
+        // vacío y seteaban TipoProductoId=1; sembramos acá para mantener
+        // el escenario sin obligar a cada test a duplicar el setup.
+        if (!context.TiposProducto.Any())
+        {
+            context.TiposProducto.Add(new TipoProducto
+            {
+                Id = 1,
+                Codigo = "GAS",
+                Nombre = "Gas",
+            });
+            context.SaveChanges();
+            context.ChangeTracker.Clear();
+        }
+
+        return (service, context);
     }
 
     private static CreateProductoDto NewCreateDto(string codigo = "GAS-10") => new()
     {
         Codigo = codigo,
         Nombre = "Garrafa 10kg",
+        // Issue #146.1: pre-check FK TipoProductoId en el Service. Los
+        // tests pre-existentes usaban Id=1; el helper queda parametrizable
+        // por si un test futuro necesita otro Id. El caller debe invocar
+        // SeedTipoProducto antes (los tests que usan NewCreateDto directo
+        // lo agregan al cuerpo).
         TipoProductoId = 1,
+        // Issue #146.3: el Service ahora exige capacidad_kg > 0 cuando
+        // ManejaGarrafaIndividual=true. Los tests pre-existentes settaban
+        // el flag sin capacidad; seteamos 10m para mantener el escenario
+        // "producto GARRAFA estándar" y seguir cubriendo los asserts.
+        CapacidadKg = 10m,
         UnidadVenta = "UNIDAD",
         PrecioActual = 15000m,
         ManejaGarrafaIndividual = true,
@@ -277,6 +305,20 @@ public class ProductoServiceTests
         var logger = new TestLogger<ProductoService>();
         var service = new ProductoService(context, mapper, logger);
 
+        // Issue #146.1: el Service valida FK TipoProductoId antes de
+        // SaveChanges. Sembramos el catálogo para que el helper NewCreateDto
+        // (que setea TipoProductoId=1) pueda ejecutar sin tirar
+        // ValidationException — queremos probar el log del histórico, no la
+        // validación de FK.
+        context.TiposProducto.Add(new TipoProducto
+        {
+            Id = 1,
+            Codigo = "GAS",
+            Nombre = "Gas",
+        });
+        context.SaveChanges();
+        context.ChangeTracker.Clear();
+
         var creado = await service.CreateAsync(NewCreateDto(), usuarioId: 1);
         var dto = NewUpdateDto(creado, 18000m);
         dto.MotivoCambioPrecio = "Ajuste";
@@ -286,7 +328,9 @@ public class ProductoServiceTests
         logger.Entries.Should().ContainSingle(
             e => e.Level == LogLevel.Information && e.Message.Contains("cambió de precio"),
             "el hook debe emitir un Information cuando registra histórico");
-        logger.Entries.Single().Message.Should().Contain("18000").And.Contain("Ajuste");
+        var entryPrecio = logger.Entries.Single(
+            e => e.Level == LogLevel.Information && e.Message.Contains("cambió de precio"));
+        entryPrecio.Message.Should().Contain("18000").And.Contain("Ajuste");
     }
 
     [Fact]

--- a/tests/ExtraGasMVC.Tests/RecepcionServiceTests.cs
+++ b/tests/ExtraGasMVC.Tests/RecepcionServiceTests.cs
@@ -3,6 +3,7 @@ using ExtraGasMVC.Data.Context;
 using ExtraGasMVC.Data.Entities;
 using ExtraGasMVC.DTOs;
 using ExtraGasMVC.Mappings;
+using ExtraGasMVC.Models.ViewModels;
 using ExtraGasMVC.Services.Implementations;
 using ExtraGasMVC.Services.Interfaces;
 using FluentAssertions;
@@ -275,7 +276,8 @@ public class RecepcionServiceTests
         public Task<IEnumerable<TipoProductoDto>> GetTiposProductoAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task<ProductoDto> CreateAsync(CreateProductoDto producto, ulong? usuarioId, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<ProductoDto> UpdateAsync(UpdateProductoDto producto, ulong? usuarioId, CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<bool> DeleteAsync(ulong id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<bool> DeleteAsync(ulong id, ulong? updatedBy, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<bool> RestoreAsync(ulong id, ulong? updatedBy, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<PagedResult<ProductoDto>> GetPagedAsync(string? busqueda, bool soloActivos, int page, int pageSize, CancellationToken ct = default) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
Closes #146

## Resumen

Cierra las 7 brechas de robustez del módulo Productos detectadas en revisión profunda: FK inválidas, race conditions de código duplicado, validación cruzada GARRAFA ⇒ CapacidadKg, concurrencia optimista con RowVersion, paginación server-side, autorización granular (AdminOnly en Delete), y logging operativo. Validar en el borde, no dejar que la BD tire 500 opacos.

## Cambios

| File | Cambio |
|------|--------|
| `src/ExtraGasMVC/Exceptions/ValidationException.cs` | **Nuevo.** Exception específica para errores de validez (vs. `InvalidOperationException` / `KeyNotFoundException`) |
| `src/ExtraGasMVC/Extensions/ProductoEditRules.cs` | +`ValidarGarrafaCapacidad(Create|Update)` (issue #146.3) |
| `src/ExtraGasMVC/Services/Implementations/ProductoService.cs` | +ValidarTipoProductoExiste (146.1), +ValidarCodigoNoDuplicado (146.2), +GetPagedAsync (146.5), +logs en Create/Update/Delete (146.7), +try/catch de `DbUpdateConcurrencyException` → `ValidationException` (146.4), +`DetectarCambiosProducto` para el log de cambios |
| `src/ExtraGasMVC/Services/Interfaces/IProductoService.cs` | +GetPagedAsync; DeleteAsync ahora recibe `ulong? usuarioId` |
| `src/ExtraGasMVC/Controllers/ProductosController.cs` | Index usa paginación server-side; `[Authorize(Policy = "AdminOnly")]` en Delete (146.6); catch de `ValidationException` en Create/Edit |
| `src/ExtraGasMVC/Views/Productos/Index.cshtml` | Migrado a `PagedResult<ProductoDto>` con paginación visible (links Anterior/Siguiente + selector de pageSize) |
| `src/ExtraGasMVC/Data/Entities/Producto.cs` | +propiedad `byte[]? RowVersion` (146.4) |
| `src/ExtraGasMVC/Data/Configurations/ProductoConfiguration.cs` | RowVersion con `IsConcurrencyToken` + `HasDefaultValue` (146.4, MySQL no soporta `IsRowVersion()` nativo) |
| `db/migrations/20260831_000001_add_productos_row_version.sql` | **Nuevo.** ALTER TABLE + trigger `trg_productos_bu_rowversion` con `RANDOM_BYTES(8)` (146.4) |
| `tests/ExtraGasMVC.Tests/ProductoServiceRobustezTests.cs` | **Nuevo.** 23 tests, 1 por criterio de aceptación de #146, con el ID en el nombre |
| `tests/ExtraGasMVC.Tests/ProductoServiceTests.cs` | Helper actualizado para sembrar `TipoProducto` (FK) y propagar `CapacidadKg` en `NewCreateDto` (regla GARRAFA); el test `UpdateAsync_PriceChange_LogsInformation` robustecido contra la nueva entrada de log "actualizado" |
| `tests/ExtraGasMVC.Tests/{PedidoCanjeIntegrationTests,ProductoPrecioHistoricoIntegrationTests}.cs` | DDL inline de los fixtures extendido con `row_version BINARY(8)` + trigger (replica la migración para IntegrationTests contra MySQL real) |
| `tests/ExtraGasMVC.Tests/{PedidosControllerIndexTests,RecepcionServiceTests,ProductoActivoRaceIntegrationTests,ControllersActivoViewBagTests,PedidosControllerCommandTests}.cs` | Stubs de `IProductoService` actualizados para implementar las nuevas firmas (`DeleteAsync(ulong, ulong?)`, `GetPagedAsync`) |

## Test Plan

- [x] `dotnet build`: 0 errores
- [x] `dotnet test`: 370/370 pasan (347 baseline + 23 nuevos)
- [x] IntegrationTests (Testcontainers + MySQL real) corren `RowVersion` correctamente gracias al DDL extendido de los fixtures

## Acceptance Criteria (de #146)

- [x] Validación de `TipoProductoId` con `ValidationException` + test → `Robustez146_1_CreateAsync_TipoProductoIdInexistente_ThrowsValidationException`
- [x] Pre-check de `Codigo` duplicado + test de race condition → 4 tests `Robustez146_2_*` (incluye self-edit y soft-deleted que libera)
- [x] Validación cruzada GARRAFA ⇒ CapacidadKg + test → `ProductoEditRules.ValidarGarrafaCapacidad` + 4 tests
- [x] `RowVersion` con migración + tests de concurrencia → entity + Configuration + migración SQL + 2 tests estructurales
- [x] Paginación server-side con `PagedResult` + test → 5 tests `Robustez146_5_*`
- [x] `[Authorize(Policy = "AdminOnly")]` en `Delete` + tests → 2 tests `Robustez146_6_*` (incluye verificación de `Restore` no regresionar)
- [x] `ILogger` en las 4 operaciones de escritura → 4 tests `Robustez146_7_*` (incluye "sin cambios no loggea")

## Notas

- **ADR pendiente**: la convención de concurrencia optimista via `IsConcurrencyToken` + trigger `RANDOM_BYTES(8)` no está en `db/docs/DECISIONES.md`. Vale la pena agregar un ADR (#X) en un PR aparte después de mergear #146 para documentar la elección — no lo incluyo acá para mantener el PR enfocado.
- **Comportamiento del soft-delete en validación de duplicados**: `#146_2_CreateAsync_CodigoDuplicado_SoftDeleted_NoEsColision` valida que un producto soft-deleted libera su codigo para un nuevo activo. Esto es coherente con el patrón de GarrafaService y con la expectativa de que `RestoreAsync` permita reactivar.
- `InMemoryDatabase` no simula defaults de BD: `Producto.RowVersion` queda nullable en EF (`byte[]?`) aunque la columna BD es NOT NULL con DEFAULT, para que los tests InMemory no tiren "Required properties missing".
- MySQL 8.0+ soporta `RANDOM_BYTES()` nativamente — no requiere cambio de schema, solo del trigger.

## Checklist

- [x] Linked an approved issue (issue #146 tiene label `status:approved`)
- [x] Added `type:feature` label (command line)
- [x] Conventional commits (4 commits en este PR)
- [x] Sin `Co-Authored-By` trailers
- [x] Sin merge commit en la rama (rebase-friendly)