### PR TITLE
[Productos] #147 Slice 2/3: audit_log infrastructure + per-field emission from UpdateAsync

### DIFF
--- a/db/migrations/20260901_000001_create_audit_log.sql
+++ b/db/migrations/20260901_000001_create_audit_log.sql
@@ -1,0 +1,78 @@
+-- =============================================================================
+-- 20260901_000001_create_audit_log.sql
+-- Creates audit_log table: append-only log of field-level changes for any
+-- business entity. The product of issue #147 (slice 2).
+--
+-- Why a single generic table (not per-entity):
+--   - One place to query "who changed X for entity Y in window W" across the
+--     whole app, without per-module audit table sprawl.
+--   - Reusable by future modules (Clientes, Pedidos, etc.) — they just pick
+--     their `entidad` value (e.g. 'Producto', 'Cliente') and write rows.
+--
+-- Schema notes:
+--   - `entidad` is a string discriminator, not an FK. Allowing new entity
+--     types to use the table without ALTER.
+--   - `registro_id` is BIGINT UNSIGNED — matches the convention of every PK
+--     in the schema. No FK to the source table (audit log must survive
+--     deletion of the source row, and FKs would force ON DELETE behavior
+--     that hides evidence).
+--   - `user_id` is BIGINT UNSIGNED NULL — nullable for system-initiated
+--     changes (backfills, scheduled jobs). No FK to usuarios for the same
+--     reason: the audit log must outlive a user delete.
+--   - `valor_anterior` / `valor_nuevo` are TEXT — accommodates any serialized
+--     value (decimals, bools as "true"/"false", enum codes, JSON snippets).
+--   - `changed_at` is the only timestamp; this table is append-only.
+--   - NO `created_by`/`updated_by`/`deleted_at` — the table itself is the
+--     auditor, doesn't need its own audit trail.
+--
+-- Indexes:
+--   - idx_audit_entidad_registro: covers "all changes for entity X id Y"
+--     and "last change for X" (the most common query).
+--   - idx_audit_changed_at: covers "changes between T1 and T2" for
+--     time-window reports.
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS + CREATE INDEX ... (with manual
+-- existence guard to stay portable across MySQL versions that don't support
+-- CREATE INDEX IF NOT EXISTS).
+-- =============================================================================
+
+USE extragas;
+
+CREATE TABLE IF NOT EXISTS `audit_log` (
+  `id`              BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `entidad`         VARCHAR(50)     NOT NULL,
+  `registro_id`     BIGINT UNSIGNED NOT NULL,
+  `campo`           VARCHAR(100)    NOT NULL,
+  `valor_anterior`  TEXT            NULL,
+  `valor_nuevo`     TEXT            NULL,
+  `user_id`         BIGINT UNSIGNED NULL,
+  `changed_at`      DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_audit_entidad_registro` (`entidad`, `registro_id`, `changed_at`),
+  KEY `idx_audit_changed_at` (`changed_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Auditoría genérica append-only de cambios por campo';
+
+-- Index guards (CREATE INDEX IF NOT EXISTS no existe en MySQL 8.x — usamos
+-- information_schema). El CREATE TABLE ya incluye los KEY, pero si la tabla
+-- existía de una corrida previa sin índices, este bloque los crea.
+
+SET @idx1 := (SELECT COUNT(*) FROM information_schema.statistics
+              WHERE table_schema = DATABASE()
+                AND table_name = 'audit_log'
+                AND index_name = 'idx_audit_entidad_registro');
+SET @sql := IF(@idx1 = 0,
+  'CREATE INDEX `idx_audit_entidad_registro` ON `audit_log` (`entidad`, `registro_id`, `changed_at`)',
+  'SELECT "idx_audit_entidad_registro already exists" AS status');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @idx2 := (SELECT COUNT(*) FROM information_schema.statistics
+              WHERE table_schema = DATABASE()
+                AND table_name = 'audit_log'
+                AND index_name = 'idx_audit_changed_at');
+SET @sql := IF(@idx2 = 0,
+  'CREATE INDEX `idx_audit_changed_at` ON `audit_log` (`changed_at`)',
+  'SELECT "idx_audit_changed_at already exists" AS status');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'Tabla audit_log lista' AS status;

--- a/src/ExtraGasMVC/Data/Configurations/AuditLogEntryConfiguration.cs
+++ b/src/ExtraGasMVC/Data/Configurations/AuditLogEntryConfiguration.cs
@@ -1,0 +1,62 @@
+using ExtraGasMVC.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ExtraGasMVC.Data.Configurations;
+
+/// <summary>
+/// Configuración EF para <see cref="AuditLogEntry"/> (issue #147 slice 2).
+/// Mapea a la tabla <c>audit_log</c> creada por la migración
+/// <c>20260901_000001_create_audit_log.sql</c>.
+///
+/// <para>La tabla es append-only: NO se configura ningún FK ni navegación
+/// (ni a la entidad auditada ni a <c>usuarios</c>). La auditoría debe
+/// sobrevivir bajas de ambas. La convención del resto del proyecto
+/// (mapeo manual snake_case) se aplica acá también.</para>
+/// </summary>
+public class AuditLogEntryConfiguration : IEntityTypeConfiguration<AuditLogEntry>
+{
+    public void Configure(EntityTypeBuilder<AuditLogEntry> builder)
+    {
+        builder.ToTable("audit_log");
+
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("id");
+
+        builder.Property(e => e.Entidad)
+            .HasColumnName("entidad")
+            .HasMaxLength(50)
+            .IsRequired();
+
+        builder.Property(e => e.RegistroId).HasColumnName("registro_id");
+
+        builder.Property(e => e.Campo)
+            .HasColumnName("campo")
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(e => e.ValorAnterior)
+            .HasColumnName("valor_anterior")
+            .HasColumnType("text");
+
+        builder.Property(e => e.ValorNuevo)
+            .HasColumnName("valor_nuevo")
+            .HasColumnType("text");
+
+        builder.Property(e => e.UserId).HasColumnName("user_id");
+
+        builder.Property(e => e.ChangedAt)
+            .HasColumnName("changed_at")
+            .HasColumnType("datetime")
+            .ValueGeneratedOnAdd()
+            .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+        // Índices: los crea la migración SQL; los reproducimos acá para que
+        // EF los incluya en el modelo (necesario para EnsureCreated y para
+        // el cache de metadatos de las queries).
+        builder.HasIndex(e => new { e.Entidad, e.RegistroId, e.ChangedAt })
+            .HasDatabaseName("idx_audit_entidad_registro");
+        builder.HasIndex(e => e.ChangedAt)
+            .HasDatabaseName("idx_audit_changed_at");
+    }
+}

--- a/src/ExtraGasMVC/Data/Context/ExtraGasDbContext.cs
+++ b/src/ExtraGasMVC/Data/Context/ExtraGasDbContext.cs
@@ -34,6 +34,11 @@ public class ExtraGasDbContext : DbContext
     public DbSet<Producto> Productos => Set<Producto>();
     public DbSet<ProductoPrecioHistorico> ProductoPreciosHistorico => Set<ProductoPrecioHistorico>();
 
+    // ============== Auditoría genérica (issue #147 slice 2) ==============
+    // Tabla append-only alimentada por IAuditLogger. NO tiene FK a la entidad
+    // auditada ni a usuarios — el log debe sobrevivir bajas de ambos.
+    public DbSet<AuditLogEntry> AuditLog => Set<AuditLogEntry>();
+
     // ============== Pedidos y pagos ==============
     public DbSet<Pedido> Pedidos => Set<Pedido>();
     public DbSet<PedidoItem> PedidoItems => Set<PedidoItem>();

--- a/src/ExtraGasMVC/Data/Entities/AuditLogEntry.cs
+++ b/src/ExtraGasMVC/Data/Entities/AuditLogEntry.cs
@@ -1,0 +1,68 @@
+namespace ExtraGasMVC.Data.Entities;
+
+/// <summary>
+/// Una fila por cambio de campo en cualquier entidad del sistema. La tabla
+/// <c>audit_log</c> es append-only: no tiene <c>created_by</c>,
+/// <c>updated_by</c> ni <c>deleted_at</c> — la tabla misma es la auditoría.
+///
+/// <para>Issue #147 slice 2: el <see cref="IAuditLogger"/> emite una fila
+/// por cada campo modificado cuando un Service hace UPDATE. El
+/// <c>SaveChangesAsync</c> del caller commit las filas en la misma
+/// transacción que la mutación de la entidad auditada — todo o nada.</para>
+///
+/// <para><b>Sin FK a la entidad auditada ni a <c>usuarios</c></b>: el log
+/// debe sobrevivir la baja del registro fuente y la baja del usuario que
+/// hizo el cambio. La integridad referencial lógica se delega al caller
+/// (<c>IAuditLogger</c> usa los IDs como referencia, no como constraint).</para>
+/// </summary>
+public class AuditLogEntry
+{
+    public ulong Id { get; set; }
+
+    /// <summary>
+    /// Tipo de entidad auditada (ej. <c>"Producto"</c>, <c>"Cliente"</c>).
+    /// Es un discriminador string — no FK, para que agregar nuevas entidades
+    /// no requiera migrar esta tabla.
+    /// </summary>
+    public string Entidad { get; set; } = null!;
+
+    /// <summary>
+    /// Id del registro en la tabla fuente (mismo tipo que la PK de la tabla
+    /// auditada). <c>BIGINT UNSIGNED</c> en BD para matchear la convención
+    /// del resto del schema.
+    /// </summary>
+    public ulong RegistroId { get; set; }
+
+    /// <summary>
+    /// Nombre del campo modificado (ej. <c>"PrecioActual"</c>). String, no FK
+    /// a metadatos de la entidad: el contrato es que el caller sabe el
+    /// nombre del campo y lo emite verbatim.
+    /// </summary>
+    public string Campo { get; set; } = null!;
+
+    /// <summary>
+    /// Valor anterior serializado como string. <c>NULL</c> para altas
+    /// (no había valor previo) o cuando la representación textual no aplica.
+    /// </summary>
+    public string? ValorAnterior { get; set; }
+
+    /// <summary>
+    /// Valor nuevo serializado como string. <c>NULL</c> para bajas
+    /// (campo eliminado) o cuando no aplica representación textual.
+    /// </summary>
+    public string? ValorNuevo { get; set; }
+
+    /// <summary>
+    /// <c>usuarios.id</c> del operador que hizo el cambio. <c>NULL</c> para
+    /// cambios system-initiated (backfills, jobs, migraciones). No es FK en
+    /// BD — el log debe sobrevivir la baja del usuario.
+    /// </summary>
+    public ulong? UserId { get; set; }
+
+    /// <summary>
+    /// Timestamp del cambio. <c>DEFAULT CURRENT_TIMESTAMP</c> en BD; el caller
+    /// puede setearlo explícitamente cuando necesita un instante distinto al
+    /// del INSERT (ej. tests con reloj fijo).
+    /// </summary>
+    public DateTime ChangedAt { get; set; }
+}

--- a/src/ExtraGasMVC/Program.cs
+++ b/src/ExtraGasMVC/Program.cs
@@ -71,6 +71,11 @@ builder.Services.AddScoped<IEmailSender, MailKitEmailSender>();
 builder.Services.AddScoped<IEmpleadoService, EmpleadoService>();
 builder.Services.AddScoped<IRecepcionService, RecepcionService>();
 builder.Services.AddScoped<IAuditoriaLoginService, AuditoriaLoginService>();
+// Issue #147 slice 2: IAuditLogger emite filas a la tabla genérica
+// audit_log desde ProductoService.UpdateAsync (y futuros callers).
+// Scoped para compartir el ExtraGasDbContext con el Service que invoca
+// y garantizar atomicidad en el SaveChangesAsync del caller.
+builder.Services.AddScoped<IAuditLogger, AuditLogger>();
 builder.Services.AddSingleton<IPasswordPolicyService, PasswordPolicyService>();
 
 var app = builder.Build();

--- a/src/ExtraGasMVC/Services/Implementations/AuditLogger.cs
+++ b/src/ExtraGasMVC/Services/Implementations/AuditLogger.cs
@@ -1,0 +1,83 @@
+using ExtraGasMVC.Data.Context;
+using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace ExtraGasMVC.Services.Implementations;
+
+/// <summary>
+/// Implementación Scoped de <see cref="IAuditLogger"/> (issue #147 slice 2).
+/// Comparte el <see cref="ExtraGasDbContext"/> con el Service que invoca
+/// (Scoped lifetime = misma instancia por request), por lo que las entries
+/// se acumulan en el change tracker y se persisten junto con la mutación
+/// del caller — atómico.
+///
+/// <para><b>Por qué NO llama SaveChangesAsync</b>: el contrato del interface
+/// es que el logger solo encola. El caller hace un solo SaveChanges
+/// (ProductoService.UpdateAsync → sus cambios de producto + N filas de
+/// audit_log). Si el commit falla, no queda fila huérfana de audit ni un
+/// cambio de producto sin registrar. Si lo inverso (logger persistiera),
+/// un crash entre el SaveChanges del logger y el del caller dejaría la
+/// auditoría sin la mutación que documenta — peor para investigación.</para>
+///
+/// <para><b>Failure handling</b>: si EF rechaza el <c>Add</c> (caso muy raro
+/// porque no validamos constraints — el log no tiene FKs), el catch loggea
+/// y traga. La operación de negocio no debe fallar por un side-effect de
+/// auditoría. Mismo patrón que <see cref="AuditoriaLoginService.RecordAsync"/>.</para>
+/// </summary>
+public class AuditLogger : IAuditLogger
+{
+    private readonly ExtraGasDbContext _context;
+    private readonly ILogger<AuditLogger> _logger;
+
+    public AuditLogger(ExtraGasDbContext context, ILogger<AuditLogger> logger)
+    {
+        _context = context;
+        _logger = logger;
+    }
+
+    public async Task LogChangeAsync(
+        string entidad,
+        long registroId,
+        string campo,
+        string? valorAnterior,
+        string? valorNuevo,
+        long? changedBy,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var entry = new AuditLogEntry
+            {
+                Entidad = entidad,
+                RegistroId = registroId < 0 ? 0UL : (ulong)registroId,
+                Campo = campo,
+                ValorAnterior = valorAnterior,
+                ValorNuevo = valorNuevo,
+                UserId = changedBy.HasValue ? (changedBy.Value < 0 ? 0UL : (ulong)changedBy.Value) : (ulong?)null,
+                ChangedAt = DateTime.UtcNow,
+            };
+
+            // Add es sync (no hay IO en InMemory; en MySQL el INSERT
+            // ocurriría en el SaveChanges del caller). La firma devuelve
+            // Task para homogeneidad con la familia de IAuditLogger.
+            _context.AuditLog.Add(entry);
+        }
+        catch (Exception ex)
+        {
+            // El log nunca debe romper una operación de negocio. Loggeamos
+            // y seguimos — la mutación del caller commit sin la fila de
+            // audit. Si el problema es estructural (schema drift), esto
+            // aparecería en todos los UPDATEs y sería visible en el
+            // monitoring.
+            _logger.LogWarning(ex,
+                "AuditLogger: no se pudo encolar entry para {Entidad}#{RegistroId}.{Campo}",
+                entidad, registroId, campo);
+        }
+
+        // ct es forward al caller vía SaveChangesAsync — el logger no
+        // hace IO asíncrono propio. Await Task.CompletedTask satisface
+        // la firma sin agregar overhead.
+        await Task.CompletedTask;
+    }
+}

--- a/src/ExtraGasMVC/Services/Implementations/ProductoService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ProductoService.cs
@@ -32,17 +32,25 @@ public class ProductoService : IProductoService
     // GetTiposProductoAsync. AddMemoryCache() ya está registrado en
     // Program.cs:16, solo faltaba inyectar.
     private readonly IMemoryCache _cache;
+    // Issue #147 slice 2: IAuditLogger inyectado para emitir filas a la
+    // tabla genérica audit_log cuando UpdateAsync detecta cambios por campo.
+    // Scoped → comparte el ExtraGasDbContext → commit atómico con la
+    // mutación del producto (el logger NO llama SaveChanges por contrato,
+    // ver IAuditLogger XML doc).
+    private readonly IAuditLogger _audit;
 
     public ProductoService(
         ExtraGasDbContext context,
         IMapper mapper,
         ILogger<ProductoService> logger,
-        IMemoryCache cache)
+        IMemoryCache cache,
+        IAuditLogger audit)
     {
         _context = context;
         _mapper = mapper;
         _logger = logger;
         _cache = cache;
+        _audit = audit;
     }
 
     public async Task<ProductoDto?> GetByIdAsync(ulong id, CancellationToken ct = default)
@@ -301,6 +309,12 @@ public class ProductoService : IProductoService
         // last-write-wins silenciosos en otros módulos).
         var cambios = DetectarCambiosProducto(entity, producto);
 
+        // Issue #147 slice 2: snapshot paralelo (estructurado en tuplas)
+        // para emitir filas a audit_log. La diff se hace ANTES del Map
+        // para evitar contaminación: la entity post-Map tiene el valor
+        // del DTO pisado, lo que impediría detectar cambios reales.
+        var cambiosAuditables = DetectarCambiosAuditables(entity, producto);
+
         _mapper.Map(producto, entity);
         // Issue #147 item 6: normalizar Codigo (trim + upper) — mismo
         // tratamiento que CreateAsync. Mantiene invariante "Codigo
@@ -310,6 +324,23 @@ public class ProductoService : IProductoService
         entity.UpdatedAt = DateTime.UtcNow;
         entity.UpdatedBy = usuarioId;
         ProductoEditRules.PreservarFlagsNoEditables(entity, activoOriginal);
+
+        // Issue #147 slice 2: emitir filas de audit_log por cada campo
+        // auditable que difiere. _audit NO llama SaveChanges (contrato
+        // del IAuditLogger) → las filas se commiten en el mismo
+        // SaveChangesAsync de este método, atómicas con la mutación del
+        // producto. Si el commit falla, no queda fila huérfana.
+        foreach (var (campo, oldStr, newStr) in cambiosAuditables)
+        {
+            await _audit.LogChangeAsync(
+                entidad: "Producto",
+                registroId: (long)entity.Id,
+                campo: campo,
+                valorAnterior: oldStr,
+                valorNuevo: newStr,
+                changedBy: usuarioId.HasValue ? (long?)usuarioId.Value : null,
+                ct: ct);
+        }
 
         // Hook de histórico: solo cuando hay cambio real (precioAnterior != 0
         // && precioAnterior != nuevo). Atómico: la fila append-only y el
@@ -550,6 +581,64 @@ public class ProductoService : IProductoService
             cambios.Add($"PrecioActual: {entity.PrecioActual} → {dto.PrecioActual}");
         if (entity.ManejaGarrafaIndividual != dto.ManejaGarrafaIndividual)
             cambios.Add($"ManejaGarrafaIndividual: {entity.ManejaGarrafaIndividual} → {dto.ManejaGarrafaIndividual}");
+
+        return cambios;
+    }
+
+    /// <summary>
+    /// Issue #147 slice 2: devuelve una tupla estructurada (campo, oldStr,
+    /// newStr) por cada campo auditable que difiere entre la entity y el
+    /// DTO. La usa <see cref="UpdateAsync"/> para emitir filas a
+    /// <c>audit_log</c> vía <see cref="IAuditLogger"/>.
+    ///
+    /// <para><b>Excluidos explícitamente</b>:</para>
+    /// <list type="bullet">
+    ///   <item><c>CreatedAt</c>, <c>UpdatedAt</c>, <c>CreatedBy</c>,
+    ///   <c>UpdatedBy</c>, <c>DeletedAt</c>, <c>RowVersion</c> — metadata
+    ///   autogestionada por el Service, no cambios del operador.</item>
+    ///   <item><c>Activo</c> — flag de estado, no viene en el DTO y se
+    ///   preserva desde la BD vía <see cref="ProductoEditRules.PreservarFlagsNoEditables"/>.
+    ///   Si en el futuro se permite cambiarlo desde el form, agregar acá
+    ///   la comparación contra el DTO.</item>
+    ///   <item><c>StockMinimo</c>, <c>UnidadVentaId</c> — no existen en
+    ///   la entity actual (el catálogo de unidades FK llega en slice 3).</item>
+    /// </list>
+    ///
+    /// <para>Serialización: <c>decimal</c> → string InvariantCulture (sin
+    /// coma/punto regional), <c>bool</c> → "true"/"false", nullable →
+    /// <c>null</c> cuando el valor es null. La columna <c>campo</c> ya
+    /// discrimina; no hace falta JOIN a tablas de tipos.</para>
+    /// </summary>
+    private static List<(string Campo, string? Old, string? New)> DetectarCambiosAuditables(
+        Producto entity, UpdateProductoDto dto)
+    {
+        var inv = System.Globalization.CultureInfo.InvariantCulture;
+        var cambios = new List<(string, string?, string?)>();
+
+        if (!string.Equals(entity.Codigo, dto.Codigo, StringComparison.Ordinal))
+            cambios.Add(("Codigo", entity.Codigo, dto.Codigo));
+        if (!string.Equals(entity.Nombre, dto.Nombre, StringComparison.Ordinal))
+            cambios.Add(("Nombre", entity.Nombre, dto.Nombre));
+        if (!string.Equals(entity.Descripcion, dto.Descripcion, StringComparison.Ordinal))
+            cambios.Add(("Descripcion", entity.Descripcion, dto.Descripcion));
+        if (entity.TipoProductoId != dto.TipoProductoId)
+            cambios.Add(("TipoProductoId",
+                entity.TipoProductoId.ToString(inv),
+                dto.TipoProductoId.ToString(inv)));
+        if (entity.CapacidadKg != dto.CapacidadKg)
+            cambios.Add(("CapacidadKg",
+                entity.CapacidadKg?.ToString(inv),
+                dto.CapacidadKg?.ToString(inv)));
+        if (!string.Equals(entity.UnidadVenta, dto.UnidadVenta, StringComparison.Ordinal))
+            cambios.Add(("UnidadVenta", entity.UnidadVenta, dto.UnidadVenta));
+        if (entity.PrecioActual != dto.PrecioActual)
+            cambios.Add(("PrecioActual",
+                entity.PrecioActual.ToString(inv),
+                dto.PrecioActual.ToString(inv)));
+        if (entity.ManejaGarrafaIndividual != dto.ManejaGarrafaIndividual)
+            cambios.Add(("ManejaGarrafaIndividual",
+                entity.ManejaGarrafaIndividual ? "true" : "false",
+                dto.ManejaGarrafaIndividual ? "true" : "false"));
 
         return cambios;
     }

--- a/src/ExtraGasMVC/Services/Interfaces/IAuditLogger.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IAuditLogger.cs
@@ -1,0 +1,45 @@
+namespace ExtraGasMVC.Services.Interfaces;
+
+/// <summary>
+/// Emite filas a la tabla <c>audit_log</c> para registrar cambios
+/// field-level sobre entidades del dominio.
+///
+/// <para>Issue #147 slice 2 — contrato de uso:</para>
+/// <list type="bullet">
+///   <item><b>Una llamada por campo modificado</b>. El caller itera sobre
+///   los campos que difieren y emite un <c>LogChangeAsync</c> por cada
+///   uno. Más simple que un batch overload y trazable 1:1 al diff.</item>
+///   <item><b>NO llama <c>SaveChangesAsync</c></b>. La entry se agrega al
+///   change tracker del <c>ExtraGasDbContext</c> compartido (la misma
+///   instancia Scoped que el Service que invoca). El <c>SaveChangesAsync</c>
+///   del caller persiste la entry de audit JUNTO con su propia mutación en
+///   la misma transacción — todo o nada. Si la mutación falla, no queda
+///   fila huérfana en <c>audit_log</c>.</item>
+///   <item><b>Failure handling</b>: si la inserción en <c>audit_log</c>
+///   fallara por una razón no controlada (constraint rara, schema drift),
+///   el catch interno loggea y traga. La auditoría es un side-effect, no
+///   debe bloquear la operación de negocio.</item>
+/// </list>
+/// </summary>
+public interface IAuditLogger
+{
+    /// <summary>
+    /// Encola una fila en el change tracker describiendo el cambio de un
+    /// campo. NO persiste — el caller hace <c>SaveChangesAsync</c>.
+    /// </summary>
+    /// <param name="entidad">Tipo de entidad auditada (ej. <c>"Producto"</c>).</param>
+    /// <param name="registroId">Id del registro en la tabla fuente.</param>
+    /// <param name="campo">Nombre del campo modificado (ej. <c>"PrecioActual"</c>).</param>
+    /// <param name="valorAnterior">Valor viejo serializado a string. <c>null</c> para altas.</param>
+    /// <param name="valorNuevo">Valor nuevo serializado a string. <c>null</c> cuando no aplica.</param>
+    /// <param name="changedBy"><c>usuarios.id</c> del operador, o <c>null</c> para cambios del sistema.</param>
+    /// <param name="ct">Token de cancelación (forwarded al caller vía SaveChangesAsync).</param>
+    Task LogChangeAsync(
+        string entidad,
+        long registroId,
+        string campo,
+        string? valorAnterior,
+        string? valorNuevo,
+        long? changedBy,
+        CancellationToken ct = default);
+}

--- a/tests/ExtraGasMVC.Tests/Integration/ProductoAuditLogIntegrationTests.cs
+++ b/tests/ExtraGasMVC.Tests/Integration/ProductoAuditLogIntegrationTests.cs
@@ -1,0 +1,467 @@
+using AutoMapper;
+using ExtraGasMVC.Data.Context;
+using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Mappings;
+using ExtraGasMVC.Services.Implementations;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using MySqlConnector;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
+using Testcontainers.MySql;
+using Xunit;
+
+namespace ExtraGasMVC.Tests.Integration;
+
+/// <summary>
+/// Integration test del hook de auditoría (issue #147 slice 2) contra
+/// MySQL real en container Docker. Valida end-to-end:
+///
+///   1. La migración <c>20260901_000001_create_audit_log.sql</c> corre
+///      contra la BD efímera y crea la tabla con el shape esperado.
+///   2. <c>ProductoService.UpdateAsync</c> emite filas a <c>audit_log</c>
+///      y esas filas son legibles vía EF Core (no solo el change tracker).
+///   3. La emisión es atómica con la mutación del producto: si el commit
+///      pasa, ambas cosas están; si falla, ninguna.
+///
+/// Patrón: IClassFixture comparte container entre tests; cada test crea
+/// su base, aplica el schema mínimo + la migración bajo prueba, y dropea
+/// la base al final. Réplica del patrón de
+/// <see cref="ProductoPrecioHistoricoIntegrationTests"/>.
+/// </summary>
+public class ProductoAuditLogIntegrationTests
+    : IClassFixture<ProductoAuditLogMySqlFixture>
+{
+    private readonly ProductoAuditLogMySqlFixture _fixture;
+
+    public ProductoAuditLogIntegrationTests(ProductoAuditLogMySqlFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task Migracion_CreaTablaAuditLog_ConColumnasEsperadas()
+    {
+        // Aplica la migración y verifica con information_schema que la
+        // tabla audit_log tiene las 8 columnas exactas del design.
+        var dbName = await _fixture.NewDatabaseAsync(nameof(Migracion_CreaTablaAuditLog_ConColumnasEsperadas));
+        try
+        {
+            await _fixture.ApplyMigrationAsync(dbName);
+
+            var columnas = await _fixture.GetColumnNamesAsync(dbName, "audit_log");
+            columnas.Should().BeEquivalentTo(
+                new[]
+                {
+                    "id",
+                    "entidad",
+                    "registro_id",
+                    "campo",
+                    "valor_anterior",
+                    "valor_nuevo",
+                    "user_id",
+                    "changed_at",
+                },
+                options => options.WithStrictOrdering(),
+                "el schema debe coincidir 1:1 con el design (incluido snake_case)");
+        }
+        finally
+        {
+            await _fixture.DropDatabaseAsync(dbName);
+        }
+    }
+
+    [Fact]
+    public async Task Migracion_CreaIndiceCompuesto()
+    {
+        // Spec scenario "composite index exists": idx_audit_entidad_registro
+        // sobre (entidad, registro_id, changed_at). La migración lo crea;
+        // validamos que efectivamente quedó registrado.
+        var dbName = await _fixture.NewDatabaseAsync(nameof(Migracion_CreaIndiceCompuesto));
+        try
+        {
+            await _fixture.ApplyMigrationAsync(dbName);
+
+            (await _fixture.IndexExistsAsync(dbName, "audit_log", "idx_audit_entidad_registro"))
+                .Should().BeTrue("el composite index es obligatorio por el spec");
+            (await _fixture.IndexExistsAsync(dbName, "audit_log", "idx_audit_changed_at"))
+                .Should().BeTrue("el index sobre changed_at cubre queries temporales");
+        }
+        finally
+        {
+            await _fixture.DropDatabaseAsync(dbName);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateAsync_EmitsAuditLogRow_ReadableFromMySql()
+    {
+        // End-to-end: el hook de audit_log escribe filas que sobreviven
+        // el commit. Releemos con EF contra la BD real y verificamos shape
+        // y contenido.
+        var context = await _fixture.NewDbContextAsync(
+            nameof(UpdateAsync_EmitsAuditLogRow_ReadableFromMySql));
+        try
+        {
+            // Seed: producto con precio inicial + un usuario (FK user_id).
+            var producto = new Producto
+            {
+                Codigo = "GAS-10",
+                Nombre = "Garrafa 10kg",
+                TipoProductoId = 1,
+                CapacidadKg = 10m,
+                UnidadVenta = "UNIDAD",
+                PrecioActual = 1000m,
+                ManejaGarrafaIndividual = true,
+                Activo = true,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                CreatedBy = 1,
+                UpdatedBy = 1,
+            };
+            context.Productos.Add(producto);
+            await context.SaveChangesAsync();
+
+            var mapper = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>()).CreateMapper();
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var audit = new AuditLogger(context, NullLogger<AuditLogger>.Instance);
+            var service = new ProductoService(
+                context, mapper, NullLogger<ProductoService>.Instance, cache, audit);
+
+            // Update: cambio de precio 1000 → 1500 con userId=1.
+            var dto = new UpdateProductoDto
+            {
+                Id = producto.Id,
+                Codigo = producto.Codigo,
+                Nombre = producto.Nombre,
+                TipoProductoId = producto.TipoProductoId,
+                CapacidadKg = producto.CapacidadKg,
+                UnidadVenta = producto.UnidadVenta,
+                PrecioActual = 1500m,
+                ManejaGarrafaIndividual = producto.ManejaGarrafaIndividual,
+            };
+
+            await service.UpdateAsync(dto, usuarioId: 1);
+
+            // Releer con un context fresco desde la BD para confirmar que
+            // el row está persistido (no solo en el change tracker).
+            using var verifyContext = _fixture.NewDbContextForDatabase(
+                context.Database.GetDbConnection().Database);
+            var entry = await verifyContext.AuditLog
+                .AsNoTracking()
+                .SingleAsync();
+            entry.Entidad.Should().Be("Producto");
+            entry.RegistroId.Should().Be(producto.Id);
+            entry.Campo.Should().Be("PrecioActual");
+            entry.ValorAnterior.Should().Be("1000",
+                "decimal serializado InvariantCulture sin separador de miles");
+            entry.ValorNuevo.Should().Be("1500");
+            entry.UserId.Should().Be(1UL);
+            entry.ChangedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(1),
+                "ChangedAt por DEFAULT CURRENT_TIMESTAMP, dentro de la ventana del test");
+        }
+        finally
+        {
+            await _fixture.DropDatabaseAsyncForDbContext(context);
+        }
+    }
+
+    [Fact]
+    public async Task Migracion_ReEjecutarEsNoOp_NoProduceError()
+    {
+        // Idempotencia: la migración se puede correr dos veces (re-run
+        // manual, retry) sin fallar — la protección nativa es
+        // CREATE TABLE IF NOT EXISTS + guards de information_schema
+        // para los índices.
+        var dbName = await _fixture.NewDatabaseAsync(nameof(Migracion_ReEjecutarEsNoOp_NoProduceError));
+        try
+        {
+            await _fixture.ApplyMigrationAsync(dbName);
+            await _fixture.ApplyMigrationAsync(dbName); // segunda corrida
+
+            // Sigue teniendo 8 columnas y los índices.
+            (await _fixture.GetColumnNamesAsync(dbName, "audit_log"))
+                .Should().HaveCount(8);
+            (await _fixture.IndexExistsAsync(dbName, "audit_log", "idx_audit_entidad_registro"))
+                .Should().BeTrue();
+        }
+        finally
+        {
+            await _fixture.DropDatabaseAsync(dbName);
+        }
+    }
+}
+
+/// <summary>
+/// Fixture xUnit que arranca un container MySQL via Testcontainers. Replica
+/// la estructura de <see cref="ProductoPrecioHistoricoMySqlFixture"/> para
+/// que la convención sea reconocible.
+/// </summary>
+public class ProductoAuditLogMySqlFixture : IAsyncLifetime
+{
+    private const string MysqlImage = "mysql:8.0";
+    private const string RootPassword = "test_root_pwd";
+    private const string RootUsername = "root";
+    private const string DatabasePrefix = "aud_";
+
+    private MySqlContainer? _container;
+    private string? _rootConnectionString;
+
+    public async Task InitializeAsync()
+    {
+        _container = new MySqlBuilder()
+            .WithImage(MysqlImage)
+            .WithUsername(RootUsername)
+            .WithPassword(RootPassword)
+            .WithDatabase("placeholder_db")
+            .Build();
+        await _container.StartAsync();
+        _rootConnectionString = _container.GetConnectionString();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_container is not null)
+            await _container.DisposeAsync();
+    }
+
+    public string GetConnectionString(string dbName)
+    {
+        // MySqlConnector desactiva variables de usuario (@idx1, @sql) por
+        // default. La migración 20260901_000001 usa el patrón
+        // information_schema + PREPARE/EXECUTE para los guards de índices,
+        // que requiere AllowUserVariables=true en la connection string.
+        return _rootConnectionString!
+            .Replace("database=placeholder_db", $"database={dbName}", StringComparison.OrdinalIgnoreCase)
+            + ";AllowUserVariables=true";
+    }
+
+    public async Task<string> NewDatabaseAsync(string testName)
+    {
+        _ = testName;
+        var dbName = DatabasePrefix + Guid.NewGuid().ToString("N");
+
+        await using var conn = new MySqlConnection(_rootConnectionString);
+        await conn.OpenAsync();
+        await using var create = conn.CreateCommand();
+        create.CommandText = $"CREATE DATABASE `{dbName}` " +
+                             "CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;";
+        await create.ExecuteNonQueryAsync();
+
+        return dbName;
+    }
+
+    public async Task DropDatabaseAsync(string dbName)
+    {
+        await using var conn = new MySqlConnection(_rootConnectionString);
+        await conn.OpenAsync();
+        await using var drop = conn.CreateCommand();
+        drop.CommandText = $"DROP DATABASE IF EXISTS `{dbName}`;";
+        await drop.ExecuteNonQueryAsync();
+    }
+
+    public async Task ApplyMigrationAsync(string dbName)
+    {
+        var connString = GetConnectionString(dbName);
+        await using var conn = new MySqlConnection(connString);
+        await conn.OpenAsync();
+
+        await using (var schema = conn.CreateCommand())
+        {
+            schema.CommandText = SchemaMinimal;
+            await schema.ExecuteNonQueryAsync();
+        }
+
+        await using (var mig = conn.CreateCommand())
+        {
+            mig.CommandText = LoadMigrationSql();
+            await mig.ExecuteNonQueryAsync();
+        }
+    }
+
+    public async Task<bool> IndexExistsAsync(string dbName, string tableName, string indexName)
+    {
+        await using var conn = new MySqlConnection(GetConnectionString(dbName));
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT COUNT(*) FROM information_schema.statistics
+            WHERE table_schema = @db
+              AND table_name = @tbl
+              AND index_name = @idx
+            """;
+        cmd.Parameters.AddWithValue("@db", dbName);
+        cmd.Parameters.AddWithValue("@tbl", tableName);
+        cmd.Parameters.AddWithValue("@idx", indexName);
+        var count = Convert.ToInt32(await cmd.ExecuteScalarAsync());
+        return count > 0;
+    }
+
+    public async Task<List<string>> GetColumnNamesAsync(string dbName, string tableName)
+    {
+        await using var conn = new MySqlConnection(GetConnectionString(dbName));
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT column_name FROM information_schema.columns
+            WHERE table_schema = @db AND table_name = @tbl
+            ORDER BY ordinal_position
+            """;
+        cmd.Parameters.AddWithValue("@db", dbName);
+        cmd.Parameters.AddWithValue("@tbl", tableName);
+        var nombres = new List<string>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            nombres.Add(reader.GetString(0));
+        }
+        return nombres;
+    }
+
+    public async Task<ExtraGasDbContext> NewDbContextAsync(string testName)
+    {
+        _ = testName;
+        var dbName = DatabasePrefix + Guid.NewGuid().ToString("N");
+
+        await using (var conn = new MySqlConnection(_rootConnectionString))
+        {
+            await conn.OpenAsync();
+            await using var create = conn.CreateCommand();
+            create.CommandText = $"CREATE DATABASE `{dbName}` " +
+                                 "CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;";
+            await create.ExecuteNonQueryAsync();
+        }
+
+        await ApplyMigrationAsync(dbName);
+
+        return BuildDbContext(dbName);
+    }
+
+    /// <summary>
+    /// Construye un DbContext fresco contra la base ya creada. Usado por
+    /// el test que necesita releer audit_log después del commit del
+    /// Service (un context nuevo evita cualquier cache de change tracker).
+    /// </summary>
+    public ExtraGasDbContext NewDbContextForDatabase(string dbName)
+    {
+        return BuildDbContext(dbName);
+    }
+
+    public async Task DropDatabaseAsyncForDbContext(ExtraGasDbContext context)
+    {
+        var dbName = context.Database.GetDbConnection().Database;
+        await context.DisposeAsync();
+        await DropDatabaseAsync(dbName);
+    }
+
+    private ExtraGasDbContext BuildDbContext(string dbName)
+    {
+        var connString = GetConnectionString(dbName);
+        var serverVersion = ServerVersion.Create(
+            new Version(8, 0, 0), ServerType.MySql);
+        var options = new DbContextOptionsBuilder<ExtraGasDbContext>()
+            .UseMySql(connString, serverVersion)
+            .Options;
+        return new ExtraGasDbContext(options);
+    }
+
+    private static string LoadMigrationSql()
+    {
+        // Carga el archivo de migración desde el repo. Acopla el test al
+        // path real — garantía de que probamos lo que se va a deployar.
+        var repoRoot = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+        var migrationPath = Path.Combine(repoRoot, "db", "migrations",
+            "20260901_000001_create_audit_log.sql");
+        if (!File.Exists(migrationPath))
+        {
+            throw new FileNotFoundException(
+                $"Migración bajo prueba no encontrada en {migrationPath}");
+        }
+        var raw = File.ReadAllText(migrationPath);
+
+        // Strip del "USE extragas;" porque los tests apuntan a bases
+        // efímeras (aud_<guid>).
+        return System.Text.RegularExpressions.Regex.Replace(
+            raw, @"^\s*USE\s+\w+\s*;\s*$",
+            "",
+            System.Text.RegularExpressions.RegexOptions.Multiline);
+    }
+
+    /// <summary>
+    /// Schema mínimo para que la FK de Producto a tipos_producto/usuarios
+    /// tenga destino, y el seed del test pueda insertar sin colisión.
+    /// Réplica del schema real reducido a lo que estos tests necesitan.
+    /// Idempotente (todos los CREATE con IF NOT EXISTS).
+    /// </summary>
+    private const string SchemaMinimal = """
+        CREATE TABLE IF NOT EXISTS tipos_producto (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            codigo VARCHAR(30) NOT NULL,
+            nombre VARCHAR(100) NOT NULL,
+            descripcion VARCHAR(255) NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            UNIQUE KEY uq_tipos_producto_codigo (codigo)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+        CREATE TABLE IF NOT EXISTS usuarios (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            username VARCHAR(50) NOT NULL,
+            password_hash VARCHAR(255) NOT NULL,
+            email VARCHAR(150) NULL,
+            rol_id BIGINT UNSIGNED NOT NULL,
+            activo TINYINT(1) NOT NULL DEFAULT 1,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+        CREATE TABLE IF NOT EXISTS productos (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            codigo VARCHAR(30) NOT NULL,
+            nombre VARCHAR(150) NOT NULL,
+            descripcion VARCHAR(255) NULL,
+            tipo_producto_id BIGINT UNSIGNED NOT NULL,
+            capacidad_kg DECIMAL(8,2) NULL,
+            unidad_venta VARCHAR(20) NOT NULL DEFAULT 'UNIDAD',
+            precio_actual DECIMAL(12,2) NOT NULL DEFAULT 0,
+            maneja_garrafa_individual TINYINT(1) NOT NULL DEFAULT 0,
+            activo TINYINT(1) NOT NULL DEFAULT 1,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            created_by BIGINT UNSIGNED NULL,
+            updated_by BIGINT UNSIGNED NULL,
+            deleted_at DATETIME NULL,
+            row_version BINARY(8) NOT NULL DEFAULT 0x0000000000000000,
+            CONSTRAINT fk_productos_tipo FOREIGN KEY (tipo_producto_id) REFERENCES tipos_producto(id),
+            UNIQUE KEY uq_productos_codigo (codigo)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+        -- producto_precios_historico: hook append-only de UpdateAsync
+        -- (issue #145 slice 3). El Service inserta una fila en el mismo
+        -- SaveChangesAsync que la mutación del producto, por lo que la
+        -- tabla DEBE existir para que el test e2e pueda ejercitar el
+        -- path de audit_log.
+        CREATE TABLE IF NOT EXISTS producto_precios_historico (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            producto_id BIGINT UNSIGNED NOT NULL,
+            precio_anterior DECIMAL(12,2) NOT NULL,
+            precio_nuevo DECIMAL(12,2) NOT NULL,
+            motivo_cambio_precio VARCHAR(255) NULL,
+            changed_by BIGINT UNSIGNED NULL,
+            changed_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            KEY idx_pph_producto_changed (producto_id, changed_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+        DROP TRIGGER IF EXISTS trg_productos_bu_rowversion;
+        CREATE TRIGGER trg_productos_bu_rowversion
+        BEFORE UPDATE ON productos
+        FOR EACH ROW
+            SET NEW.row_version = RANDOM_BYTES(8);
+
+        INSERT IGNORE INTO tipos_producto (id, codigo, nombre) VALUES (1, 'GAS', 'Gas');
+        INSERT IGNORE INTO usuarios (id, username, password_hash, rol_id) VALUES (1, 'system', 'noop', 1);
+        """;
+}

--- a/tests/ExtraGasMVC.Tests/ProductoAuditLogTests.cs
+++ b/tests/ExtraGasMVC.Tests/ProductoAuditLogTests.cs
@@ -1,0 +1,190 @@
+using AutoMapper;
+using ExtraGasMVC.Data.Context;
+using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Mappings;
+using ExtraGasMVC.Services.Implementations;
+using ExtraGasMVC.Services.Interfaces;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Tests del hook de auditoría genérica en <see cref="ProductoService.UpdateAsync"/>
+/// (issue #147 slice 2).
+///
+/// <para>Contrato del spec scenario "Auditoría de cambios por campo":</para>
+/// <list type="bullet">
+///   <item>Un cambio real de un campo auditable debe dejar exactamente UNA
+///   fila en <c>audit_log</c> con <c>entidad="Producto"</c>, <c>registro_id</c>
+///   del producto, <c>campo</c> = nombre del campo, <c>valor_anterior</c>/
+///   <c>valor_nuevo</c> como string, y <c>user_id</c> del operator.</item>
+///   <item>Un UPDATE sin cambios (no-op) NO debe generar filas.</item>
+///   <item>Cambios en múltiples campos generan múltiples filas (1:1).</item>
+/// </list>
+/// </summary>
+public class ProductoAuditLogTests
+{
+    private static (ProductoService service, ExtraGasDbContext context) NewService(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<ExtraGasDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+        var context = new ExtraGasDbContext(options);
+        var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        var mapper = mapperConfig.CreateMapper();
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var audit = new AuditLogger(context, NullLogger<AuditLogger>.Instance);
+        var service = new ProductoService(
+            context, mapper, NullLogger<ProductoService>.Instance, cache, audit);
+
+        if (!context.TiposProducto.Any())
+        {
+            context.TiposProducto.Add(new TipoProducto { Id = 1, Codigo = "GAS", Nombre = "Gas" });
+            context.SaveChanges();
+            context.ChangeTracker.Clear();
+        }
+
+        return (service, context);
+    }
+
+    private static CreateProductoDto NewCreateDto(string codigo = "GAS-10") => new()
+    {
+        Codigo = codigo,
+        Nombre = "Garrafa 10kg",
+        TipoProductoId = 1,
+        CapacidadKg = 10m,
+        UnidadVenta = "UNIDAD",
+        PrecioActual = 1000m,
+        ManejaGarrafaIndividual = true,
+    };
+
+    private static UpdateProductoDto NewUpdateDto(ProductoDto creado, decimal? nuevoPrecio = null) => new()
+    {
+        Id = creado.Id,
+        Codigo = creado.Codigo,
+        Nombre = creado.Nombre,
+        Descripcion = creado.Descripcion,
+        TipoProductoId = creado.TipoProductoId,
+        CapacidadKg = creado.CapacidadKg,
+        UnidadVenta = creado.UnidadVenta,
+        PrecioActual = nuevoPrecio ?? creado.PrecioActual,
+        ManejaGarrafaIndividual = creado.ManejaGarrafaIndividual,
+        MotivoCambioPrecio = null,
+    };
+
+    [Fact]
+    public async Task UpdateAsync_PriceChange_EmitsOneAuditLogRow()
+    {
+        // Spec scenario "precio change emits one row":
+        // PrecioActual 1000 → 1500 con userId=42 → exactamente una fila
+        // con campo="PrecioActual", valor_anterior="1000", valor_nuevo="1500",
+        // user_id=42.
+        var (service, context) = NewService(nameof(UpdateAsync_PriceChange_EmitsOneAuditLogRow));
+        var creado = await service.CreateAsync(NewCreateDto(), usuarioId: 1);
+
+        await service.UpdateAsync(NewUpdateDto(creado, nuevoPrecio: 1500m), usuarioId: 42);
+
+        var entries = await context.AuditLog.AsNoTracking().ToListAsync();
+        entries.Should().ContainSingle(
+            "un solo cambio de precio debe dejar exactamente una fila en audit_log");
+        var entry = entries[0];
+        entry.Entidad.Should().Be("Producto");
+        entry.RegistroId.Should().Be(creado.Id);
+        entry.Campo.Should().Be("PrecioActual");
+        entry.ValorAnterior.Should().Be("1000",
+            "PrecioActual anterior serializado con la representación que el Service eligió");
+        entry.ValorNuevo.Should().Be("1500");
+        entry.UserId.Should().Be(42UL);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_NoChange_EmitsZeroAuditLogRows()
+    {
+        // Spec scenario "no-op update emits zero rows": el operador
+        // reenvía el form sin tocar nada → no hay diff → no se loguea.
+        var (service, context) = NewService(nameof(UpdateAsync_NoChange_EmitsZeroAuditLogRows));
+        var creado = await service.CreateAsync(NewCreateDto(), usuarioId: 1);
+
+        await service.UpdateAsync(NewUpdateDto(creado), usuarioId: 1);
+
+        var entries = await context.AuditLog.AsNoTracking().ToListAsync();
+        entries.Should().BeEmpty(
+            "un Update sin cambios reales no debe generar filas de audit");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_MultipleFieldChange_EmitsOneRowPerChangedField()
+    {
+        // Triangulación: cambiar 3 campos en el mismo UPDATE debe dejar
+        // 3 filas (no 1, no 4+). Esto valida que la iteración es por
+        // campo y no por Update.
+        var (service, context) = NewService(nameof(UpdateAsync_MultipleFieldChange_EmitsOneRowPerChangedField));
+        var creado = await service.CreateAsync(NewCreateDto(), usuarioId: 1);
+
+        var dto = new UpdateProductoDto
+        {
+            Id = creado.Id,
+            Codigo = creado.Codigo,
+            Nombre = "Garrafa 10kg v2",         // cambio 1
+            Descripcion = "Nueva descripción",   // cambio 2
+            TipoProductoId = creado.TipoProductoId,
+            CapacidadKg = creado.CapacidadKg,
+            UnidadVenta = creado.UnidadVenta,
+            PrecioActual = 1500m,                // cambio 3
+            ManejaGarrafaIndividual = creado.ManejaGarrafaIndividual,
+        };
+        await service.UpdateAsync(dto, usuarioId: 7);
+
+        var entries = await context.AuditLog.AsNoTracking().ToListAsync();
+        entries.Should().HaveCount(3, "1 fila por cada campo modificado (Nombre + Descripcion + PrecioActual)");
+        entries.Select(e => e.Campo).Should().BeEquivalentTo(new[] { "Nombre", "Descripcion", "PrecioActual" });
+        entries.Should().OnlyContain(e => e.Entidad == "Producto");
+        entries.Should().OnlyContain(e => e.RegistroId == creado.Id);
+        entries.Should().OnlyContain(e => e.UserId == 7UL);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_AuditEntryChangedAt_IsWithinCallWindow()
+    {
+        // Smoke test: la fila de audit lleva un ChangedAt now-ish.
+        // Importante para el orden temporal cuando se hacen varios updates
+        // consecutivos sobre el mismo producto.
+        var (service, context) = NewService(nameof(UpdateAsync_AuditEntryChangedAt_IsWithinCallWindow));
+        var creado = await service.CreateAsync(NewCreateDto(), usuarioId: 1);
+
+        var before = DateTime.UtcNow.AddSeconds(-1);
+        await service.UpdateAsync(NewUpdateDto(creado, nuevoPrecio: 1500m), usuarioId: 1);
+        var after = DateTime.UtcNow.AddSeconds(1);
+
+        var entry = await context.AuditLog.AsNoTracking().SingleAsync();
+        entry.ChangedAt.Should().BeOnOrAfter(before).And.BeOnOrBefore(after);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_AuditLog_AtomicWithProductUpdate()
+    {
+        // Contrato atómico (design §"IAuditLogger" + "Transaction model"):
+        // la fila de audit y el cambio del producto viven en el mismo
+        // SaveChangesAsync. Si el commit falla, no queda fila huérfana.
+        // Verificamos que tras un UpdateAsync exitoso, AMBAS escrituras
+        // son visibles. (El caso negativo — SaveChanges fallido — se cubre
+        // en la rama concurrencia del UpdateAsync, fuera de scope de este
+        // test.)
+        var (service, context) = NewService(nameof(UpdateAsync_AuditLog_AtomicWithProductUpdate));
+        var creado = await service.CreateAsync(NewCreateDto(), usuarioId: 1);
+
+        await service.UpdateAsync(NewUpdateDto(creado, nuevoPrecio: 1500m), usuarioId: 1);
+
+        var productoActualizado = await context.Productos.AsNoTracking()
+            .FirstAsync(p => p.Id == creado.Id);
+        productoActualizado.PrecioActual.Should().Be(1500m,
+            "el cambio del producto debe estar persistido");
+        (await context.AuditLog.CountAsync()).Should().Be(1,
+            "la fila de audit debe estar persistida en la misma transacción");
+    }
+}

--- a/tests/ExtraGasMVC.Tests/ProductoPrecioHistoricoIntegrationTests.cs
+++ b/tests/ExtraGasMVC.Tests/ProductoPrecioHistoricoIntegrationTests.cs
@@ -551,5 +551,26 @@ public class ProductoPrecioHistoricoMySqlFixture : IAsyncLifetime
         -- apuntan a usuarios(id) y productos(id); sembramos solo lo mínimo.
         INSERT IGNORE INTO tipos_producto (id, codigo, nombre) VALUES (1, 'GAS', 'Gas');
         INSERT IGNORE INTO usuarios (id, username, password_hash, rol_id) VALUES (1, 'system', 'noop', 1);
+
+        -- Issue #147 slice 2: ProductoService.UpdateAsync ahora emite
+        -- filas a audit_log en el mismo SaveChangesAsync que la mutación
+        -- del producto. Si la tabla no existe, el SaveChanges revienta
+        -- y estos tests focused de producto_precios_historico se rompen
+        -- con un error colateral. Creamos la tabla mínima con el shape
+        -- de la migración 20260901_000001_create_audit_log.sql para
+        -- que la atomicidad no nos sabotee el path bajo prueba.
+        CREATE TABLE IF NOT EXISTS audit_log (
+            id              BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            entidad         VARCHAR(50)     NOT NULL,
+            registro_id     BIGINT UNSIGNED NOT NULL,
+            campo           VARCHAR(100)    NOT NULL,
+            valor_anterior  TEXT            NULL,
+            valor_nuevo     TEXT            NULL,
+            user_id         BIGINT UNSIGNED NULL,
+            changed_at      DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (id),
+            KEY idx_audit_entidad_registro (entidad, registro_id, changed_at),
+            KEY idx_audit_changed_at (changed_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
         """;
 }

--- a/tests/ExtraGasMVC.Tests/ProductoPrecioHistoricoIntegrationTests.cs
+++ b/tests/ExtraGasMVC.Tests/ProductoPrecioHistoricoIntegrationTests.cs
@@ -233,7 +233,11 @@ public class ProductoPrecioHistoricoIntegrationTests
             // (cache de GetTiposProductoAsync). MemoryCache fresh por test.
             var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
                 new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
-            var service = new ProductoService(context, mapper, NullLogger<ProductoService>.Instance, cache);
+            // Issue #147 slice 2: IAuditLogger agregado al ctor. Comparte
+            // el mismo DbContext para que las filas de audit commit junto
+            // con la mutación del producto (atomicidad transaccional).
+            var audit = new AuditLogger(context, NullLogger<AuditLogger>.Instance);
+            var service = new ProductoService(context, mapper, NullLogger<ProductoService>.Instance, cache, audit);
 
             // Update con cambio de precio 1000 → 1500 + motivo.
             var dto = new UpdateProductoDto

--- a/tests/ExtraGasMVC.Tests/ProductoServiceRobustezTests.cs
+++ b/tests/ExtraGasMVC.Tests/ProductoServiceRobustezTests.cs
@@ -46,7 +46,9 @@ public class ProductoServiceRobustezTests
         // (la clave de cache es constante).
         var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
             new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
-        var service = new ProductoService(context, mapper, logger, cache);
+        // Issue #147 slice 2: IAuditLogger agregado al ctor.
+        var audit = new AuditLogger(context, NullLogger<AuditLogger>.Instance);
+        var service = new ProductoService(context, mapper, logger, cache, audit);
 
         // Sembrar el catálogo de tipos_producto para que las validaciones FK
         // que ya pasan el Helper (CreateAsync con TipoProductoId=1) no tiren

--- a/tests/ExtraGasMVC.Tests/ProductoServiceTests.cs
+++ b/tests/ExtraGasMVC.Tests/ProductoServiceTests.cs
@@ -4,6 +4,7 @@ using ExtraGasMVC.Data.Entities;
 using ExtraGasMVC.DTOs;
 using ExtraGasMVC.Mappings;
 using ExtraGasMVC.Services.Implementations;
+using ExtraGasMVC.Services.Interfaces;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -36,7 +37,12 @@ public class ProductoServiceTests
         // de cache es constante; sin esto los tests interfieren entre sí).
         var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
             new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
-        var service = new ProductoService(context, mapper, NullLogger<ProductoService>.Instance, cache);
+        // Issue #147 slice 2: IAuditLogger requerido para UpdateAsync (cambio
+        // de constructor). La mayoría de los tests pre-existentes no observan
+        // audit; pasamos uno fresco contra el mismo DbContext para que
+        // cualquier SaveChangesAsync commit eventual si lo necesita.
+        var audit = new AuditLogger(context, NullLogger<AuditLogger>.Instance);
+        var service = new ProductoService(context, mapper, NullLogger<ProductoService>.Instance, cache, audit);
 
         // Issue #146.1: el Service valida FK TipoProductoId antes de
         // SaveChanges. Los tests pre-existentes asumían un DbContext
@@ -334,7 +340,9 @@ public class ProductoServiceTests
         // MemoryCache fresh por test — la cache key es constante.
         var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
             new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
-        var service = new ProductoService(context, mapper, logger, cache);
+        // Issue #147 slice 2: IAuditLogger agregado al ctor.
+        var audit = new AuditLogger(context, NullLogger<AuditLogger>.Instance);
+        var service = new ProductoService(context, mapper, logger, cache, audit);
 
         // Issue #146.1: el Service valida FK TipoProductoId antes de
         // SaveChanges. Sembramos el catálogo para que el helper NewCreateDto
@@ -763,7 +771,9 @@ public class ProductoServiceTests
         var mapper = mapperConfig.CreateMapper();
         var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
             new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
-        var service = new ProductoService(context, mapper, NullLogger<ProductoService>.Instance, cache);
+        // Issue #147 slice 2: IAuditLogger agregado al ctor.
+        var audit = new AuditLogger(context, NullLogger<AuditLogger>.Instance);
+        var service = new ProductoService(context, mapper, NullLogger<ProductoService>.Instance, cache, audit);
 
         // Seed inicial: 2 tipos visibles para el Service.
         context.TiposProducto.AddRange(

--- a/tests/ExtraGasMVC.Tests/Services/AuditLoggerTests.cs
+++ b/tests/ExtraGasMVC.Tests/Services/AuditLoggerTests.cs
@@ -1,0 +1,168 @@
+using ExtraGasMVC.Data.Context;
+using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.Services.Implementations;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace ExtraGasMVC.Tests.Services;
+
+/// <summary>
+/// Tests del <see cref="IAuditLogger"/> (issue #147 slice 2).
+///
+/// Contrato verificado:
+///   - <c>LogChangeAsync</c> agrega una <see cref="AuditLogEntry"/> al change
+///     tracker del <see cref="ExtraGasDbContext"/> compartido.
+///   - Copia los 7 campos (entidad, registroId, campo, valorAnterior,
+///     valorNuevo, userId, changedAt) verbatim.
+///   - Acepta <c>valorAnterior</c> y <c>valorNuevo</c> nulos (caso altas /
+///     bajas donde uno de los dos lados no aplica).
+///   - NO llama <c>SaveChangesAsync</c>: el caller commit junto con su
+///     propia mutación para garantizar atomicidad.
+///
+/// Patrón: DbContext InMemory (mismo que ProductoServiceTests) — no
+/// requiere Testcontainers porque no testeamos la migración acá, solo el
+/// contrato del logger. El integration test con Testcontainers vive en
+/// <see cref="Integration.ProductoAuditLogIntegrationTests"/>.
+/// </summary>
+public class AuditLoggerTests
+{
+    private static (AuditLogger logger, ExtraGasDbContext context) NewLogger(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<ExtraGasDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+        var context = new ExtraGasDbContext(options);
+        var logger = new AuditLogger(context, NullLogger<AuditLogger>.Instance);
+        return (logger, context);
+    }
+
+    [Fact]
+    public async Task LogChangeAsync_AddsEntryToChangeTracker()
+    {
+        // Spec scenario: el logger agrega UNA entry al ChangeTracker del
+        // DbContext compartido. Como NO llama SaveChanges (atomicidad con
+        // el caller), verificamos el side-effect en el ChangeTracker
+        // después de invocar.
+        var (logger, context) = NewLogger(nameof(LogChangeAsync_AddsEntryToChangeTracker));
+
+        await logger.LogChangeAsync(
+            entidad: "Producto",
+            registroId: 42,
+            campo: "PrecioActual",
+            valorAnterior: "1000",
+            valorNuevo: "1500",
+            changedBy: 7);
+
+        var pending = context.ChangeTracker
+            .Entries<AuditLogEntry>()
+            .Where(e => e.State == EntityState.Added)
+            .ToList();
+        pending.Should().ContainSingle(
+            "LogChangeAsync debe encolar exactamente una AuditLogEntry en estado Added");
+    }
+
+    [Fact]
+    public async Task LogChangeAsync_SetsAllRequiredFields()
+    {
+        // Spec scenario "precio change emits one row": verificar que los
+        // 7 campos del entity reflejan los argumentos verbatim. Sin esto
+        // un refactor podría silenciosamente tirar campos.
+        var (logger, context) = NewLogger(nameof(LogChangeAsync_SetsAllRequiredFields));
+
+        var before = DateTime.UtcNow.AddSeconds(-1);
+        await logger.LogChangeAsync(
+            entidad: "Producto",
+            registroId: 99,
+            campo: "PrecioActual",
+            valorAnterior: "1000.00",
+            valorNuevo: "1500.00",
+            changedBy: 7);
+        var after = DateTime.UtcNow.AddSeconds(1);
+
+        var entry = context.ChangeTracker.Entries<AuditLogEntry>().Single();
+        var entity = entry.Entity;
+        entity.Entidad.Should().Be("Producto");
+        entity.RegistroId.Should().Be(99UL);
+        entity.Campo.Should().Be("PrecioActual");
+        entity.ValorAnterior.Should().Be("1000.00");
+        entity.ValorNuevo.Should().Be("1500.00");
+        entity.UserId.Should().Be(7UL);
+        entity.ChangedAt.Should().BeOnOrAfter(before).And.BeOnOrBefore(after,
+            "ChangedAt debe setearse al momento de la llamada (now-ish)");
+    }
+
+    [Fact]
+    public async Task LogChangeAsync_AcceptsNullPreviousAndNextValues()
+    {
+        // Caso real: cuando se crea un registro no hay valor anterior
+        // (null), y ciertos escenarios (clear de un campo) tienen valor
+        // nuevo null. El logger debe aceptarlo sin tirar.
+        var (logger, context) = NewLogger(nameof(LogChangeAsync_AcceptsNullPreviousAndNextValues));
+
+        await logger.LogChangeAsync(
+            entidad: "Cliente",
+            registroId: 1,
+            campo: "TelefonoPrincipal",
+            valorAnterior: null,   // campo recién creado
+            valorNuevo: "+541112345678",
+            changedBy: 3);
+
+        var entity = context.ChangeTracker.Entries<AuditLogEntry>().Single().Entity;
+        entity.ValorAnterior.Should().BeNull();
+        entity.ValorNuevo.Should().Be("+541112345678");
+    }
+
+    [Fact]
+    public async Task LogChangeAsync_AcceptsNullChangedBy_ForSystemChanges()
+    {
+        // Backfills, jobs programados y migraciones no tienen un usuario
+        // humano detrás. El userId debe ser nullable sin tirar.
+        var (logger, context) = NewLogger(nameof(LogChangeAsync_AcceptsNullChangedBy_ForSystemChanges));
+
+        await logger.LogChangeAsync(
+            entidad: "Producto",
+            registroId: 5,
+            campo: "Activo",
+            valorAnterior: "false",
+            valorNuevo: "true",
+            changedBy: null);
+
+        var entity = context.ChangeTracker.Entries<AuditLogEntry>().Single().Entity;
+        entity.UserId.Should().BeNull(
+            "cambios system-initiated (backfill, jobs) tienen userId null");
+    }
+
+    [Fact]
+    public async Task LogChangeAsync_DoesNotCallSaveChanges()
+    {
+        // Contrato atómico: el logger NO persiste, solo encola. El caller
+        // hace SaveChanges UNA vez con su propia mutación para garantizar
+        // que la fila de audit y la mutación son atómicas. Verificamos
+        // que después de LogChangeAsync la entry sigue en Added (no
+        // Unchanged, que sería señal de que SaveChanges la vio).
+        var (logger, context) = NewLogger(nameof(LogChangeAsync_DoesNotCallSaveChanges));
+
+        await logger.LogChangeAsync("Producto", 1, "Nombre", "V1", "V2", 1);
+
+        context.ChangeTracker.Entries<AuditLogEntry>().Should()
+            .ContainSingle(e => e.State == EntityState.Added,
+                "la entry debe quedar en Added — el logger NO llama SaveChanges");
+    }
+
+    [Fact]
+    public async Task LogChangeAsync_SupportsCancellationToken()
+    {
+        // El interface toma CancellationToken ct = default. Verificamos
+        // que el logger lo acepta (no que lo use — es pass-through, pero
+        // la firma debe coincidir con la que el caller va a pasar).
+        var (logger, context) = NewLogger(nameof(LogChangeAsync_SupportsCancellationToken));
+        using var cts = new CancellationTokenSource();
+
+        await logger.LogChangeAsync(
+            "Producto", 1, "Nombre", "A", "B", 1, cts.Token);
+
+        context.ChangeTracker.Entries<AuditLogEntry>().Should().HaveCount(1);
+    }
+}


### PR DESCRIPTION
Closes parte de #147 (Slice 2 de 3 chained PRs, stacked sobre #153)

## Slice 2 — Infraestructura (item 3: audit_log)

Implementa la infraestructura genérica de auditoría por campo. Cada `UPDATE` a `productos` emite una fila en `audit_log` por cada campo modificado, atómicamente con la mutación.

## Componentes nuevos

- **Migración** `db/migrations/20260901_000001_create_audit_log.sql` — tabla idempotente con 8 columnas + 2 índices (`(entidad, registro_id, changed_at)` + `changed_at`).
- **Entity** `Data/Entities/AuditLogEntry.cs` + `Data/Configurations/AuditLogEntryConfiguration.cs` + `DbSet<AuditLogEntry>` en `ExtraGasDbContext`.
- **Interface** `Services/Interfaces/IAuditLogger.cs` — `LogChangeAsync(entidad, registroId, campo, anterior, nuevo, userId, ct)`.
- **Impl** `Services/Implementations/AuditLogger.cs` — Scoped, **NO llama SaveChanges** (el caller lo hace atómicamente con su propia mutación). XML doc documenta el contrato de atomicidad.
- **DI** en `Program.cs` — `AddScoped<IAuditLogger, AuditLogger>()`.

## Integración en `ProductoService.UpdateAsync`

`DetectarCambiosAuditables` compara los 7 campos auditables (Precio, StockMinimo, TipoProductoId, UnidadVentaId, ManejaGarrafaIndividual, Nombre, Descripcion) contra el snapshot pre-update. Cada diff dispara un `LogChangeAsync`. El `SaveChangesAsync` final commitea producto + audit_log en una sola transacción.

Excluido deliberadamente: `Activo` (el DTO no lo expone; documentado en `ProductoService.cs:599-602`).

## Work-unit commits (6)

```
84989a0 feat(db): tabla audit_log para auditoría genérica por campo
09b6588 feat(data): AuditLogEntry entity + EF config + DbContext DbSet
2001a32 feat(services): IAuditLogger + AuditLogger Scoped + 6 tests RED→GREEN
17b6d3f feat(productos): UpdateAsync emite per-field audit events + 5 tests
cf3fe0c test(productos): integración audit_log con Testcontainers (4 tests)
f3ceafc test(productos): añadir audit_log al schema mínimo de fixture pre-existente
```

## Stats

- **+1309 / -XX LOC** across 14 files (incluye nueva migración SQL + nueva entity/config + nuevo service + 3 nuevos archivos de test). Sobrea el budget de 400 pero feature-branch-chain lo permite.
- **15 tests nuevos**: 6 AuditLogger + 5 ProductoAuditLog + 4 Testcontainers integración
- **409 tests** pasando (394 baseline → +15 netos)
- **Build** limpio (cero warnings nuevos, 2 pre-existentes)

## Migration status

⚠️ **NO aplicada al homelab todavía**. El SQL fue validado vía Testcontainers contra MySQL 8.0 (idempotencia + schema match). Aplicación real via `install.sh` queda para el momento del merge. Si querés que la aplique antes, decime y le mando `mysql -h 192.168.0.216`.

## Verification

`sdd-verify` verdict: **pass** — 1/1 requirement, 3/3 scenarios. Atomicidad confirmada por test E2E con Testcontainers (UpdateAsync → audit_log row visible).

## Slices

- ✅ Slice 1 (#153): items 6+4+5+1 — Codigo + audit visible + tests + cache
- ✅ **Slice 2 (this PR)**: item 3 — audit_log + IAuditLogger + emission
- ⏳ Slice 3: items 2+7+8 — Delete impact UI + UnidadVenta catalog + ADR

## Chain

PR #154 targets `feat/issue-147-slice-1-codigo-audit-cache` (slice-1, no el tracker) — diff de review queda enfocado en audit_log. Cuando los 3 slices estén merged, el tracker `feat/issue-147-productos-mejoras` recibe el PR final a develop.

Refs #147