### PR TITLE
fix(constants): exponer PedidoEstados como IReadOnlySet (#157)

### DIFF
--- a/src/ExtraGasMVC/Constants/PedidoEstados.cs
+++ b/src/ExtraGasMVC/Constants/PedidoEstados.cs
@@ -15,19 +15,27 @@ public static class PedidoEstados
 
     /// <summary>
     /// States that are considered final — no further transitions allowed.
+    /// Exposed as <see cref="IReadOnlySet{T}"/> so callers can query membership
+    /// without being able to mutate the underlying set (S3887).
     /// </summary>
-    public static readonly HashSet<string> EstadosFinales = new()
+    private static readonly HashSet<string> _estadosFinales = new()
     {
         Entregado,
         Cancelado
     };
 
+    public static readonly IReadOnlySet<string> EstadosFinales = _estadosFinales;
+
     /// <summary>
     /// States where only DireccionEntrega and Observaciones can be edited.
+    /// Exposed as <see cref="IReadOnlySet{T}"/> so callers can query membership
+    /// without being able to mutate the underlying set (S3887).
     /// </summary>
-    public static readonly HashSet<string> EstadosSoloLecturaParcial = new()
+    private static readonly HashSet<string> _estadosSoloLecturaParcial = new()
     {
         Confirmado,
         EnPreparacion
     };
+
+    public static readonly IReadOnlySet<string> EstadosSoloLecturaParcial = _estadosSoloLecturaParcial;
 }


### PR DESCRIPTION
## Resumen

Resuelve #157 — SonarQube reporta 2 bugs de Reliability (`csharpsquid:S3887`) en `src/ExtraGasMVC/Constants/PedidoEstados.cs` por exponer colecciones mutables (`HashSet<string>`) como `public static readonly`.

## Cambios

`src/ExtraGasMVC/Constants/PedidoEstados.cs`:

- `EstadosFinales` y `EstadosSoloLecturaParcial` ahora se exponen como `IReadOnlySet<string>`.
- Los datos se mueven a backing fields `private static readonly HashSet<string>` (`_estadosFinales`, `_estadosSoloLecturaParcial`).
- Los campos públicos mantienen `.Contains(...)` (operación de `IReadOnlySet<T>`), así que ningún caller necesita cambios.

> Nota: el body de la issue describe los campos como `string[]`, pero al revisar el archivo en `develop` ya estaban tipados como `HashSet<string>`. La regla S3887 aplica a ambos (cualquier colección mutable accesible públicamente), y el fix es análogo — se preserva la semántica de búsqueda O(1) de HashSet.

## Verificación de callers

Búsqueda global en el repo (`rg 'EstadosFinales|EstadosSoloLecturaParcial'`) muestra 9 sitios de uso en 3 archivos:

- `src/ExtraGasMVC/Services/Implementations/PedidoService.cs` (líneas 241, 245, 334)
- `src/ExtraGasMVC/Controllers/PedidosController.cs` (líneas 117, 316, 449)
- `src/ExtraGasMVC/Views/Pedidos/Edit.cshtml` (líneas 15, 16)

**Todos invocan solo `.Contains(...)`.** Cero llamadas a `.Add()` / `.Remove()` / index assignment sobre estos campos (verificado por búsqueda negativa).

## Build

```
dotnet build ExtraGasMVC.sln
0 Error(s)
```

Warnings pre-existentes sin relación con el cambio (vulnerabilidades NuGet en AutoMapper / SSH.NET, null reference en `Views/Recepciones/Create.cshtml:62`).

## Criterio de cierre

Cuando se vuelva a correr el análisis de SonarQube post-merge, las 2 instancias de S3887 deben figurar como `FIXED` y el Reliability rating volver a **A**.

## Riesgo / impacto

- **Cambio mínimo** — un archivo, +10/-2 líneas.
- **Sin migraciones, sin dependencias nuevas** (`IReadOnlySet<T>` vive en el BCL desde .NET 5).
- **Sin cambios de comportamiento observable** desde los callers.
- **Backwards-compatible** para cualquier ensamblado que consuma los campos por su tipo concreto `HashSet<string>` — ver nota abajo.

> Heads-up para revisores: el cambio del tipo público *sí* rompe la compatibilidad binaria hacia abajo para consumidores externos que referencien estos campos como `HashSet<string>`. En este repo no aplica (todos los callers son internos y solo usan `.Contains`), pero si en el futuro alguna dependencia externa los consume, ese consumidor necesitará migrar a `IReadOnlySet<string>` antes de actualizar.

## Notas

- Esta issue **no bloquea** el Quality Gate por sí sola (los bugs son pre-existentes, no `new code`). El gate sigue fallando por las 29 violaciones de new code que se trackean en la issue hermana.
- No requiere cambios en CI ni en SonarQube (el scanner detecta S3887 automáticamente).