### PR TITLE
chore(sonarqube): resolver 8 issues new code restantes de #161 (#161)

### DIFF
--- a/src/ExtraGasMVC/Controllers/ProductosController.cs
+++ b/src/ExtraGasMVC/Controllers/ProductosController.cs
@@ -51,7 +51,7 @@ public class ProductosController : BaseController
         await LoadViewBagsAsync(ct);
         // Issue #114: CreateProductoDto ya no expone Activo — lo setea el
         // Service en true. UnidadVenta queda como default de UI.
-        return View(new CreateProductoDto { UnidadVenta = "UNIDAD" });
+        return View(new CreateProductoDto { UnidadVenta = "UNIDAD", ManejaGarrafaIndividual = false });
     }
 
     [HttpPost]

--- a/src/ExtraGasMVC/DTOs/ClienteDto.cs
+++ b/src/ExtraGasMVC/DTOs/ClienteDto.cs
@@ -32,8 +32,9 @@ public class ClienteDtoBase
     [Required(ErrorMessage = "El teléfono principal es obligatorio.")]
     [StringLength(25, ErrorMessage = "El teléfono no puede superar {1} caracteres.")]
     // Issue #117: regex estricto (mín 6 chars) — el regex anterior ^[0-9 +()\-.]*$
-    // permitía string vacío o todo separadores. La app no podía llamar/WhatsAppear
-    // a un cliente con un teléfono basura. Formato argentino típico: "+54 11 4455-6677".
+    // permitía string vacío o compuesto solo por separadores. La app no podía
+    // llamar/WhatsAppear a un cliente con un teléfono basura. Formato argentino
+    // típico: "+54 11 4455-6677".
     [RegularExpression("^[\\d\\s\\-\\+\\(\\)]{6,25}$", ErrorMessage = "El teléfono solo puede contener dígitos, espacios, guiones y signo +.")]
     public string TelefonoPrincipal { get; set; } = null!;
 

--- a/src/ExtraGasMVC/DTOs/ProductoDto.cs
+++ b/src/ExtraGasMVC/DTOs/ProductoDto.cs
@@ -82,12 +82,14 @@ public class CreateProductoDto
     public decimal PrecioActual { get; set; }
 
     [Display(Name = "Maneja garrafas individuales")]
-    // Issue #158 (S6964): [Required] en un bool no bloquea el under-posting
-    // (el binder igual lo llena con false si no se postea), pero cumple con
-    // la regla de SonarQube y blinda contra valores por default accidentales
-    // en consumidores no-MVC (tests, integration scripts).
-    [Required]
-    public bool ManejaGarrafaIndividual { get; set; }
+    // Issue #161 (S6964): C# 11 `required` keyword. [Required] (DataAnnotations)
+    // no alcanza para S6964 sobre un value-type en un DTO de MVC: Sonar exige
+    // una de tres variantes — `nullable`, `required` (keyword) o `[JsonRequired]`.
+    // El keyword es la opción moderna: enforce compile-time en consumers C# y
+    // el binder MVC lo sigue poblando via reflection sin cambios. Tests +
+    // ProductosController.Create (que arma un CreateProductoDto con un set
+    // initializer parcial) deben setear la propiedad explícitamente.
+    public required bool ManejaGarrafaIndividual { get; set; }
 }
 
 /// <summary>
@@ -135,9 +137,9 @@ public class UpdateProductoDto
     public decimal PrecioActual { get; set; }
 
     [Display(Name = "Maneja garrafas individuales")]
-    // Issue #158 (S6964): ver nota sobre [Required] en CreateProductoDto.
-    [Required]
-    public bool ManejaGarrafaIndividual { get; set; }
+    // Issue #161 (S6964): ver nota en CreateProductoDto — `required` keyword
+    // en lugar de [Required] para satisfacer Sonar S6964.
+    public required bool ManejaGarrafaIndividual { get; set; }
 
     /// <summary>
     /// Motivo del cambio de precio. Solo tiene sentido registrarlo cuando el

--- a/src/ExtraGasMVC/Services/Implementations/ClienteService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ClienteService.cs
@@ -472,15 +472,26 @@ public class ClienteService : IClienteService
                 _logger.LogWarning(
                     ex,
                     "Race condition de DNI duplicado (errno 1062) al persistir cambios.");
+                // Issue #161 (S2139): `mapped` ya preserva `ex` como inner
+                // (MapDuplicateDniException devuelve InvalidOperationException(msg, ex)),
+                // así que el rethrow con stack completo cumple la regla.
                 throw mapped;
             }
-            // No es duplicate-DNI: error inesperado de BD. Lo loggeamos con el
-            // stack completo antes de re-throw para que el caller pueda
-            // registrar el error y nosotros tengamos el detalle abajo.
+            // No es duplicate-DNI: error inesperado de BD. Loggeamos el stack
+            // completo y re-lanzamos como una nueva DbUpdateException con un
+            // mensaje contextual. Esto satisface S2139 ("rethrow with
+            // contextual information") sin cambiar el contrato: el Controller
+            // de Clientes sigue catcheando `Exception` genérico y el test
+            // `CreateAsync_cuando_SaveChangesAsync_tira_otra_DbUpdate_*`
+            // espera exactamente DbUpdateException como tipo de salida.
             _logger.LogError(
                 ex,
                 "DbUpdateException no esperada al persistir cliente.");
-            throw;
+            throw new DbUpdateException(
+                "Error de base de datos no esperado al persistir el cliente. " +
+                "La causa original está preservada como inner exception. " +
+                $"Detalle original: {ex.Message}",
+                ex);
         }
     }
 }

--- a/src/ExtraGasMVC/Services/Implementations/ProductoService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/ProductoService.cs
@@ -367,9 +367,6 @@ public class ProductoService : IProductoService
             // ValidationException (mismo canal que las validaciones de
             // las brechas 1-3) para que el Controller renderice un
             // mensaje claro en lugar de un 500 genérico.
-            var codigoLog = (producto.Codigo ?? "<sin código>")
-                .Replace("\r", " ")
-                .Replace("\n", " ");
 
             _logger.LogWarning(ex,
                 "Producto {ProductoId} ({Codigo}) — conflicto de concurrencia al actualizar por {UsuarioId}",
@@ -431,7 +428,16 @@ public class ProductoService : IProductoService
             _logger.LogWarning(ex,
                 "Producto {Id} ({Codigo}) — conflicto de concurrencia al desactivar por {UsuarioId}",
                 producto.Id, producto.Codigo, usuarioId);
-            throw;
+            // Issue #161 (S2139): rethrow CON contexto para satisfacer la
+            // regla. Re-lanzamos como nueva DbUpdateConcurrencyException con
+            // mensaje contextual + preservando `ex` como inner. Mantenemos
+            // el tipo concreto para que el caller pueda distinguir este
+            // error de otros (concurrencia ≠ violación de unique constraint).
+            throw new DbUpdateConcurrencyException(
+                $"Conflicto de concurrencia al desactivar el producto {producto.Codigo}. " +
+                "La causa original está preservada como inner exception. " +
+                $"Detalle original: {ex.Message}",
+                ex);
         }
 
         // Issue #146.7 + #146.6: Delete es AdminOnly (PR #145 Slice 2 lo

--- a/tests/ExtraGasMVC.Tests/ClienteDtoValidationTests.cs
+++ b/tests/ExtraGasMVC.Tests/ClienteDtoValidationTests.cs
@@ -15,9 +15,12 @@ namespace ExtraGasMVC.Tests;
 /// </summary>
 public class ClienteDtoValidationTests
 {
-    // Issue #158 (CA1859): IReadOnlyList porque el caller nunca muta el
-    // resultado de Validator.TryValidateObject — comunica la intención.
-    private static IReadOnlyList<ValidationResult> Validar(object dto)
+    // Issue #161 (CA1859): cambiamos a `List<ValidationResult>` porque CA1859
+    // marca el uso de IReadOnlyList cuando el método siempre materializa una
+    // List internamente — el wrapper genérico agrega una capa sin beneficio de
+    // performance. Los callers siguen pudiendo tratar el resultado como
+    // IEnumerable<ValidationResult> sin cambios.
+    private static List<ValidationResult> Validar(object dto)
     {
         var ctx = new ValidationContext(dto);
         var results = new List<ValidationResult>();

--- a/tests/ExtraGasMVC.Tests/ClienteServiceDniRaceConditionTests.cs
+++ b/tests/ExtraGasMVC.Tests/ClienteServiceDniRaceConditionTests.cs
@@ -266,6 +266,10 @@ public class ClienteServiceDniRaceConditionTests
         var act = async () => await service.CreateAsync(dto, createdBy: 1);
 
         await act.Should().ThrowAsync<DbUpdateException>()
-            .WithMessage("connection lost");
+            // Issue #161 (S2139): el Service ahora envuelve la excepción con
+            // un mensaje contextual ("Error de base de datos no esperado..."),
+            // preservando el DbUpdateException original como inner. El mensaje
+            // original ("connection lost") ahora vive en `InnerException.Message`.
+            .WithMessage("*no esperado al persistir el cliente*");
     }
 }

--- a/tests/ExtraGasMVC.Tests/ProveedorDtoValidationTests.cs
+++ b/tests/ExtraGasMVC.Tests/ProveedorDtoValidationTests.cs
@@ -14,9 +14,12 @@ namespace ExtraGasMVC.Tests;
 /// </summary>
 public class ProveedorDtoValidationTests
 {
-    // Issue #158 (CA1859): IReadOnlyList porque el caller nunca muta el
-    // resultado de Validator.TryValidateObject — comunica la intención.
-    private static IReadOnlyList<ValidationResult> Validar(object dto)
+    // Issue #161 (CA1859): cambiamos a `List<ValidationResult>` porque CA1859
+    // marca el uso de IReadOnlyList cuando el método siempre materializa una
+    // List internamente — el wrapper genérico agrega una capa sin beneficio de
+    // performance. Los callers siguen pudiendo tratar el resultado como
+    // IEnumerable<ValidationResult> sin cambios.
+    private static List<ValidationResult> Validar(object dto)
     {
         var ctx = new ValidationContext(dto);
         var results = new List<ValidationResult>();


### PR DESCRIPTION
## Resumen

Resuelve las **8 issues restantes en new code** de [#161](https://github.com/elflacoseba/ExtraGas/issues/161) que bloqueaban el Quality Gate.

> **Nota:** al tomar la issue, las 26 issues S6964 listadas en el body original estaban **fuera del leak period** — el baseline v1.0 las excluía del new code. El scope real al momento de la resolución era de 8 issues activas.

## Cambios

### S6964 — under-posting value-type (2 issues)

`src/ExtraGasMVC/DTOs/ProductoDto.cs` — `CreateProductoDto.ManejaGarrafaIndividual` y `UpdateProductoDto.ManejaGarrafaIndividual`:

- **Antes:** `[Required]` (DataAnnotations) — Sonar S6964 lo rechaza para value-types en MVC.
- **Después:** C# 11 `required` keyword. Es una de las 3 variantes que acepta la regla (`nullable`, `required`, `[JsonRequired]`).
- **Consumers actualizados:** `ProductosController.Create` ahora setea la propiedad al armar el DTO inicial.

### S2139 — silent catches con log + rethrow sin contexto (2 issues)

- `ClienteService.SaveOrThrowDuplicateDniAsync`: el path "no es duplicate-DNI" ahora hace `throw new DbUpdateException(msg, ex)` con mensaje contextual, preservando `ex` como inner. Mantiene el **tipo concreto** `DbUpdateException` para que el Controller siga distinguiendo errores de BD genéricos.
- `ProductoService.DeleteAsync`: idem, `throw new DbUpdateConcurrencyException(msg, ex)` con contexto.

### S1481 — variable local sin uso (1 issue)

- `ProductoService.UpdateAsync` L370: `var codigoLog = ...` se calculaba pero nunca se usaba (sospecho que era residue de un fix anterior). Removido.

### S1135 — false positive de TODO (1 issue)

- `ClienteDto.cs` L35: el comentario decía "...string vacío o todo separadores..." — la palabra **todo** (todo lowercase) matcheaba la heurística S1135. Rephrasing a "compuesto solo por separadores".

### CA1859 — return type subóptimo (2 issues)

- `ClienteDtoValidationTests.Validar` y `ProveedorDtoValidationTests.Validar`: cambiado de `IReadOnlyList<ValidationResult>` a `List<ValidationResult>`. CA1859 marca `IReadOnlyList` cuando internamente siempre se materializa una `List`.

## Test updates

- `ClienteServiceDniRaceConditionTests`: actualizado el `.WithMessage(...)` para reflejar que la DbUpdateException ahora tiene mensaje contextual. Sigue esperando `DbUpdateException` como tipo (contrato del Controller intacto).

## Validación

- **Build:** OK
- **Tests:** 394/394 pass
- **SonarQube Quality Gate:** **OK** (new_violations=0, new_coverage=78.3%, new_duplicated_lines_density=0.14%)

## Cierra

- Closes #161
