### PR TITLE
[Productos] #147 Slice 1/3: normalize Codigo + audit fields + tests +…

### DIFF
--- a/src/ExtraGasMVC/Controllers/ProductosController.cs
+++ b/src/ExtraGasMVC/Controllers/ProductosController.cs
@@ -111,6 +111,16 @@ public class ProductosController : BaseController
         // como info read-only en la vista.
         ViewBag.Activo = producto.Activo;
 
+        // Issue #147 item 4: auditoría visible read-only al pie del form.
+        // UpdateProductoDto NO expone los 4 miembros de auditoría — el
+        // Service los necesita para escribir (UpdatedAt/UpdatedBy), no
+        // para bindear desde el form. Los exponemos via ViewBag desde el
+        // ProductoDto que ya cargó GetByIdAsync (que sí los pobló).
+        ViewBag.AuditCreatedAt = producto.CreatedAt;
+        ViewBag.AuditUpdatedAt = producto.UpdatedAt;
+        ViewBag.AuditCreatedBy = producto.CreatedByUserName;
+        ViewBag.AuditUpdatedBy = producto.UpdatedByUserName;
+
         await LoadViewBagsAsync(ct);
         return View(updateDto);
     }

--- a/src/ExtraGasMVC/DTOs/ProductoDto.cs
+++ b/src/ExtraGasMVC/DTOs/ProductoDto.cs
@@ -24,6 +24,25 @@ public class ProductoDto
     public decimal PrecioActual { get; set; }
     public bool ManejaGarrafaIndividual { get; set; }
     public bool Activo { get; set; }
+
+    // Issue #147 item 4: auditoría visible en Details/Edit. Los timestamps
+    // se mapean por convención desde Producto.CreatedAt/UpdatedAt; los
+    // usernames NO se mapean por convención (Producto expone CreatedBy/
+    // UpdatedBy como ulong FK, no como string) — el Service los resuelve
+    // explícitamente vía LoadAuditUsersAsync + AplicarAudit y los asigna
+    // después del Map. El MappingProfile tiene .Ignore() explícito para
+    // los dos usernames como defensa en profundidad (regresión #118).
+    [Display(Name = "Creado")]
+    public DateTime CreatedAt { get; set; }
+
+    [Display(Name = "Última modificación")]
+    public DateTime UpdatedAt { get; set; }
+
+    [Display(Name = "Creado por")]
+    public string? CreatedByUserName { get; set; }
+
+    [Display(Name = "Modificado por")]
+    public string? UpdatedByUserName { get; set; }
 }
 
 /// <summary>

--- a/src/ExtraGasMVC/Extensions/StringNormalizer.cs
+++ b/src/ExtraGasMVC/Extensions/StringNormalizer.cs
@@ -3,10 +3,11 @@ using System.Text;
 namespace ExtraGasMVC.Extensions;
 
 /// <summary>
-/// Helpers de normalización de strings de identidad/contacto del cliente.
-/// Garantizan que valores equivalentes por formato (con/sin espacios, con/sin
-/// separadores) se almacenen, validen y busquen de forma canónica.
-/// Issue #113.
+/// Helpers de normalización de strings de identidad/contacto del cliente y de
+/// códigos de producto. Garantizan que valores equivalentes por formato (con/sin
+/// espacios, con/sin separadores, mayúsculas/minúsculas) se almacenen,
+/// validen y busquen de forma canónica.
+/// Issue #113 (DNI / Teléfono) + issue #147 item 6 (TrimAndUpper).
 /// </summary>
 public static class StringNormalizer
 {
@@ -56,5 +57,22 @@ public static class StringNormalizer
         var longitudMinima = tieneMas ? 1 : 0;
         if (sb.Length <= longitudMinima) return null;
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Normaliza un código de producto: trim + uppercase invariante.
+    /// Devuelve <see cref="string.Empty"/> para null/empty/whitespace (no null),
+    /// porque <c>Producto.Codigo</c> es NOT NULL en BD. Diverge deliberadamente
+    /// de <see cref="NormalizarDni"/>/<see cref="NormalizarTelefono"/> que
+    /// devuelven null en entradas vacías — el dominio del código es "no hay
+    /// código canónico" en lugar de "código ausente".
+    /// Issue #147 item 6: garantiza que <c>" gas-10 "</c>, <c>"GAS-10"</c> y
+    /// <c>" gas-10 "</c> colapsan al mismo valor canónico, cubriendo el índice
+    /// único <c>uq_productos_codigo</c>.
+    /// </summary>
+    public static string TrimAndUpper(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input)) return string.Empty;
+        return input.Trim().ToUpperInvariant();
     }
 }

--- a/src/ExtraGasMVC/Mappings/MappingProfile.cs
+++ b/src/ExtraGasMVC/Mappings/MappingProfile.cs
@@ -124,9 +124,26 @@ public class MappingProfile : Profile
 
     private void ConfigureProducto()
     {
+        // Issue #147 item 4 + regresión #118 (mismo patrón que
+        // ConfigureCliente). El DTO expone 4 miembros de auditoría:
+        //   - CreatedAt, UpdatedAt: mapeo 1:1 desde la entity (timestamps).
+        //     Se declaran explícitos para que un futuro refactor que
+        //     renombre la property en la entity rompa este profile en
+        //     compile-time, no en runtime silencioso.
+        //   - CreatedByUserName, UpdatedByUserName: .Ignore() explícito.
+        //     El Service los resuelve vía LoadAuditUsersAsync +
+        //     AplicarAudit y los asigna después del Map. Sin el Ignore,
+        //     si mañana alguien agrega un `CreatedBy` string al DTO,
+        //     AutoMapper intentaría mapear la FK ulong del entity a
+        //     string y rompería el contrato (o pisaría el username real
+        //     con un "5" de la FK). El Ignore bloquea ese camino.
         CreateMap<Producto, ProductoDto>()
             .ForMember(d => d.TipoProductoNombre, o => o.MapFrom(s =>
                 s.TipoProducto != null ? s.TipoProducto.Nombre : null))
+            .ForMember(d => d.CreatedAt, o => o.MapFrom(s => s.CreatedAt))
+            .ForMember(d => d.UpdatedAt, o => o.MapFrom(s => s.UpdatedAt))
+            .ForMember(d => d.CreatedByUserName, o => o.Ignore())
+            .ForMember(d => d.UpdatedByUserName, o => o.Ignore())
             .ReverseMap();
         CreateMap<CreateProductoDto, Producto>();
         // Issue #145 Slice 3: MotivoCambioPrecio vive en el DTO pero NO tiene

--- a/src/ExtraGasMVC/Services/Implementations/ProductoService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ProductoService.cs
@@ -7,26 +7,42 @@ using ExtraGasMVC.Extensions;
 using ExtraGasMVC.Models.ViewModels;
 using ExtraGasMVC.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace ExtraGasMVC.Services.Implementations;
 
 public class ProductoService : IProductoService
 {
+    // Issue #147 item 1: clave de cache para GetTiposProductoAsync. El
+    // catálogo tipos_producto es seed-only (decisión documentada en el
+    // design #147 ADR #20 — pendiente de escritura en slice 3): no hay UI
+    // CRUD, nadie lo modifica desde la app. La lista no cambia durante la
+    // vida del proceso → cachear en memoria con TTL 1h es seguro y
+    // elimina 1 query por request.
+    private const string TiposProductoCacheKey = "tipos_producto";
+    private static readonly TimeSpan TiposProductoCacheTtl = TimeSpan.FromHours(1);
+
     private readonly ExtraGasDbContext _context;
     private readonly IMapper _mapper;
     // Issue #145 Slice 2: ILogger<ProductoService> inyectado para trazabilidad
     // del restore (operación privilegiada, AdminOnly). Issue #146.7 lo extiende
     // a las 4 operaciones de escritura (Create/Update/Delete/Restore).
     private readonly ILogger<ProductoService> _logger;
+    // Issue #147 item 1: IMemoryCache inyectado para envolver
+    // GetTiposProductoAsync. AddMemoryCache() ya está registrado en
+    // Program.cs:16, solo faltaba inyectar.
+    private readonly IMemoryCache _cache;
 
     public ProductoService(
         ExtraGasDbContext context,
         IMapper mapper,
-        ILogger<ProductoService> logger)
+        ILogger<ProductoService> logger,
+        IMemoryCache cache)
     {
         _context = context;
         _mapper = mapper;
         _logger = logger;
+        _cache = cache;
     }
 
     public async Task<ProductoDto?> GetByIdAsync(ulong id, CancellationToken ct = default)
@@ -36,15 +52,32 @@ public class ProductoService : IProductoService
             .Include(p => p.TipoProducto)
             .FirstOrDefaultAsync(p => p.Id == id, ct);
 
-        return producto is null ? null : _mapper.Map<ProductoDto>(producto);
+        if (producto is null) return null;
+
+        var dto = _mapper.Map<ProductoDto>(producto);
+        // Issue #147 item 4: auditoría visible en Details. El MappingProfile
+        // deja CreatedByUserName/UpdatedByUserName en null (.Ignore()) y el
+        // Service los resuelve explícitamente. Mismo patrón que
+        // UsuarioService.LoadAuditUsersAsync (líneas 570-587).
+        var auditUsers = await LoadAuditUsersAsync(new[] { producto }, ct);
+        AplicarAudit(dto, producto, auditUsers);
+        return dto;
     }
 
     public async Task<ProductoDto?> GetByCodigoAsync(string codigo, CancellationToken ct = default)
     {
+        // Issue #147 item 6: normalizar el input igual que Create/Update.
+        // La columna se persiste canónica (upper, sin espacios) así que el
+        // lookup debe llegar canónico. La collation utf8mb4_unicode_ci del
+        // schema hace la comparación case-insensitive, pero TrimAndUpper
+        // también remueve espacios al borde — defensa en profundidad.
+        var codigoNormalizado = StringNormalizer.TrimAndUpper(codigo);
+        if (codigoNormalizado.Length == 0) return null;
+
         var producto = await _context.Productos
             .AsNoTracking()
             .Include(p => p.TipoProducto)
-            .FirstOrDefaultAsync(p => p.Codigo == codigo, ct);
+            .FirstOrDefaultAsync(p => p.Codigo == codigoNormalizado, ct);
 
         return producto is null ? null : _mapper.Map<ProductoDto>(producto);
     }
@@ -86,12 +119,28 @@ public class ProductoService : IProductoService
 
     public async Task<IEnumerable<TipoProductoDto>> GetTiposProductoAsync(CancellationToken ct = default)
     {
-        var tipos = await _context.TiposProducto
-            .AsNoTracking()
-            .OrderBy(t => t.Nombre)
-            .ToListAsync(ct);
+        // Issue #147 item 1: cache en memoria con TTL 1h. El catálogo
+        // tipos_producto es seed-only (ADR #20 pendiente en slice 3) — no
+        // hay UI CRUD que pueda invalidar el cache entre requests. TTL
+        // absoluto (no sliding) porque la lógica de uso es "cargar al
+        // startup y servir idéntico por 1h"; un sliding extendería el TTL
+        // indefinidamente bajo uso sostenido.
+        //
+        // TODO forward-looking (issue #147 slice 3 / follow-up): si en el
+        // futuro se agrega UI CRUD para TiposProducto, este cache key debe
+        // evacuarse en Create/Update/Delete (escritura → RemoveAsync). Por
+        // ahora la API no expone esos verbos — el catálogo es cerrado.
+        return await _cache.GetOrCreateAsync(TiposProductoCacheKey, async entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = TiposProductoCacheTtl;
 
-        return _mapper.Map<IEnumerable<TipoProductoDto>>(tipos);
+            var tipos = await _context.TiposProducto
+                .AsNoTracking()
+                .OrderBy(t => t.Nombre)
+                .ToListAsync(ct);
+
+            return (IEnumerable<TipoProductoDto>)_mapper.Map<List<TipoProductoDto>>(tipos);
+        }) ?? [];
     }
 
     /// <summary>
@@ -128,14 +177,16 @@ public class ProductoService : IProductoService
         {
             // EF.Functions.Like compila a un LIKE nativo de MySQL. La
             // collation utf8mb4_unicode_ci del schema ya hace la comparación
-            // case-insensitive, así que no hace falta lower() en ambos lados.
-            // Mismo criterio que la versión anterior para no cambiar el
-            // contrato del filtro.
-            var trimmed = busqueda.Trim();
+            // case-insensitive para los 3 campos, pero normalizar el input
+            // (trim + upper) garantiza consistencia con CreateAsync/UpdateAsync:
+            // si el operador busca "gas", matchea tanto "GAS-10" como
+            // "gas-10" porque el LIKE es bilateral.
+            // Issue #147 item 6.
+            var busquedaNormalizada = StringNormalizer.TrimAndUpper(busqueda);
             query = query.Where(p =>
-                EF.Functions.Like(p.Codigo, $"%{trimmed}%")
-                || EF.Functions.Like(p.Nombre, $"%{trimmed}%")
-                || (p.Descripcion != null && EF.Functions.Like(p.Descripcion, $"%{trimmed}%")));
+                EF.Functions.Like(p.Codigo, $"%{busquedaNormalizada}%")
+                || EF.Functions.Like(p.Nombre, $"%{busquedaNormalizada}%")
+                || (p.Descripcion != null && EF.Functions.Like(p.Descripcion, $"%{busquedaNormalizada}%")));
         }
 
         // Total antes de paginar — CountAsync traduce a SELECT COUNT(*)
@@ -181,6 +232,11 @@ public class ProductoService : IProductoService
         await ValidarCodigoNoDuplicadoAsync(producto.Codigo, idAExcluir: null, ct);
 
         var entity = _mapper.Map<Producto>(producto);
+        // Issue #147 item 6: normalizar Codigo en el borde del Service
+        // (trim + upper). El DTO trae el valor crudo del form; la columna
+        // se persiste canónica para cubrir el índice único
+        // `uq_productos_codigo` y matchear búsquedas case-insensitive.
+        entity.Codigo = StringNormalizer.TrimAndUpper(entity.Codigo);
         // Issue #114: Activo no viene del DTO. Lo setea el Service en true
         // porque es estado, no dato de carga del operador.
         entity.Activo = true;
@@ -246,6 +302,11 @@ public class ProductoService : IProductoService
         var cambios = DetectarCambiosProducto(entity, producto);
 
         _mapper.Map(producto, entity);
+        // Issue #147 item 6: normalizar Codigo (trim + upper) — mismo
+        // tratamiento que CreateAsync. Mantiene invariante "Codigo
+        // siempre canónico en BD" para que las búsquedas no dependan
+        // de cómo tipeó el operador.
+        entity.Codigo = StringNormalizer.TrimAndUpper(entity.Codigo);
         entity.UpdatedAt = DateTime.UtcNow;
         entity.UpdatedBy = usuarioId;
         ProductoEditRules.PreservarFlagsNoEditables(entity, activoOriginal);
@@ -491,5 +552,48 @@ public class ProductoService : IProductoService
             cambios.Add($"ManejaGarrafaIndividual: {entity.ManejaGarrafaIndividual} → {dto.ManejaGarrafaIndividual}");
 
         return cambios;
+    }
+
+    /// <summary>
+    /// Recolecta los IDs de CreatedBy/UpdatedBy de los productos y devuelve
+    /// un diccionario Id → Username para resolver auditores en una sola query.
+    /// Issue #147 item 4: replica <see cref="UsuarioService.LoadAuditUsersAsync"/>
+    /// (líneas 570-587) — los usernames NO viven en Producto, son FKs a
+    /// usuarios. Devuelve diccionario vacío si no hay IDs para evitar la
+    /// query.
+    /// </summary>
+    private async Task<Dictionary<ulong, string>> LoadAuditUsersAsync(
+        IEnumerable<Producto> productos, CancellationToken ct)
+    {
+        var auditUserIds = new HashSet<ulong>();
+        foreach (var producto in productos)
+        {
+            if (producto.CreatedBy.HasValue) auditUserIds.Add(producto.CreatedBy.Value);
+            if (producto.UpdatedBy.HasValue) auditUserIds.Add(producto.UpdatedBy.Value);
+        }
+
+        if (auditUserIds.Count == 0) return new Dictionary<ulong, string>();
+
+        return await _context.Usuarios
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .Where(u => auditUserIds.Contains(u.Id))
+            .ToDictionaryAsync(u => u.Id, u => u.Username, ct);
+    }
+
+    /// <summary>
+    /// Copia el username del auditor (CreatedBy / UpdatedBy) en el DTO si
+    /// el auditor existe. Sin excepción si el auditor fue soft-deleted —
+    /// el Diccionario simplemente no tiene la entrada y los campos quedan
+    /// en null, que es la representación correcta (auditor desconocido).
+    /// </summary>
+    private static void AplicarAudit(
+        ProductoDto dto, Producto entity, Dictionary<ulong, string> auditUsers)
+    {
+        if (entity.CreatedBy.HasValue && auditUsers.TryGetValue(entity.CreatedBy.Value, out var creador))
+            dto.CreatedByUserName = creador;
+
+        if (entity.UpdatedBy.HasValue && auditUsers.TryGetValue(entity.UpdatedBy.Value, out var actualizador))
+            dto.UpdatedByUserName = actualizador;
     }
 }

--- a/src/ExtraGasMVC/Views/Productos/Details.cshtml
+++ b/src/ExtraGasMVC/Views/Productos/Details.cshtml
@@ -35,3 +35,25 @@
         </dl>
     </div>
 </div>
+
+@* Issue #147 item 4: tarjeta de auditoría (separada del card principal para
+   que el operador la identifique visualmente como metadata, no como datos
+   editables). El DTO expone 4 miembros — CreatedAt/UpdatedAt se mapean por
+   convención desde la entity, CreatedByUserName/UpdatedByUserName los
+   resuelve el Service vía LoadAuditUsersAsync. Si el auditor fue borrado
+   los usernames quedan null ("-"). *@
+<div class="card mt-3">
+    <div class="card-header"><h3 class="card-title">Auditoría</h3></div>
+    <div class="card-body">
+        <dl class="row mb-0">
+            <dt class="col-sm-3">@Html.DisplayNameFor(m => m.CreatedAt)</dt>
+            <dd class="col-sm-9">@Model.CreatedAt.ToShortDateTime()</dd>
+            <dt class="col-sm-3">@Html.DisplayNameFor(m => m.UpdatedAt)</dt>
+            <dd class="col-sm-9">@Model.UpdatedAt.ToShortDateTime()</dd>
+            <dt class="col-sm-3">@Html.DisplayNameFor(m => m.CreatedByUserName)</dt>
+            <dd class="col-sm-9">@(Model.CreatedByUserName ?? "-")</dd>
+            <dt class="col-sm-3">@Html.DisplayNameFor(m => m.UpdatedByUserName)</dt>
+            <dd class="col-sm-9">@(Model.UpdatedByUserName ?? "-")</dd>
+        </dl>
+    </div>
+</div>

--- a/src/ExtraGasMVC/Views/Productos/Edit.cshtml
+++ b/src/ExtraGasMVC/Views/Productos/Edit.cshtml
@@ -1,4 +1,7 @@
 @model ExtraGasMVC.DTOs.UpdateProductoDto
+@* ViewData para auditoría visible (issue #147 item 4). UpdateProductoDto NO
+   expone los 4 campos de auditoría — el Controller los pasa via ViewBag
+   desde la entity original (pre-Map) para evitar bindearlos al form. *@
 @{
     ViewData["Title"] = "Editar producto";
     ViewData["Breadcrumbs"] = new List<BreadcrumbItem>
@@ -92,6 +95,33 @@
                 <div class="col-12">
                     <label asp-for="Descripcion" class="form-label">Descripción</label>
                     <textarea asp-for="Descripcion" class="form-control" rows="3"></textarea>
+                </div>
+            </div>
+
+            @* Issue #147 item 4: auditoría visible read-only al pie del form.
+               Los valores vienen de ViewBag (entity original cargada por el
+               Controller en GET Edit, antes de cualquier Map del DTO).
+               NO están en el form — son solo display. *@
+            <hr class="my-3" />
+            <div class="row g-3">
+                <div class="col-12">
+                    <h6 class="text-secondary mb-2">Auditoría</h6>
+                </div>
+                <div class="col-md-3">
+                    <span class="form-label">Creado</span>
+                    <div class="form-control-plaintext">@(((DateTime)ViewBag.AuditCreatedAt).ToShortDateTime())</div>
+                </div>
+                <div class="col-md-3">
+                    <span class="form-label">Última modificación</span>
+                    <div class="form-control-plaintext">@(((DateTime)ViewBag.AuditUpdatedAt).ToShortDateTime())</div>
+                </div>
+                <div class="col-md-3">
+                    <span class="form-label">Creado por</span>
+                    <div class="form-control-plaintext">@(ViewBag.AuditCreatedBy ?? "-")</div>
+                </div>
+                <div class="col-md-3">
+                    <span class="form-label">Modificado por</span>
+                    <div class="form-control-plaintext">@(ViewBag.AuditUpdatedBy ?? "-")</div>
                 </div>
             </div>
         </div>

--- a/tests/ExtraGasMVC.Tests/MappingProfileProductoTests.cs
+++ b/tests/ExtraGasMVC.Tests/MappingProfileProductoTests.cs
@@ -1,0 +1,102 @@
+using AutoMapper;
+using ExtraGasMVC.Data.Entities;
+using ExtraGasMVC.DTOs;
+using ExtraGasMVC.Mappings;
+using FluentAssertions;
+using Xunit;
+
+namespace ExtraGasMVC.Tests;
+
+/// <summary>
+/// Contract tests para el <see cref="MappingProfile"/> respecto al mapeo de
+/// Producto → ProductoDto en los campos de auditoría.
+///
+/// Issue #147 item 4 + regresión #118: los campos de auditoría
+/// (<c>CreatedAt</c>, <c>UpdatedAt</c>, <c>CreatedByUserName</c>,
+/// <c>UpdatedByUserName</c>) en el DTO deben poblarse explícitamente — el
+/// Service los resuelve vía <c>LoadAuditUsersAsync</c> y NO se debe permitir
+/// que AutoMapper los pise silenciosamente si alguien agrega un miembro
+/// <c>CreatedBy</c> al DTO mañana. El <c>.ForMember(...).Ignore()</c>
+/// explícito documenta y bloquea el camino.
+///
+/// Item 4 spec: "AutoMapper MUST NOT overwrite usernames — WHEN AutoMapper
+/// maps Producto → ProductoDto, the four audit fields MUST be sourced from
+/// explicit service-level resolution, not the entity directly."
+/// </summary>
+public class MappingProfileProductoTests
+{
+    private static IMapper NewMapper()
+    {
+        // Mismo criterio que MappingProfileClienteTests.NewMapper():
+        // NO llamamos AssertConfigurationIsValid() porque el MappingProfile
+        // tiene unmapped properties intencionales en otros entities
+        // (CreateClienteDto/UpdateClienteDto/CreatePedidoDto/etc. — campos
+        // de auditoría que el Service setea explícitamente). Estos
+        // contratos están documentados y validados por separado en sus
+        // tests respectivos. La auditoría de #147 item 4 es local al
+        // mapeo Producto → ProductoDto.
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        return config.CreateMapper();
+    }
+
+    [Fact]
+    public void Producto_DtoExposesAuditFields()
+    {
+        // Sanity: los 4 miembros existen en el DTO. Si alguien los borra
+        // por error, este test rompe antes que cualquier vista o servicio
+        // (Details/Edit/audit-card) empiece a fallar en runtime.
+        typeof(ProductoDto).GetProperty(nameof(ProductoDto.CreatedAt))
+            .Should().NotBeNull("ProductoDto debe exponer CreatedAt");
+        typeof(ProductoDto).GetProperty(nameof(ProductoDto.UpdatedAt))
+            .Should().NotBeNull("ProductoDto debe exponer UpdatedAt");
+        typeof(ProductoDto).GetProperty(nameof(ProductoDto.CreatedByUserName))
+            .Should().NotBeNull("ProductoDto debe exponer CreatedByUserName");
+        typeof(ProductoDto).GetProperty(nameof(ProductoDto.UpdatedByUserName))
+            .Should().NotBeNull("ProductoDto debe exponer UpdatedByUserName");
+    }
+
+    [Fact]
+    public void Producto_DtoFromEntity_CreatedByUserName_NotOverwrittenByEntityFK()
+    {
+        // Regresión #118 (también documentada en MappingProfileClienteTests):
+        // el entity tiene `CreatedBy` (ulong FK a usuarios.id). Si AutoMapper
+        // intentara mapear la FK al DTO por convención, pisaría el username
+        // resuelto por el Service. El `.ForMember(...).Ignore()` en el profile
+        // bloquea eso explícitamente.
+        //
+        // Arrange: entity con timestamps reales + FK de auditor seteada.
+        var mapper = NewMapper();
+        var fechaAlta = DateTime.UtcNow.AddYears(-1);
+        var fechaModif = DateTime.UtcNow.AddDays(-3);
+        var entity = new Producto
+        {
+            Id = 10,
+            Codigo = "GAS-10",
+            Nombre = "Garrafa 10kg",
+            TipoProductoId = 1,
+            UnidadVenta = "UNIDAD",
+            PrecioActual = 15000m,
+            ManejaGarrafaIndividual = true,
+            Activo = true,
+            CreatedAt = fechaAlta,
+            UpdatedAt = fechaModif,
+            CreatedBy = 5, // FK — NO debe terminar como string en CreatedByUserName
+            UpdatedBy = 7, // FK — NO debe terminar como string en UpdatedByUserName
+        };
+
+        // Act: map directo entity → DTO. Sin enrichment del Service.
+        var dto = mapper.Map<ProductoDto>(entity);
+
+        // Assert: los timestamps se mapearon por convención...
+        dto.CreatedAt.Should().Be(fechaAlta);
+        dto.UpdatedAt.Should().Be(fechaModif);
+
+        // ...pero los usernames NO fueron sobreescritos por la FK (ulong → string
+        // no es un mapeo válido y el .Ignore() lo bloquea). El Service los
+        // setea explícitamente vía LoadAuditUsersAsync + AplicarAudit.
+        dto.CreatedByUserName.Should().BeNull(
+            "el DTO sale del Map sin CreatedByUserName — el Service lo setea via LoadAuditUsersAsync");
+        dto.UpdatedByUserName.Should().BeNull(
+            "el DTO sale del Map sin UpdatedByUserName — el Service lo setea via LoadAuditUsersAsync");
+    }
+}

--- a/tests/ExtraGasMVC.Tests/ProductoPrecioHistoricoIntegrationTests.cs
+++ b/tests/ExtraGasMVC.Tests/ProductoPrecioHistoricoIntegrationTests.cs
@@ -229,7 +229,11 @@ public class ProductoPrecioHistoricoIntegrationTests
             await context.SaveChangesAsync();
 
             var mapper = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>()).CreateMapper();
-            var service = new ProductoService(context, mapper, NullLogger<ProductoService>.Instance);
+            // Issue #147 item 1: IMemoryCache requerido para ProductoService
+            // (cache de GetTiposProductoAsync). MemoryCache fresh por test.
+            var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
+                new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
+            var service = new ProductoService(context, mapper, NullLogger<ProductoService>.Instance, cache);
 
             // Update con cambio de precio 1000 → 1500 + motivo.
             var dto = new UpdateProductoDto

--- a/tests/ExtraGasMVC.Tests/ProductoServiceRobustezTests.cs
+++ b/tests/ExtraGasMVC.Tests/ProductoServiceRobustezTests.cs
@@ -40,7 +40,13 @@ public class ProductoServiceRobustezTests
         var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
         var mapper = mapperConfig.CreateMapper();
         var logger = new TestLogger<ProductoService>();
-        var service = new ProductoService(context, mapper, logger);
+        // Issue #147 item 1: IMemoryCache es parámetro del constructor de
+        // ProductoService desde slice 1. Pasamos una instancia fresca de
+        // MemoryCache por test para evitar interferencia entre tests
+        // (la clave de cache es constante).
+        var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
+            new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
+        var service = new ProductoService(context, mapper, logger, cache);
 
         // Sembrar el catálogo de tipos_producto para que las validaciones FK
         // que ya pasan el Helper (CreateAsync con TipoProductoId=1) no tiren

--- a/tests/ExtraGasMVC.Tests/ProductoServiceTests.cs
+++ b/tests/ExtraGasMVC.Tests/ProductoServiceTests.cs
@@ -31,7 +31,12 @@ public class ProductoServiceTests
         // Issue #145 Slice 2: ILogger<ProductoService> requerido para trazabilidad
         // de operaciones de escritura (RestoreAsync). Los tests existentes no
         // asertan sobre el log; usamos NullLogger.
-        var service = new ProductoService(context, mapper, NullLogger<ProductoService>.Instance);
+        // Issue #147 item 1: IMemoryCache requerido para GetTiposProductoAsync
+        // cacheado. Pasamos una instancia fresca de MemoryCache por test (clave
+        // de cache es constante; sin esto los tests interfieren entre sí).
+        var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
+            new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
+        var service = new ProductoService(context, mapper, NullLogger<ProductoService>.Instance, cache);
 
         // Issue #146.1: el Service valida FK TipoProductoId antes de
         // SaveChanges. Los tests pre-existentes asumían un DbContext
@@ -50,6 +55,28 @@ public class ProductoServiceTests
         }
 
         return (service, context);
+    }
+
+    /// <summary>
+    /// Helper que siembra un Usuario con username único (issue #147 item 4:
+    /// LoadAuditUsersAsync resuelve las FKs de CreatedBy/UpdatedBy a usernames
+    /// legibles). Devuelve el Id del usuario sembrado.
+    /// </summary>
+    private static ulong SeedUsuario(ExtraGasDbContext context, string username)
+    {
+        var usuario = new Usuario
+        {
+            Id = (ulong)(context.Usuarios.Count() + 1) * 10,
+            Username = username,
+            PasswordHash = "test-hash",
+            RolId = 1,
+            Activo = true,
+            DebeCambiarPassword = false,
+        };
+        context.Usuarios.Add(usuario);
+        context.SaveChanges();
+        context.ChangeTracker.Clear();
+        return usuario.Id;
     }
 
     private static CreateProductoDto NewCreateDto(string codigo = "GAS-10") => new()
@@ -303,7 +330,11 @@ public class ProductoServiceTests
         var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
         var mapper = mapperConfig.CreateMapper();
         var logger = new TestLogger<ProductoService>();
-        var service = new ProductoService(context, mapper, logger);
+        // Issue #147 item 1: IMemoryCache es parámetro del constructor.
+        // MemoryCache fresh por test — la cache key es constante.
+        var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
+            new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
+        var service = new ProductoService(context, mapper, logger, cache);
 
         // Issue #146.1: el Service valida FK TipoProductoId antes de
         // SaveChanges. Sembramos el catálogo para que el helper NewCreateDto
@@ -333,11 +364,11 @@ public class ProductoServiceTests
         entryPrecio.Message.Should().Contain("18000").And.Contain("Ajuste");
     }
 
-    [Fact]
+[Fact]
     public void UpdateProductoDto_MotivoCambioPrecio_RechazaMasDe255Chars()
     {
         // DataAnnotations del DTO: la columna es VARCHAR(255) — el límite se
-        // enforce a nivel modelo para que el Controller rechace el POST antes
+        // enforce a nivel modelo para que el Controller rechche el POST antes
         // de invocar al Service. Test plano sobre las anotaciones, sin EF.
         var dto = new UpdateProductoDto
         {
@@ -360,5 +391,404 @@ public class ProductoServiceTests
             "un motivo de 256 chars debe fallar la validación [StringLength(255)] antes de llegar al Service");
         results.Should().Contain(r =>
             r.MemberNames.Contains(nameof(UpdateProductoDto.MotivoCambioPrecio)));
+    }
+
+    // ====================================================================
+    // Issue #147 item 6: normalización de Codigo (trim + upper) en el Service.
+    // El operador puede tipear " gas-10 " en el form; el Service debe
+    // persistir "GAS-10" para que coincida con el índice único
+    // `uq_productos_codigo` y con futuras búsquedas.
+    // ====================================================================
+
+    [Fact]
+    public async Task CreateAsync_CodigoConEspaciosYLowercase_PersisteNormalizado()
+    {
+        // Spec scenario "Create persists normalized": input " gas-10 " →
+        // persistido "GAS-10". El DTO llega con el valor crudo del form;
+        // el Service es responsable de aplicar TrimAndUpper antes del INSERT.
+        var (service, context) = NewService(nameof(CreateAsync_CodigoConEspaciosYLowercase_PersisteNormalizado));
+        var dto = NewCreateDto(codigo: " gas-10 ");
+
+        var creado = await service.CreateAsync(dto, usuarioId: 1);
+
+        creado.Codigo.Should().Be("GAS-10",
+            "el Service debe normalizar Codigo (trim + upper) antes de persistir");
+        var entity = await context.Productos.AsNoTracking().FirstAsync(p => p.Id == creado.Id);
+        entity.Codigo.Should().Be("GAS-10",
+            "el valor normalizado debe quedar en la entity persistida");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_CodigoCambiaAFormaNormalizada_PersisteNormalizado()
+    {
+        // Spec scenario "Index search normalizes input" (vía Update): si el
+        // operador edita un producto y manda " gas-10 " desde el form, el
+        // Service debe persistir el valor canónico, no el input crudo.
+        var (service, context) = NewService(nameof(UpdateAsync_CodigoCambiaAFormaNormalizada_PersisteNormalizado));
+        var creado = await service.CreateAsync(NewCreateDto(), usuarioId: 1);
+
+        var updateDto = new UpdateProductoDto
+        {
+            Id = creado.Id,
+            Codigo = " gas-10 ", // mismo codigo en lowercase+espacios
+            Nombre = creado.Nombre,
+            TipoProductoId = creado.TipoProductoId,
+            CapacidadKg = creado.CapacidadKg,
+            UnidadVenta = creado.UnidadVenta,
+            PrecioActual = creado.PrecioActual,
+            ManejaGarrafaIndividual = creado.ManejaGarrafaIndividual,
+        };
+
+        var actualizado = await service.UpdateAsync(updateDto, usuarioId: 2);
+
+        actualizado.Codigo.Should().Be("GAS-10",
+            "UpdateAsync debe normalizar Codigo igual que CreateAsync");
+        var entity = await context.Productos.AsNoTracking().FirstAsync(p => p.Id == creado.Id);
+        entity.Codigo.Should().Be("GAS-10");
+    }
+
+    [Fact]
+    public async Task GetByCodigoAsync_InputLowercase_MatcheaStoredUppercase()
+    {
+        // Spec scenario "GetByCodigoAsync matches normalized input":
+        // producto persistido como "GAS-10", query con "gas-10" → debe
+        // matchear. El Service normaliza el input del lookup igual que el
+        // persist (canónico a ambos lados).
+        var (service, _) = NewService(nameof(GetByCodigoAsync_InputLowercase_MatcheaStoredUppercase));
+        await service.CreateAsync(NewCreateDto(codigo: "GAS-10"), usuarioId: 1);
+
+        var encontrado = await service.GetByCodigoAsync("gas-10");
+
+        encontrado.Should().NotBeNull("la query normalizada debe matchear el producto persistido canónico");
+        encontrado!.Codigo.Should().Be("GAS-10");
+    }
+
+    [Fact]
+    public async Task GetPagedAsync_BusquedaLowercase_MatcheaCodigoUppercase()
+    {
+        // Spec scenario "Index search normalizes input": busqueda " gas "
+        // debe matchear el Codigo "GAS-10" porque el LIKE corre contra el
+        // valor normalizado. La collation utf8mb4_unicode_ci ya hace el
+        // match case-insensitive, pero la normalización del input garantiza
+        // que espacios al borde no rompan la búsqueda.
+        var (service, _) = NewService(nameof(GetPagedAsync_BusquedaLowercase_MatcheaCodigoUppercase));
+        await service.CreateAsync(NewCreateDto(codigo: "GAS-10"), usuarioId: 1);
+
+        var resultado = await service.GetPagedAsync(busqueda: " gas ", soloActivos: true, page: 1, pageSize: 25);
+
+        resultado.Total.Should().Be(1,
+            "la búsqueda normalizada debe matchear el producto persistido");
+        resultado.Items.Should().ContainSingle().Which.Codigo.Should().Be("GAS-10");
+    }
+
+    // ====================================================================
+    // Issue #147 item 4: auditoría visible en Details/Edit.
+    // GetByIdAsync resuelve los usernames de CreatedBy/UpdatedBy via
+    // LoadAuditUsersAsync + AplicarAudit. Los timestamps los mapea
+    // AutoMapper por convención desde la entity.
+    // ====================================================================
+
+    [Fact]
+    public async Task GetByIdAsync_PopulatesAuditFields_WithResolvingUsernames()
+    {
+        // Spec scenario "ProductoDto populates 4 audit fields":
+        // sembramos 2 usuarios (creador y modificador), creamos un producto
+        // con uno, lo editamos con el otro, y verificamos que el DTO
+        // expone los 4 miembros con los usernames resueltos.
+        var (service, context) = NewService(nameof(GetByIdAsync_PopulatesAuditFields_WithResolvingUsernames));
+        var creadorId = SeedUsuario(context, "creador");
+        var modificadorId = SeedUsuario(context, "modificador");
+        var creado = await service.CreateAsync(NewCreateDto(), usuarioId: creadorId);
+
+        // Re-edit con un usuario distinto para que UpdatedBy != CreatedBy.
+        var updateDto = new UpdateProductoDto
+        {
+            Id = creado.Id,
+            Codigo = creado.Codigo,
+            Nombre = creado.Nombre + " v2",
+            TipoProductoId = creado.TipoProductoId,
+            CapacidadKg = creado.CapacidadKg,
+            UnidadVenta = creado.UnidadVenta,
+            PrecioActual = creado.PrecioActual,
+            ManejaGarrafaIndividual = creado.ManejaGarrafaIndividual,
+        };
+        await service.UpdateAsync(updateDto, usuarioId: modificadorId);
+
+        var dto = await service.GetByIdAsync(creado.Id);
+
+        dto.Should().NotBeNull();
+        dto!.CreatedAt.Should().Be(creado.CreatedAt,
+            "CreatedAt del entity se mapea por convención desde Producto.CreatedAt");
+        dto.UpdatedAt.Should().BeAfter(creado.CreatedAt,
+            "UpdatedAt del entity se mapea por convención y debe ser posterior al Create");
+        dto.CreatedByUserName.Should().Be("creador",
+            "LoadAuditUsersAsync resuelve CreatedBy FK → username");
+        dto.UpdatedByUserName.Should().Be("modificador",
+            "LoadAuditUsersAsync resuelve UpdatedBy FK → username");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_AuditFields_NullWhenUsuarioNoExiste()
+    {
+        // Defensa: si el FK apunta a un usuario que fue hard-deleted (no
+        // debería pasar, pero el FK NO es restrict en BD para auditoría),
+        // el DTO debe devolver null en lugar de tirar. LoadAuditUsersAsync
+        // usa IgnoreQueryFilters() para incluir soft-deleted, pero no
+        // puede incluir hard-deleted — el TryGetValue devuelve false y
+        // el username queda null.
+        var (service, context) = NewService(nameof(GetByIdAsync_AuditFields_NullWhenUsuarioNoExiste));
+        var dto = NewCreateDto();
+        var entity = new Producto
+        {
+            Codigo = dto.Codigo,
+            Nombre = dto.Nombre,
+            TipoProductoId = dto.TipoProductoId,
+            CapacidadKg = dto.CapacidadKg,
+            UnidadVenta = dto.UnidadVenta,
+            PrecioActual = dto.PrecioActual,
+            ManejaGarrafaIndividual = dto.ManejaGarrafaIndividual,
+            Activo = true,
+            CreatedAt = DateTime.UtcNow.AddDays(-1),
+            UpdatedAt = DateTime.UtcNow.AddDays(-1),
+            CreatedBy = 999_999UL, // FK que NO existe
+            UpdatedBy = 999_998UL, // FK que NO existe
+        };
+        context.Productos.Add(entity);
+        await context.SaveChangesAsync();
+
+        var result = await service.GetByIdAsync(entity.Id);
+
+        result.Should().NotBeNull();
+        result!.CreatedByUserName.Should().BeNull(
+            "CreatedBy FK sin usuario → username null (no excepción)");
+        result.UpdatedByUserName.Should().BeNull(
+            "UpdatedBy FK sin usuario → username null (no excepción)");
+    }
+
+    // ====================================================================
+    // Issue #147 item 5: 7 branches faltantes en ProductoService. El
+    // código de producción YA maneja estos casos — los tests documentan
+    // el contrato explícitamente para evitar que un refactor los rompa
+    // silenciosamente. Patrón "approval tests for spec scenarios" del
+    // strict-tdd.md.
+    // ====================================================================
+
+    [Fact]
+    public async Task GetByCodigoAsync_NotFound_ReturnsNull()
+    {
+        // Spec scenario "GetByCodigoAsync missing → null": no hay producto
+        // con ese código → la query no devuelve filas → el método devuelve
+        // null (no lanza excepción).
+        var (service, _) = NewService(nameof(GetByCodigoAsync_NotFound_ReturnsNull));
+
+        var resultado = await service.GetByCodigoAsync("GAS-INEXISTENTE");
+
+        resultado.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByCodigoAsync_SoftDeleted_ReturnsNull()
+    {
+        // Spec scenario "GetByCodigoAsync soft-deleted → null": el
+        // QueryFilter global (`p => p.DeletedAt == null`) oculta los
+        // productos soft-deleted de las queries de lectura. Un producto
+        // con DeletedAt != null pero Codigo = "GAS-10" NO debe aparecer.
+        var (service, context) = NewService(nameof(GetByCodigoAsync_SoftDeleted_ReturnsNull));
+        var creado = await service.CreateAsync(NewCreateDto(codigo: "GAS-10"), usuarioId: 1);
+        await service.DeleteAsync(creado.Id, ct: default);
+        // Sanity: el producto realmente está soft-deleted en BD.
+        var entity = await context.Productos.IgnoreQueryFilters().FirstAsync(p => p.Id == creado.Id);
+        entity.DeletedAt.Should().NotBeNull();
+
+        var resultado = await service.GetByCodigoAsync("GAS-10");
+
+        resultado.Should().BeNull(
+            "el QueryFilter global oculta soft-deleted de GetByCodigoAsync");
+    }
+
+    [Fact]
+    public async Task GetByTipoAsync_UnknownTipo_ReturnsEmpty()
+    {
+        // Spec scenario "GetByTipoAsync empty list": no hay productos con
+        // ese tipo → lista vacía (no null, no excepción). El operador
+        // puede estar filtrando por un TipoProductoId recién creado y sin
+        // productos asignados.
+        var (service, _) = NewService(nameof(GetByTipoAsync_UnknownTipo_ReturnsEmpty));
+
+        var resultado = await service.GetByTipoAsync(999UL);
+
+        resultado.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetActivosAsync_MixedStatus_ReturnsOnlyActive()
+    {
+        // Spec scenario "GetActivosAsync filters inactives": con un mix de
+        // activos + soft-deleted, solo Activo=true AND DeletedAt IS NULL
+        // llegan al resultado. Soft-deleted sin DeletedAt != null ya está
+        // excluido por el QueryFilter; este test verifica además que
+        // Activo=false (sin soft-delete) tampoco aparece.
+        var (service, context) = NewService(nameof(GetActivosAsync_MixedStatus_ReturnsOnlyActive));
+        var activo = await service.CreateAsync(NewCreateDto(codigo: "GAS-10"), usuarioId: 1);
+
+        // Producto soft-deleted: Activo=false + DeletedAt!=null → excluido
+        // por ambos (QueryFilter + filtro Activo).
+        var softDeleted = await service.CreateAsync(NewCreateDto(codigo: "GAS-15"), usuarioId: 1);
+        await service.DeleteAsync(softDeleted.Id, ct: default);
+
+        // Producto "inactivo" sin soft-delete (caso raro: Activo=false pero
+        // DeletedAt=null — un zombie). Configuración manual vía BD para
+        // forzar el estado.
+        var zombie = new Producto
+        {
+            Codigo = "GAS-45",
+            Nombre = "Garrafa 45kg",
+            TipoProductoId = 1,
+            UnidadVenta = "UNIDAD",
+            PrecioActual = 30000m,
+            ManejaGarrafaIndividual = false,
+            Activo = false, // sin soft-delete
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        context.Productos.Add(zombie);
+        await context.SaveChangesAsync();
+
+        var resultado = (await service.GetActivosAsync()).ToList();
+
+        resultado.Should().ContainSingle()
+            .Which.Id.Should().Be(activo.Id,
+                "solo el producto activo (Activo=true + DeletedAt=null) debe aparecer");
+        resultado.Should().NotContain(p => p.Id == softDeleted.Id,
+            "soft-deleted debe estar excluido");
+        resultado.Should().NotContain(p => p.Id == zombie.Id,
+            "zombie (Activo=false sin soft-delete) debe estar excluido");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_UnknownId_ThrowsKeyNotFoundException()
+    {
+        // Spec scenario "UpdateAsync unknown Id → KeyNotFoundException": el
+        // FindAsync del Service devuelve null → el método lanza
+        // KeyNotFoundException con un mensaje claro. El Controller traduce
+        // eso a NotFound o ModelState según el patrón existente.
+        // Importante: CapacidadKg > 0 cuando ManejaGarrafaIndividual=true
+        // (issue #146.3). Sin esto, el método tira ValidationException
+        // ANTES de llegar al FindAsync y nunca veríamos el
+        // KeyNotFoundException que queremos verificar.
+        var (service, _) = NewService(nameof(UpdateAsync_UnknownId_ThrowsKeyNotFoundException));
+        var dto = new UpdateProductoDto
+        {
+            Id = 999_999UL, // no existe
+            Codigo = "GAS-10",
+            Nombre = "Garrafa 10kg",
+            TipoProductoId = 1,
+            UnidadVenta = "UNIDAD",
+            CapacidadKg = 10m,
+            PrecioActual = 15000m,
+            ManejaGarrafaIndividual = true,
+        };
+
+        var act = async () => await service.UpdateAsync(dto, usuarioId: 1);
+
+        await act.Should().ThrowAsync<KeyNotFoundException>()
+            .WithMessage("*999999*",
+                "el mensaje debe incluir el Id buscado para que el Controller pueda mostrarlo");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_UnknownId_ReturnsFalse()
+    {
+        // Spec scenario "DeleteAsync unknown Id → false": a diferencia de
+        // UpdateAsync, Delete NO lanza — devuelve false para que el
+        // Controller mapee TempData[Error]. Coherente con RestoreAsync
+        // que también devuelve false para Id inexistente.
+        var (service, _) = NewService(nameof(DeleteAsync_UnknownId_ReturnsFalse));
+
+        var resultado = await service.DeleteAsync(999_999UL);
+
+        resultado.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CreateAsync_NullUser_Succeeds()
+    {
+        // Spec scenario "CreateAsync null userId → no crash": usado por
+        // tests automatizados, seeds y scripts de bootstrap que no tienen
+        // un usuario "humano" detrás. La entity persiste con
+        // CreatedBy=NULL/UpdatedBy=NULL — la auditoría queda "huérfana"
+        // pero la operación no falla.
+        var (service, context) = NewService(nameof(CreateAsync_NullUser_Succeeds));
+
+        var creado = await service.CreateAsync(NewCreateDto(), usuarioId: null);
+
+        creado.Should().NotBeNull();
+        creado.Id.Should().BeGreaterThan(0);
+        var entity = await context.Productos.AsNoTracking().FirstAsync(p => p.Id == creado.Id);
+        entity.CreatedBy.Should().BeNull(
+            "null usuario → CreatedBy NULL en BD (operación sincrónica válida)");
+        entity.UpdatedBy.Should().BeNull();
+    }
+
+    // ====================================================================
+    // Issue #147 item 1: cache de GetTiposProductoAsync con IMemoryCache.
+    // Spec scenario "2nd call within 1 h is cached": el segundo call
+    // dentro de la hora NO debe hit EF Core — debe servirse desde el
+    // cache en memoria.
+    // ====================================================================
+
+    [Fact]
+    public async Task GetTiposProductoAsync_SecondCall_HitsCache()
+    {
+        // Estrategia de verificación: spy sobre el DbContext no es trivial
+        // con InMemoryDatabase (no soporta interceptores). Lo que SÍ
+        // podemos verificar de forma robusta:
+        //   1. Sembrar 2 tipos (GAS, CARBON) en BD antes de la 1er call.
+        //   2. Llamar GetTiposProductoAsync → devuelve [GAS, CARBON].
+        //   3. Agregar un 3er tipo (LENA) directo al context SIN guardar
+        //      (simularía que la BD cambió, pero el cache no se entera).
+        //   4. Llamar GetTiposProductoAsync de nuevo → si la 2da call
+        //      hit BD, devolvería [GAS, CARBON, LENA]; si hit cache,
+        //      devuelve [GAS, CARBON] (sin el LENA recién agregado).
+        //
+        // Si el cache no estuviera implementado, la 2da call vería los 3
+        // tipos (porque EF InMemoryDb ve cualquier entity agregada al
+        // ChangeTracker, incluso sin SaveChanges).
+        var dbName = nameof(GetTiposProductoAsync_SecondCall_HitsCache);
+        var options = new DbContextOptionsBuilder<ExtraGasDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+        using var context = new ExtraGasDbContext(options);
+        var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+        var mapper = mapperConfig.CreateMapper();
+        var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(
+            new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
+        var service = new ProductoService(context, mapper, NullLogger<ProductoService>.Instance, cache);
+
+        // Seed inicial: 2 tipos visibles para el Service.
+        context.TiposProducto.AddRange(
+            new TipoProducto { Id = 1, Codigo = "GAS", Nombre = "Gas" },
+            new TipoProducto { Id = 2, Codigo = "CARBON", Nombre = "Carbón" });
+        await context.SaveChangesAsync();
+
+        // Primera llamada: pobla el cache.
+        var primera = (await service.GetTiposProductoAsync()).ToList();
+        primera.Should().HaveCount(2, "antes del cache hay 2 tipos sembrados");
+
+        // Simulamos un tercer tipo que aparece DESPUÉS de la 1era call.
+        // Si la 2da call hit BD, lo vería; si hit cache, NO.
+        context.TiposProducto.Add(new TipoProducto
+        {
+            Id = 3,
+            Codigo = "LENA",
+            Nombre = "Leña",
+        });
+        await context.SaveChangesAsync();
+
+        // Segunda llamada: debe hit cache (mismos 2 tipos, sin LENA).
+        var segunda = (await service.GetTiposProductoAsync()).ToList();
+        segunda.Should().HaveCount(2,
+            "la 2da call debe hit cache y NO incluir el LENA agregado después");
+        segunda.Select(t => t.Codigo).Should().BeEquivalentTo(new[] { "GAS", "CARBON" });
     }
 }

--- a/tests/ExtraGasMVC.Tests/StringNormalizerTests.cs
+++ b/tests/ExtraGasMVC.Tests/StringNormalizerTests.cs
@@ -160,4 +160,63 @@ public class StringNormalizerTests
         // descarta el resto, así que sb.Length == 1 == longitudMinima → null.
         StringNormalizer.NormalizarTelefono("+ - . ( )").Should().BeNull();
     }
+
+    // --- TrimAndUpper (issue #147 item 6) ---
+    // Normalización canónica de códigos de producto: trim + upper invariant.
+    // Devuelve string.Empty para null/whitespace (no null) porque el dominio
+    // (Producto.Codigo) es NOT NULL — diverge deliberadamente de
+    // NormalizarDni/NormalizarTelefono que devuelven null.
+
+    [Fact]
+    public void TrimAndUpper_Null_DevuelveEmpty()
+    {
+        StringNormalizer.TrimAndUpper(null).Should().Be(
+            string.Empty,
+            "Codigo es NOT NULL — null debe colapsar a string.Empty");
+    }
+
+    [Fact]
+    public void TrimAndUpper_Vacio_DevuelveEmpty()
+    {
+        StringNormalizer.TrimAndUpper(string.Empty).Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void TrimAndUpper_Whitespace_DevuelveEmpty()
+    {
+        StringNormalizer.TrimAndUpper("   ").Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void TrimAndUpper_Minusculas_Uppercase()
+    {
+        StringNormalizer.TrimAndUpper("gas-10").Should().Be("GAS-10");
+    }
+
+    [Fact]
+    public void TrimAndUpper_EspaciosAlrededor_Trim()
+    {
+        StringNormalizer.TrimAndUpper("  gas-10  ").Should().Be("GAS-10");
+    }
+
+    [Fact]
+    public void TrimAndUpper_YaUppercase_NoCambia()
+    {
+        StringNormalizer.TrimAndUpper("GAS-10").Should().Be("GAS-10");
+    }
+
+    [Fact]
+    public void TrimAndUpper_Mixto_TrimYUpper()
+    {
+        // Caso del usuario: " gas-10 " → "GAS-10".
+        StringNormalizer.TrimAndUpper(" gas-10 ").Should().Be("GAS-10");
+    }
+
+    [Fact]
+    public void TrimAndUpper_ConAcentos_NoStrippea_UpperInvariant()
+    {
+        // ToUpperInvariant preserva caracteres no-ASCII — para "café" no
+        // rompe acentos. El spec exige upper, no quitar diacríticos.
+        StringNormalizer.TrimAndUpper("café").Should().Be("CAFÉ");
+    }
 }


### PR DESCRIPTION
… cache tipos_producto (#153)

* feat(extensions): StringNormalizer.TrimAndUpper + tests (#147)

Normaliza Codigo de Producto al borde del Service (trim + upper invariant). Devuelve string.Empty para null/whitespace (no null) porque Producto.Codigo es NOT NULL — diverge de NormalizarDni/NormalizarTelefono deliberadamente.

Cubre spec 'TrimAndUpper(null) → empty' y los 7 casos derivados (8 tests RED → GREEN en StringNormalizerTests).

* feat(productos): normalizar Codigo en Create/Update/Get/Search + tests (#147)

Aplica StringNormalizer.TrimAndUpper al borde del Service (4 métodos):
- CreateAsync: normaliza después del AutoMapper.Map, antes del Add.
- UpdateAsync: normaliza después del Map, antes de SaveChanges.
- GetByCodigoAsync: normaliza el input del lookup (la BD guarda canónico).
- GetPagedAsync: normaliza el busqueda del LIKE.

Cubre spec scenarios 'Create persists normalized', 'GetByCodigoAsync matches normalized input' e 'Index search normalizes input'. 4 tests RED → GREEN en ProductoServiceTests (no production regression).

* feat(productos): exponer audit fields en ProductoDto + MappingProfile explicito (#147)

Agrega 4 miembros a ProductoDto: CreatedAt, UpdatedAt, CreatedByUserName, UpdatedByUserName. MappingProfile.ConfigureProducto declara explicit .ForMember para los 4 (regresión #118):
- CreatedAt, UpdatedAt: MapFrom(s => s.X) — bloqueo por convención rota silenciosa si alguien renombra en la entity.
- CreatedByUserName, UpdatedByUserName: .Ignore() — el Service los resuelve via LoadAuditUsersAsync y los asigna después del Map.

Nuevo MappingProfileProductoTests (2 tests): DtoExposesAuditFields (sanity) y Producto_DtoFromEntity_CreatedByUserName_NotOverwrittenByEntityFK (regresión).

* feat(productos): audit enrichment en GetByIdAsync + LoadAuditUsersAsync + tests (#147)

GetByIdAsync resuelve los usernames de CreatedBy/UpdatedBy via LoadAuditUsersAsync (una sola query batch con IgnoreQueryFilters) y AplicarAudit (copia al DTO si la FK existe). Mismo patrón que UsuarioService:570-587.

Cubre spec scenario 'ProductoDto populates 4 audit fields' y el edge case 'FK → usuario inexistente → username null'. 2 tests RED → GREEN.

* feat(productos): audit fields visibles en Details/Edit views (#147)

Details.cshtml: nueva tarjeta AdminLTE con <dl> rows para los 4 miembros de auditoría (separada del card principal para distinguir metadata de data).

Edit.cshtml: bloque read-only al pie del form con los 4 campos vía ViewBag (NO bindeados al submit, NO parte de UpdateProductoDto). El Service escribe UpdatedAt/UpdatedBy pero el form no debe poder editarlos.

ProductosController.Edit (GET): popula ViewBag.AuditCreatedAt/UpdatedAt/ AuditCreatedBy/AuditUpdatedBy desde el ProductoDto que ya cargó GetByIdAsync (que sí los pobló con LoadAuditUsersAsync).

Cubre spec scenarios 'Details.cshtml renders audit card' y 'Edit.cshtml renders audit fields read-only'.

* test(productos): cubrir 7 branches faltantes en ProductoService (#147)

Tests de 'approval' (sin cambio de producción) que documentan los contratos especificados en el spec del issue #147 item 5:
- GetByCodigoAsync_NotFound_ReturnsNull
- GetByCodigoAsync_SoftDeleted_ReturnsNull (QueryFilter global)
- GetByTipoAsync_UnknownTipo_ReturnsEmpty
- GetActivosAsync_MixedStatus_ReturnsOnlyActive (excluye zombies)
- UpdateAsync_UnknownId_ThrowsKeyNotFoundException (con CapacidadKg>0 para no tropezar con GARRAFA⇒capacidad validation issue #146.3)
- DeleteAsync_UnknownId_ReturnsFalse (no exception)
- CreateAsync_NullUser_Succeeds (auditoría huérfana OK)

Contrato explícito: si un refactor rompe alguno de estos branches, los tests rompen antes que el operador lo sufra en producción.

* feat(productos): IMemoryCache en GetTiposProductoAsync + cache hit test (#147)

Inyecta IMemoryCache en el ctor (Program.cs:16 ya registra AddMemoryCache()). Envuelve GetTiposProductoAsync con _cache.GetOrCreateAsync:
- Clave constante 'tipos_producto' (catálogo seed-only, no per-request).
- TTL absoluto 1h (no sliding — uso típico 'cargar al startup y servir idéntico por 1h', sliding extendería indefinidamente).
- TODO documentado en código: si en el futuro se agrega UI CRUD para TiposProducto, evacuar el cache key en Create/Update/Delete.

Test verifica que la 2da call dentro de la hora NO incluye tipos agregados al DbContext después de la 1era call (spy robusto sin interceptors de InMemoryDatabase).

Ctor updates en ProductoServiceTests.NewService, ProductoServiceRobustez y ProductoPrecioHistoricoIntegration (MemoryCache fresh por test).