### PR TITLE
feat(pedidos): histórico append-only de cambios de estado (#165)

### DIFF
--- a/db/docs/DECISIONES.md
+++ b/db/docs/DECISIONES.md
@@ -392,6 +392,38 @@ Mensaje de error de PedidoService: `"El producto {nombre} (id={id}) fue desactiv
 
 ---
 
+## 20. Histórico append-only de cambios de estado de pedidos
+
+**Contexto:** `pedidos` solo guardaba `estado_pedido_id` + `updated_at` + `updated_by` + `motivo_cancelacion` (este último cuando aplicaba). Si un pedido recorría `PENDIENTE → CONFIRMADO → EN_PREPARACION → ENTREGADO`, el sistema perdía el rastro de los estados intermedios. Para auditoría (¿cuándo se confirmó? ¿cuánto tiempo estuvo en preparación? ¿quién lo canceló y por qué motivo en cada paso?) no había forma de reconstruirlo. Issue #165.
+
+**Decisión:** crear tabla `pedido_estados_historico` append-only, escrita exclusivamente desde un helper privado (`PedidoService.RegistrarCambioEstadoAsync`) invocado dentro del mismo `SaveChangesAsync` que muta `pedidos.estado_pedido_id`. Schema (`db/migrations/20260831_000002_create_pedido_estados_historico.sql`):
+
+- Columnas: `id`, `pedido_id` (FK RESTRICT), `estado_anterior_id` (FK RESTRICT, NULL permitido — solo se usaría para una hipotética fila de estado inicial, hoy no se inserta), `estado_nuevo_id` (FK RESTRICT, NOT NULL), `motivo_cancelacion` (VARCHAR(500) NULL, solo se setea cuando destino = CANCELADO), `usuario_id` (FK RESTRICT NULL), `created_at` (default CURRENT_TIMESTAMP).
+- Sin `updated_at`, sin `deleted_at` — append-only. Borrar una fila sería reescribir la historia.
+- Índice `(pedido_id, created_at DESC)` cubre la query más frecuente: `SELECT ... WHERE pedido_id = ? ORDER BY created_at DESC` que alimenta la timeline de `Details` y el endpoint `GET /Pedidos/{id}/historial-estados`.
+- FKs `RESTRICT` (no CASCADE) — no se puede borrar un pedido, estado o usuario que tengan historial registrado. Si un día hay que desvincular, se hace explícitamente, no por side-effect.
+
+**Por qué:**
+
+- **Append-only es el patrón del sistema.** `movimientos_garrafa` (ADR #2 implícito) y `producto_precios_historico` (ADR #18) ya usan este modelo. Consistencia interna: las tablas de auditoría NO se actualizan ni borran, solo se les agrega filas. Un PRD nuevo que pida "borrar el historial" se rechazaría por inconsistente con dos ADRs previos.
+- **El helper se invoca dentro del `SaveChangesAsync` que muta `pedido`**. Garantía atómica: si falla el `UPDATE` de `pedidos.estado_pedido_id`, no queda fila huérfana en el histórico. El path de canje (`AplicarCanjeYConfirmarAsync`) además abre una transacción ambiente (`BeginTransactionAsync` en `RegistrarCanjePedidoAsync`), así que si la fila de histórico falla por FK violada o cualquier otra razón, el rollback deshace también los `movimientos_garrafa` y la transición a CONFIRMADO. No hay estado intermedio observable.
+- **Trigger AFTER UPDATE descartado.** La alternativa más simple sería un trigger `AFTER UPDATE ON pedidos` que escriba la fila de historial. Se descartó porque perderíamos `usuario_id` y `motivo_cancelacion` confiables: los triggers no tienen contexto del usuario actual salvo vía `CURRENT_USER()` o variables de sesión, y no reciben el motivo de cancelación como parámetro. Hacer una variable de sesión por cada transición es complejidad innecesaria cuando el código de la app ya conoce esos valores.
+- **FKs RESTRICT.** Mismo razonamiento que ADR #18: la trazabilidad es más importante que la limpieza. Borrar un usuario debería ser una operación consciente (desvincular primero el historial explícitamente), no un side-effect de CASCADE.
+- **`estado_anterior_id` NULLABLE** aunque hoy la app nunca inserta NULL — la fila de creación del pedido no se registra (el estado inicial siempre es PENDIENTE, conocido por convención). Dejar la columna NULLABLE permite un eventual seed de migración / import inicial que represente el estado inicial sin tocar el schema. Si en el futuro alguien quiere auditar también la fila de creación (quién la creó y cuándo), basta agregar el INSERT en `CreateAsync` sin migración.
+- **`motivo_cancelacion` se persiste crudo desde el helper.** El Service ya hace `.Trim()` antes de guardarlo en `pedidos.motivo_cancelacion`, pero el helper recibe el valor original (que en ese punto ya fue validado no-vacío). Funcionalmente equivalente: si no es vacío al ingresar, después del trim sigue siendo no-vacío.
+- **No se inserta fila en `CreateAsync`**. Solo se registran TRANSICIONES. La app no expone la creación del pedido como "estado inicial explícito"; el estado inicial se deriva de la convención (PENDIENTE) más la fila 1 del historial cuando ocurre la primera transición. Si alguien pide auditar también el INSERT inicial, se agrega el helper en `CreateAsync` con `estado_anterior_id = null` — sin migración.
+
+**Implicancia:**
+
+- Cualquier futuro flujo que cambie `pedidos.estado_pedido_id` DEBE invocar `RegistrarCambioEstadoAsync`. Hoy son tres: `CambiarEstadoAsync` (path genérico), `ConfirmarSinCanjeAsync` (caso degenerado VENTA-only), `AplicarCanjeYConfirmarAsync` (path canje). Si mañana se agrega un flujo tipo "cancelación masiva de pedidos vencidos", ese flujo debe llamar al helper en su `SaveChanges` final.
+- El helper NO llama `SaveChanges` por sí mismo — se invoca dentro del `SaveChangesAsync` del caller. Esta restricción está documentada en el XMLDoc del método y protegida por los tests (`PedidoServiceCambiarEstadoTests`: la fila aparece después del `CambiarEstadoAsync`, no antes).
+- El `CreatedAt` se setea explícitamente en C# (`DateTime.UtcNow`) como defensa contra el desfase entre el reloj de la app y el del servidor MySQL — mismo patrón que ADR #18. El default `CURRENT_TIMESTAMP` de la columna es el fallback si alguien hace `INSERT` manual sin setearlo.
+- La vista `Details.cshtml` muestra la timeline solo si hay al menos una entrada. Un pedido recién creado no muestra la card hasta su primera transición — comportamiento correcto, no es un bug.
+- El endpoint `GET /Pedidos/{id}/historial-estados` es la API pública del modelo de auditoría. Devuelve 404 si el pedido no existe; 200 con array (posiblemente vacío) si existe pero no tiene transiciones.
+- Si en el futuro hay que revertir una transición "mal registrada", NO se borra la fila del histórico. Se hace un nuevo INSERT con `motivo_cancelacion = "Reversión de ID=X"` o, si el cambio fue correcto, se acepta como parte de la historia. La trazabilidad es preservar la verdad de lo que pasó, no maquillar los errores.
+
+---
+
 ## Supuestos explícitos (no validados con el usuario)
 
 1. No hay delivery con zonas / tarifas distintas. Un pedido = una dirección.

--- a/db/migrations/20260831_000002_create_pedido_estados_historico.sql
+++ b/db/migrations/20260831_000002_create_pedido_estados_historico.sql
@@ -1,0 +1,74 @@
+-- =============================================================================
+-- 20260831_000002_create_pedido_estados_historico.sql
+-- Crea la tabla append-only `pedido_estados_historico` para auditoría
+-- completa de cambios de estado de pedidos.
+--
+-- Issue #165: hoy `pedidos` solo guarda `estado_pedido_id` + `updated_at`
+-- + `updated_by` + `motivo_cancelacion`. Si un pedido recorre
+-- PENDIENTE → CONFIRMADO → EN_PREPARACION → ENTREGADO, el sistema pierde
+-- el rastro de los estados intermedios. Para auditoría (¿cuándo se
+-- confirmó? ¿cuánto tiempo estuvo en preparación? ¿quién lo canceló y
+-- por qué motivo en cada paso?) no hay forma de reconstruirlo.
+--
+-- Patrón consistente con:
+--   - movimientos_garrafa (ADR #2 implícito, modelo append-only).
+--   - producto_precios_historico (ADR #18, FKs RESTRICT, sin soft-delete,
+--     sin updated_at).
+--
+-- Decisiones:
+--   - Tabla append-only: sin columnas de soft-delete ni updated_at. Borrar
+--     una fila sería reescribir la historia.
+--   - FKs ON DELETE RESTRICT: no se permite perder histórico borrando un
+--     pedido, estado o usuario referenciado. La auditoría es más importante
+--     que la limpieza (mismo razonamiento que ADR #18).
+--   - estado_anterior_id NULLABLE: una hipotética fila de creación del
+--     pedido (estado inicial) tendría NULL porque no hay estado previo.
+--     Hoy no se inserta esa fila — la app solo registra TRANSICIONES.
+--     El NULL queda permitido para que un eventual seed de migración /
+--     import inicial pueda representar el estado inicial sin tocar el
+--     schema.
+--   - motivo_cancelacion VARCHAR(500) NULL: solo se setea cuando el destino
+--     es CANCELADO. En cualquier otra transición es NULL. Coincide con el
+--     ancho de pedidos.motivo_cancelacion.
+--   - Índice (pedido_id, created_at DESC): cubre la query más frecuente:
+--     "SELECT ... WHERE pedido_id = ? ORDER BY created_at DESC", que es
+--     la timeline del pedido (Details + endpoint /historial-estados).
+--
+-- Idempotencia:
+--   - CREATE TABLE IF NOT EXISTS cubre el re-run directo.
+--   - El índice está DENTRO del CREATE TABLE (no como ALTER posterior),
+--     así que es creado atómicamente con la tabla en la primera ejecución
+--     y skipped automáticamente en las siguientes.
+--   - El nombre del archivo usa 000002 porque 000001 (add_productos_row_version)
+--     ya existe en el mismo día.
+--   - La capa runner (schema_migrations) skippea si el checksum coincide.
+-- =============================================================================
+
+USE extragas;
+
+CREATE TABLE IF NOT EXISTS `pedido_estados_historico` (
+  `id`                 BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `pedido_id`          BIGINT UNSIGNED NOT NULL,
+  `estado_anterior_id` BIGINT UNSIGNED NULL,
+  `estado_nuevo_id`    BIGINT UNSIGNED NOT NULL,
+  `motivo_cancelacion` VARCHAR(500)    NULL,
+  `usuario_id`         BIGINT UNSIGNED NULL,
+  `created_at`         DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_peh_pedido_created` (`pedido_id`, `created_at` DESC),
+  CONSTRAINT `fk_peh_pedido`
+    FOREIGN KEY (`pedido_id`) REFERENCES `pedidos` (`id`)
+    ON DELETE RESTRICT,
+  CONSTRAINT `fk_peh_estado_anterior`
+    FOREIGN KEY (`estado_anterior_id`) REFERENCES `estados_pedido` (`id`)
+    ON DELETE RESTRICT,
+  CONSTRAINT `fk_peh_estado_nuevo`
+    FOREIGN KEY (`estado_nuevo_id`) REFERENCES `estados_pedido` (`id`)
+    ON DELETE RESTRICT,
+  CONSTRAINT `fk_peh_usuario`
+    FOREIGN KEY (`usuario_id`) REFERENCES `usuarios` (`id`)
+    ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Auditoría append-only de cambios de estado de pedidos (issue #165)';
+
+SELECT 'Tabla pedido_estados_historico lista' AS status;

--- a/src/ExtraGasMVC/Controllers/PedidosController.cs
+++ b/src/ExtraGasMVC/Controllers/PedidosController.cs
@@ -70,6 +70,12 @@ public class PedidosController : BaseController
         var movimientosGarrafa = await _garrafaService.GetMovimientosByPedidoAsync(id, ct);
         ViewBag.MovimientosGarrafa = movimientosGarrafa;
 
+        // Issue #165: timeline de cambios de estado. Append-only, ordenada
+        // del más reciente al más antiguo. La card se rendera solo cuando
+        // hay al menos una transición registrada.
+        var historialEstados = await _pedidoService.GetHistorialEstadosAsync(id, ct);
+        ViewBag.HistorialEstados = historialEstados;
+
         return View(pedido);
     }
 
@@ -322,6 +328,27 @@ public class PedidosController : BaseController
     {
         var pedidos = await _pedidoService.GetPendientesAsync(ct);
         return View(pedidos);
+    }
+
+    /// <summary>
+    /// Issue #165: endpoint que devuelve el historial append-only de
+    /// cambios de estado del pedido en formato JSON, ordenado del más
+    /// reciente al más antiguo. Alimenta integraciones AJAX (futuro) y
+    /// sirve como contrato público del modelo de auditoría.
+    /// </summary>
+    /// <returns>
+    /// 404 si el pedido no existe (mismo contrato que Details); 200 con
+    /// array (posiblemente vacío) si existe. Un pedido recién creado no
+    /// tiene entradas en el histórico hasta su primera transición.
+    /// </returns>
+    [HttpGet]
+    public async Task<IActionResult> HistorialEstados(ulong id, CancellationToken ct = default)
+    {
+        var pedido = await _pedidoService.GetByIdAsync(id, ct);
+        if (pedido is null) return NotFound();
+
+        var historial = await _pedidoService.GetHistorialEstadosAsync(id, ct);
+        return Ok(historial);
     }
 
     // ---- Items del pedido ----

--- a/src/ExtraGasMVC/DTOs/PedidoEstadoHistoricoDto.cs
+++ b/src/ExtraGasMVC/DTOs/PedidoEstadoHistoricoDto.cs
@@ -1,0 +1,28 @@
+namespace ExtraGasMVC.DTOs;
+
+/// <summary>
+/// DTO de una fila de <c>pedido_estados_historico</c> (issue #165).
+/// Expone los datos crudos (ids, motivo, fecha) y, para la vista de
+/// timeline, los nombres legibles de los estados y del usuario que
+/// disparó la transición.
+/// </summary>
+public class PedidoEstadoHistoricoDto
+{
+    public ulong Id { get; set; }
+    public ulong PedidoId { get; set; }
+    public ulong? EstadoAnteriorId { get; set; }
+    public ulong EstadoNuevoId { get; set; }
+    public string? MotivoCancelacion { get; set; }
+    public ulong? UsuarioId { get; set; }
+    public DateTime CreatedAt { get; set; }
+
+    // Display fields (resolved via Include en el Service).
+    public string? EstadoAnteriorCodigo { get; set; }
+    public string? EstadoAnteriorNombre { get; set; }
+    public string? EstadoAnteriorColor { get; set; }
+    public string EstadoNuevoCodigo { get; set; } = null!;
+    public string EstadoNuevoNombre { get; set; } = null!;
+    public string? EstadoNuevoColor { get; set; }
+
+    public string? UsuarioNombre { get; set; }
+}

--- a/src/ExtraGasMVC/Data/Configurations/PedidoEstadoHistoricoConfiguration.cs
+++ b/src/ExtraGasMVC/Data/Configurations/PedidoEstadoHistoricoConfiguration.cs
@@ -1,0 +1,68 @@
+using ExtraGasMVC.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ExtraGasMVC.Data.Configurations;
+
+/// <summary>
+/// Configuración EF Core de <see cref="PedidoEstadoHistorico"/>.
+/// Tabla append-only: sin soft-delete (no <c>HasQueryFilter</c>), sin
+/// <c>UpdatedAt</c>. Los FKs usan <c>RESTRICT</c> porque no queremos
+/// perder histórico si se intenta borrar un pedido, estado o usuario
+/// referenciado.
+///
+/// El índice <c>idx_peh_pedido_created</c> cubre la query más frecuente:
+/// "SELECT ... WHERE pedido_id = ? ORDER BY created_at DESC" que alimenta
+/// la timeline de Details y el endpoint <c>/Pedidos/{id}/historial-estados</c>.
+/// </summary>
+public class PedidoEstadoHistoricoConfiguration : IEntityTypeConfiguration<PedidoEstadoHistorico>
+{
+    public void Configure(EntityTypeBuilder<PedidoEstadoHistorico> builder)
+    {
+        builder.ToTable("pedido_estados_historico");
+
+        builder.HasKey(h => h.Id);
+        builder.Property(h => h.Id).HasColumnName("id");
+
+        builder.Property(h => h.PedidoId).HasColumnName("pedido_id");
+        builder.Property(h => h.EstadoAnteriorId).HasColumnName("estado_anterior_id");
+        builder.Property(h => h.EstadoNuevoId).HasColumnName("estado_nuevo_id");
+        builder.Property(h => h.MotivoCancelacion)
+            .HasColumnName("motivo_cancelacion")
+            .HasMaxLength(500);
+        builder.Property(h => h.UsuarioId).HasColumnName("usuario_id");
+
+        builder.Property(h => h.CreatedAt)
+            .HasColumnName("created_at")
+            .HasColumnType("datetime")
+            .ValueGeneratedOnAdd()
+            .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+        builder.HasOne(h => h.Pedido)
+            .WithMany()
+            .HasForeignKey(h => h.PedidoId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("fk_peh_pedido");
+
+        builder.HasOne(h => h.EstadoAnterior)
+            .WithMany()
+            .HasForeignKey(h => h.EstadoAnteriorId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("fk_peh_estado_anterior");
+
+        builder.HasOne(h => h.EstadoNuevo)
+            .WithMany()
+            .HasForeignKey(h => h.EstadoNuevoId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("fk_peh_estado_nuevo");
+
+        builder.HasOne(h => h.Usuario)
+            .WithMany()
+            .HasForeignKey(h => h.UsuarioId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("fk_peh_usuario");
+
+        builder.HasIndex(h => new { h.PedidoId, h.CreatedAt })
+            .HasDatabaseName("idx_peh_pedido_created");
+    }
+}

--- a/src/ExtraGasMVC/Data/Context/ExtraGasDbContext.cs
+++ b/src/ExtraGasMVC/Data/Context/ExtraGasDbContext.cs
@@ -38,6 +38,8 @@ public class ExtraGasDbContext : DbContext
     public DbSet<Pedido> Pedidos => Set<Pedido>();
     public DbSet<PedidoItem> PedidoItems => Set<PedidoItem>();
     public DbSet<Pago> Pagos => Set<Pago>();
+    // Issue #165: histórico append-only de cambios de estado de pedidos.
+    public DbSet<PedidoEstadoHistorico> PedidoEstadosHistorico => Set<PedidoEstadoHistorico>();
 
     // ============== Recepciones y pagos a proveedor ==============
     public DbSet<RecepcionProveedor> RecepcionesProveedor => Set<RecepcionProveedor>();

--- a/src/ExtraGasMVC/Data/Entities/PedidoEstadoHistorico.cs
+++ b/src/ExtraGasMVC/Data/Entities/PedidoEstadoHistorico.cs
@@ -1,0 +1,35 @@
+namespace ExtraGasMVC.Data.Entities;
+
+/// <summary>
+/// Registro append-only de cambios de estado de un <see cref="Pedido"/>.
+/// Una fila por transición efectiva (estado anterior != estado nuevo).
+/// Sin soft-delete, sin updated_at: la tabla es inmutable por convención y
+/// por diseño (issue #165).
+///
+/// El Service <c>PedidoService</c> es el único punto de INSERT, vía el
+/// helper privado <c>RegistrarCambioEstadoAsync</c> que se invoca dentro
+/// del mismo <c>SaveChangesAsync</c> que muta <c>pedidos.estado_pedido_id</c>.
+/// Si el <c>SaveChanges</c> falla, ni la mutación del pedido ni la fila
+/// de historial quedan persistidas — atomicidad garantizada por compartir
+/// transacción.
+///
+/// Decisión de diseño: las columnas se llaman en snake_case en SQL
+/// (<c>estado_anterior_id</c>, <c>motivo_cancelacion</c>, etc.) siguiendo
+/// la convención del repositorio (AGENTS.md §Convenciones), mapeadas vía
+/// <c>PedidoEstadoHistoricoConfiguration</c>.
+/// </summary>
+public class PedidoEstadoHistorico
+{
+    public ulong Id { get; set; }
+    public ulong PedidoId { get; set; }
+    public ulong? EstadoAnteriorId { get; set; }
+    public ulong EstadoNuevoId { get; set; }
+    public string? MotivoCancelacion { get; set; }
+    public ulong? UsuarioId { get; set; }
+    public DateTime CreatedAt { get; set; }
+
+    public Pedido Pedido { get; set; } = null!;
+    public EstadoPedido? EstadoAnterior { get; set; }
+    public EstadoPedido EstadoNuevo { get; set; } = null!;
+    public Usuario? Usuario { get; set; }
+}

--- a/src/ExtraGasMVC/Mappings/MappingProfile.cs
+++ b/src/ExtraGasMVC/Mappings/MappingProfile.cs
@@ -23,6 +23,30 @@ public class MappingProfile : Profile
         ConfigureProvincia();
         ConfigureEmpleado();
         ConfigureVSaldoCliente();
+        ConfigurePedidoEstadoHistorico();
+    }
+
+    // Issue #165: histórico append-only de cambios de estado de pedidos.
+    // Mapea los nombres legibles de los estados (anterior/nuevo) y del
+    // usuario para alimentar la timeline en Details.cshtml y el endpoint
+    // /Pedidos/{id}/historial-estados.
+    private void ConfigurePedidoEstadoHistorico()
+    {
+        CreateMap<PedidoEstadoHistorico, PedidoEstadoHistoricoDto>()
+            .ForMember(d => d.EstadoAnteriorCodigo, o => o.MapFrom(s =>
+                s.EstadoAnterior != null ? s.EstadoAnterior.Codigo : null))
+            .ForMember(d => d.EstadoAnteriorNombre, o => o.MapFrom(s =>
+                s.EstadoAnterior != null ? s.EstadoAnterior.Nombre : null))
+            .ForMember(d => d.EstadoAnteriorColor, o => o.MapFrom(s =>
+                s.EstadoAnterior != null ? s.EstadoAnterior.Color : null))
+            .ForMember(d => d.EstadoNuevoCodigo, o => o.MapFrom(s =>
+                s.EstadoNuevo != null ? s.EstadoNuevo.Codigo : string.Empty))
+            .ForMember(d => d.EstadoNuevoNombre, o => o.MapFrom(s =>
+                s.EstadoNuevo != null ? s.EstadoNuevo.Nombre : string.Empty))
+            .ForMember(d => d.EstadoNuevoColor, o => o.MapFrom(s =>
+                s.EstadoNuevo != null ? s.EstadoNuevo.Color : null))
+            .ForMember(d => d.UsuarioNombre, o => o.MapFrom(s =>
+                s.Usuario != null ? s.Usuario.Username : null));
     }
 
     // Issue #109: mapping de la vista v_saldo_clientes para evitar N+1 en

--- a/src/ExtraGasMVC/Services/Implementations/PedidoService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/PedidoService.cs
@@ -349,9 +349,21 @@ public class PedidoService : IPedidoService
             pedido.MotivoCancelacion = motivoCancelacion.Trim();
         }
 
+        // Issue #165: capturar el estado previo ANTES de pisar el entity.
+        // Si capturáramos después, estadoAnteriorId == nuevoEstadoId y la
+        // fila de historial diría "transición de X a X".
+        var estadoAnteriorId = pedido.EstadoPedidoId;
+
         pedido.EstadoPedidoId = nuevoEstadoId;
         pedido.UpdatedAt = DateTime.UtcNow;
         pedido.UpdatedBy = usuarioId;
+
+        // Issue #165: append-only audit. Se inserta dentro del MISMO
+        // SaveChangesAsync que persiste la mutación de pedido — si el
+        // SaveChanges falla, ni el cambio de estado ni la fila de historial
+        // quedan persistidas. Atomicidad garantizada por compartir el
+        // SaveChanges (no hace falta transacción explícita acá).
+        await RegistrarCambioEstadoAsync(id, estadoAnteriorId, nuevoEstadoId, usuarioId, motivoCancelacion, ct);
 
         await _context.SaveChangesAsync(ct);
 
@@ -718,9 +730,18 @@ public class PedidoService : IPedidoService
     private async Task<bool> ConfirmarSinCanjeAsync(
         Pedido pedido, ulong estadoConfirmadoId, ulong? usuarioId, CancellationToken ct)
     {
+        // Issue #165: capturar estado previo antes de la mutación.
+        var estadoAnteriorId = pedido.EstadoPedidoId;
+
         pedido.EstadoPedidoId = estadoConfirmadoId;
         pedido.UpdatedAt = DateTime.UtcNow;
         pedido.UpdatedBy = usuarioId;
+
+        // Append-only audit. ConfirmarSinCanjeAsync no abre transacción
+        // propia (es un único SaveChanges); el helper y la mutación del
+        // pedido commitean atómicamente juntos.
+        await RegistrarCambioEstadoAsync(pedido.Id, estadoAnteriorId, estadoConfirmadoId, usuarioId, motivo: null, ct);
+
         await _context.SaveChangesAsync(ct);
         return true;
     }
@@ -890,9 +911,21 @@ public class PedidoService : IPedidoService
                 estadoDestinoId, clienteIdParaCanje, ctx.UsuarioId, ct);
         }
 
+        // Issue #165: capturar estado previo antes de la mutación. La
+        // transición a CONFIRMADO via canje puede partir de PENDIENTE
+        // (caso normal) o EN_PREPARACION (post-#144), por eso leemos el
+        // id vigente en el entity en lugar de hardcodear.
+        var estadoAnteriorId = ctx.Pedido.EstadoPedidoId;
+
         ctx.Pedido.EstadoPedidoId = ctx.EstadoConfirmadoId;
         ctx.Pedido.UpdatedAt = DateTime.UtcNow;
         ctx.Pedido.UpdatedBy = ctx.UsuarioId;
+
+        // Append-only audit. La transacción ambiente abierta por
+        // RegistrarCanjePedidoAsync cubre este SaveChanges — si la fila de
+        // historial falla por cualquier razón (FK violada, etc.), la
+        // transacción rollbackea y el pedido queda en su estado original.
+        await RegistrarCambioEstadoAsync(ctx.PedidoId, estadoAnteriorId, ctx.EstadoConfirmadoId, ctx.UsuarioId, motivo: null, ct);
 
         await _context.SaveChangesAsync(ct);
     }
@@ -936,6 +969,44 @@ public class PedidoService : IPedidoService
 
     #endregion
 
+    /// <summary>
+    /// Issue #165: helper privado que registra una fila append-only en
+    /// <c>pedido_estados_historico</c>. NO llama a <c>SaveChanges</c> por
+    /// sí mismo — se invoca dentro del mismo <c>SaveChangesAsync</c> del
+    /// caller para garantizar atomicidad con la mutación de
+    /// <c>pedidos.estado_pedido_id</c>. Si el SaveChanges falla, ni el
+    /// cambio de estado ni la fila de historial quedan persistidas.
+    /// </summary>
+    /// <param name="estadoAnteriorId">
+    /// Id del estado del pedido ANTES de la transición. El caller debe
+    /// capturar este valor de <c>pedido.EstadoPedidoId</c> ANTES de
+    /// pisarlo, o la fila diría "transición de X a X".
+    /// </param>
+    /// <param name="motivo">
+    /// Motivo de cancelación cuando aplica. Coincide con el valor
+    /// persistido en <c>pedidos.motivo_cancelacion</c>; null en cualquier
+    /// transición cuyo destino no sea CANCELADO.
+    /// </param>
+    private Task RegistrarCambioEstadoAsync(
+        ulong pedidoId,
+        ulong? estadoAnteriorId,
+        ulong estadoNuevoId,
+        ulong? usuarioId,
+        string? motivo,
+        CancellationToken ct = default)
+    {
+        _context.PedidoEstadosHistorico.Add(new PedidoEstadoHistorico
+        {
+            PedidoId = pedidoId,
+            EstadoAnteriorId = estadoAnteriorId,
+            EstadoNuevoId = estadoNuevoId,
+            UsuarioId = usuarioId,
+            MotivoCancelacion = motivo,
+            CreatedAt = DateTime.UtcNow,
+        });
+        return Task.CompletedTask;
+    }
+
     #region State & Lookups
 
     public async Task<List<EstadoPedidoDto>> GetTransicionesDisponiblesAsync(ulong pedidoId, CancellationToken ct = default)
@@ -973,6 +1044,33 @@ public class PedidoService : IPedidoService
                 .ToListAsync(ct);
             return _mapper.Map<List<EstadoPedidoDto>>(estados);
         }) ?? [];
+    }
+
+    /// <summary>
+    /// Issue #165: devuelve el historial append-only de cambios de estado
+    /// del pedido, ordenado del más reciente al más antiguo. Cubre la
+    /// timeline de <c>Pedidos/Details.cshtml</c> y el endpoint
+    /// <c>/Pedidos/{id}/historial-estados</c>.
+    ///
+    /// El índice <c>idx_peh_pedido_created (pedido_id, created_at DESC)</c>
+    /// cubre exactamente esta query. El <c>Id DESC</c> como tiebreaker
+    /// garantiza orden estable cuando dos filas comparten timestamp (caso
+    /// raro pero posible bajo clock skew entre la app y MySQL).
+    /// </summary>
+    public async Task<IEnumerable<PedidoEstadoHistoricoDto>> GetHistorialEstadosAsync(
+        ulong pedidoId, CancellationToken ct = default)
+    {
+        var entries = await _context.PedidoEstadosHistorico
+            .AsNoTracking()
+            .Include(h => h.EstadoAnterior)
+            .Include(h => h.EstadoNuevo)
+            .Include(h => h.Usuario)
+            .Where(h => h.PedidoId == pedidoId)
+            .OrderByDescending(h => h.CreatedAt)
+            .ThenByDescending(h => h.Id)
+            .ToListAsync(ct);
+
+        return _mapper.Map<IEnumerable<PedidoEstadoHistoricoDto>>(entries);
     }
 
     public async Task<List<CanalVentaDto>> GetCanalesVentaAsync(CancellationToken ct = default)

--- a/src/ExtraGasMVC/Services/Interfaces/IPedidoService.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IPedidoService.cs
@@ -31,6 +31,21 @@ public interface IPedidoService
     Task<bool> CambiarEstadoAsync(ulong id, ulong nuevoEstadoId, string? motivoCancelacion, ulong? usuarioId, CancellationToken ct = default);
     Task<List<EstadoPedidoDto>> GetTransicionesDisponiblesAsync(ulong pedidoId, CancellationToken ct = default);
 
+    /// <summary>
+    /// Devuelve el historial append-only de cambios de estado del pedido
+    /// (issue #165), ordenado del más reciente al más antiguo. Cada fila
+    /// incluye los nombres legibles del estado anterior/nuevo y del
+    /// usuario que disparó la transición, para alimentar la timeline de
+    /// <c>Pedidos/Details.cshtml</c> y el endpoint
+    /// <c>/Pedidos/{id}/historial-estados</c>.
+    /// </summary>
+    /// <remarks>
+    /// El índice <c>idx_peh_pedido_created (pedido_id, created_at DESC)</c>
+    /// cubre exactamente esta query. Si el pedido no existe o no tiene
+    /// transiciones registradas, devuelve enumerable vacío.
+    /// </remarks>
+    Task<IEnumerable<PedidoEstadoHistoricoDto>> GetHistorialEstadosAsync(ulong pedidoId, CancellationToken ct = default);
+
     Task<PedidoItemDto> AddItemAsync(CreatePedidoItemDto item, CancellationToken ct = default);
     Task<PedidoItemDto> UpdateItemAsync(UpdatePedidoItemDto item, CancellationToken ct = default);
     Task<bool> RemoveItemAsync(ulong itemId, CancellationToken ct = default);

--- a/src/ExtraGasMVC/Views/Pedidos/Details.cshtml
+++ b/src/ExtraGasMVC/Views/Pedidos/Details.cshtml
@@ -177,3 +177,55 @@
         </div>
     </div>
 }
+
+@* Issue #165: timeline de cambios de estado del pedido. Append-only, *@
+@* ordenada del más reciente al más antiguo (servicio garantiza ORDER BY *@
+@* created_at DESC, id DESC). La card se muestra solo si hay al menos una *@
+@* transición registrada — los pedidos recién creados no tienen historial *@
+@* hasta su primer cambio de estado. *@
+@if (ViewBag.HistorialEstados is IEnumerable<ExtraGasMVC.DTOs.PedidoEstadoHistoricoDto> historial && historial.Any())
+{
+    <div class="card mb-4">
+        <div class="card-header"><h3 class="card-title">Historial de estados</h3></div>
+        <div class="card-body table-responsive p-0">
+            <table class="table table-hover align-middle mb-0">
+                <thead>
+                    <tr>
+                        <th>Fecha</th>
+                        <th>Estado anterior</th>
+                        <th>Estado nuevo</th>
+                        <th>Usuario</th>
+                        <th>Motivo</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var h in historial)
+                    {
+                        <tr>
+                            <td>@h.CreatedAt.ToShortDateTime()</td>
+                            <td>
+                                @if (!string.IsNullOrEmpty(h.EstadoAnteriorCodigo))
+                                {
+                                    <span class="badge" style="background-color: @(h.EstadoAnteriorColor ?? "#6c757d")">
+                                        @(h.EstadoAnteriorNombre ?? h.EstadoAnteriorCodigo)
+                                    </span>
+                                }
+                                else
+                                {
+                                    <span class="text-muted">— (estado inicial)</span>
+                                }
+                            </td>
+                            <td>
+                                <span class="badge" style="background-color: @(h.EstadoNuevoColor ?? "#6c757d")">
+                                    @(h.EstadoNuevoNombre ?? h.EstadoNuevoCodigo)
+                                </span>
+                            </td>
+                            <td>@(h.UsuarioNombre ?? "—")</td>
+                            <td class="text-danger">@(h.MotivoCancelacion ?? "—")</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+}

--- a/tests/ExtraGasMVC.Tests/PedidoCanjeIntegrationTests.cs
+++ b/tests/ExtraGasMVC.Tests/PedidoCanjeIntegrationTests.cs
@@ -1002,6 +1002,27 @@ public class PedidoCanjeMySqlFixture : IAsyncLifetime
             KEY idx_pedido_items_deleted_at (deleted_at)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+        -- Issue #165: histórico append-only de cambios de estado. Réplica
+        -- mínima del DDL de la migración 20260831_000002_create_pedido_estados_historico.sql.
+        -- PedidoService.RegistrarCanjePedidoAsync y CambiarEstadoAsync insertan
+        -- aquí; sin esta tabla, los tests de canje happy-path fallan con
+        -- "Table doesn't exist" en SaveChanges. Los FKs apuntan a pedidos y
+        -- estados_pedido que ya existen en este punto.
+        CREATE TABLE pedido_estados_historico (
+            id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            pedido_id BIGINT UNSIGNED NOT NULL,
+            estado_anterior_id BIGINT UNSIGNED NULL,
+            estado_nuevo_id BIGINT UNSIGNED NOT NULL,
+            motivo_cancelacion VARCHAR(500) NULL,
+            usuario_id BIGINT UNSIGNED NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            CONSTRAINT fk_peh_pedido FOREIGN KEY (pedido_id) REFERENCES pedidos(id),
+            CONSTRAINT fk_peh_estado_anterior FOREIGN KEY (estado_anterior_id) REFERENCES estados_pedido(id),
+            CONSTRAINT fk_peh_estado_nuevo FOREIGN KEY (estado_nuevo_id) REFERENCES estados_pedido(id),
+            CONSTRAINT fk_peh_usuario FOREIGN KEY (usuario_id) REFERENCES usuarios(id),
+            KEY idx_peh_pedido_created (pedido_id, created_at DESC)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
         -- Garrafas y movimientos
         CREATE TABLE garrafas (
             id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,

--- a/tests/ExtraGasMVC.Tests/PedidoServiceCambiarEstadoTests.cs
+++ b/tests/ExtraGasMVC.Tests/PedidoServiceCambiarEstadoTests.cs
@@ -416,6 +416,191 @@ public class PedidoServiceCambiarEstadoTests
     // PedidoServiceSearchTests.NotImplementedGarrafaService.
     // ====================================================================
 
+    // ====================================================================
+    // Audit: pedido_estados_historico (issue #165)
+    //
+    // El helper privado RegistrarCambioEstadoAsync NO se invoca desde afuera
+    // (es private). Estos tests verifican su efecto observable: el helper
+    // debe crear exactamente una fila de historial por transición efectiva,
+    // con estado_anterior_id reflejando el estado previo y motivo solo
+    // cuando destino == CANCELADO.
+    //
+    // Patrón: InMemory provee PedidoEstadosHistorico porque el DbSet se
+    // aplica vía ApplyConfigurationsFromAssembly — InMemory no exige FKs.
+    // ====================================================================
+
+    [Fact]
+    public async Task CambiarEstadoAsync_TransicionValida_PersisteFilaEnHistorico()
+    {
+        var (service, context) = NewService(
+            nameof(CambiarEstadoAsync_TransicionValida_PersisteFilaEnHistorico));
+        var pedidoId = Seed(context, PedidoEstados.Pendiente);
+
+        var pendienteId = context.EstadosPedido.Single(e => e.Codigo == PedidoEstados.Pendiente).Id;
+        var confirmadoId = context.EstadosPedido.Single(e => e.Codigo == PedidoEstados.Confirmado).Id;
+
+        await service.CambiarEstadoAsync(pedidoId, confirmadoId, motivoCancelacion: null, usuarioId: 7);
+
+        var rows = await context.PedidoEstadosHistorico
+            .Where(h => h.PedidoId == pedidoId)
+            .ToListAsync();
+
+        rows.Should().HaveCount(1);
+        var row = rows[0];
+        row.EstadoAnteriorId.Should().Be(pendienteId,
+            "el helper debe capturar el estado previo ANTES de pisar el entity");
+        row.EstadoNuevoId.Should().Be(confirmadoId);
+        row.UsuarioId.Should().Be(7);
+        row.MotivoCancelacion.Should().BeNull(
+            "en transiciones cuyo destino no es CANCELADO, el motivo queda null");
+    }
+
+    [Fact]
+    public async Task CambiarEstadoAsync_DestinoCanceladoConMotivo_PersisteMotivoEnHistorico()
+    {
+        var (service, context) = NewService(
+            nameof(CambiarEstadoAsync_DestinoCanceladoConMotivo_PersisteMotivoEnHistorico));
+        var pedidoId = Seed(context, PedidoEstados.Pendiente);
+
+        var canceladoId = context.EstadosPedido.Single(e => e.Codigo == PedidoEstados.Cancelado).Id;
+
+        await service.CambiarEstadoAsync(
+            pedidoId, canceladoId, motivoCancelacion: "Cliente canceló por lluvia", usuarioId: 3);
+
+        var row = await context.PedidoEstadosHistorico
+            .SingleAsync(h => h.PedidoId == pedidoId);
+
+        row.MotivoCancelacion.Should().Be("Cliente canceló por lluvia",
+            "el motivo se persiste igual que en pedidos.motivo_cancelacion");
+        row.UsuarioId.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task CambiarEstadoAsync_MismoEstado_NoCreaFilaEnHistorico()
+    {
+        var (service, context) = NewService(
+            nameof(CambiarEstadoAsync_MismoEstado_NoCreaFilaEnHistorico));
+        var pedidoId = Seed(context, PedidoEstados.Pendiente);
+        var pendienteId = context.EstadosPedido.Single(e => e.Codigo == PedidoEstados.Pendiente).Id;
+
+        var ok = await service.CambiarEstadoAsync(
+            pedidoId, pendienteId, motivoCancelacion: null, usuarioId: 99);
+
+        ok.Should().BeTrue();
+        var rows = await context.PedidoEstadosHistorico
+            .Where(h => h.PedidoId == pedidoId)
+            .ToListAsync();
+        rows.Should().BeEmpty(
+            "el no-op (mismo estado actual que destino) no debe persistir fila de historial");
+    }
+
+    [Fact]
+    public async Task CambiarEstadoAsync_PedidoNoExiste_NoCreaFilaEnHistorico()
+    {
+        var (service, context) = NewService(
+            nameof(CambiarEstadoAsync_PedidoNoExiste_NoCreaFilaEnHistorico));
+
+        var ok = await service.CambiarEstadoAsync(
+            id: 9999, nuevoEstadoId: 1, motivoCancelacion: null, usuarioId: 1);
+
+        ok.Should().BeFalse();
+        var rows = await context.PedidoEstadosHistorico.ToListAsync();
+        rows.Should().BeEmpty(
+            "si el pedido no existe, no debe persistirse nada — ni el pedido ni el historial");
+    }
+
+    [Fact]
+    public async Task CambiarEstadoAsync_TransicionNoPermitida_NoCreaFilaEnHistorico()
+    {
+        // Defensa en profundidad: si la validación de la matriz de
+        // transiciones lanza, el helper no debe haber sido invocado (ni
+        // siquiera en el DbSet tracker, porque SaveChanges rollbackea).
+        var (service, context) = NewService(
+            nameof(CambiarEstadoAsync_TransicionNoPermitida_NoCreaFilaEnHistorico));
+        var pedidoId = Seed(context, PedidoEstados.Pendiente);
+        var entregadoId = context.EstadosPedido.Single(e => e.Codigo == PedidoEstados.Entregado).Id;
+
+        var act = async () => await service.CambiarEstadoAsync(
+            pedidoId, entregadoId, motivoCancelacion: null, usuarioId: 1);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Transición no permitida*");
+
+        var rows = await context.PedidoEstadosHistorico.ToListAsync();
+        rows.Should().BeEmpty("una transición rechazada no debe dejar fila de historial");
+    }
+
+    [Fact]
+    public async Task CambiarEstadoAsync_FlujoCompleto_CreaUnaFilaPorTransicion()
+    {
+        // Cubre el contrato central del helper: una fila por transición,
+        // no más, no menos. El estado_anterior de cada fila debe ser el
+        // estado_nuevo de la anterior — invariante crítico para reconstruir
+        // la timeline sin huecos.
+        var (service, context) = NewService(
+            nameof(CambiarEstadoAsync_FlujoCompleto_CreaUnaFilaPorTransicion));
+        var pedidoId = Seed(context, PedidoEstados.Pendiente);
+
+        var pendienteId = context.EstadosPedido.Single(e => e.Codigo == PedidoEstados.Pendiente).Id;
+        var confirmadoId = context.EstadosPedido.Single(e => e.Codigo == PedidoEstados.Confirmado).Id;
+        var enPreparacionId = context.EstadosPedido.Single(e => e.Codigo == PedidoEstados.EnPreparacion).Id;
+        var canceladoId = context.EstadosPedido.Single(e => e.Codigo == PedidoEstados.Cancelado).Id;
+
+        // PENDIENTE → CONFIRMADO
+        await service.CambiarEstadoAsync(pedidoId, confirmadoId, null, usuarioId: 1);
+        // CONFIRMADO → EN_PREPARACION
+        await service.CambiarEstadoAsync(pedidoId, enPreparacionId, null, usuarioId: 2);
+        // EN_PREPARACION → CANCELADO con motivo
+        await service.CambiarEstadoAsync(pedidoId, canceladoId, "Lluvia", usuarioId: 3);
+
+        var rows = await context.PedidoEstadosHistorico
+            .Where(h => h.PedidoId == pedidoId)
+            .OrderBy(h => h.Id)
+            .ToListAsync();
+
+        rows.Should().HaveCount(3, "tres transiciones efectivas = tres filas");
+
+        rows[0].EstadoAnteriorId.Should().Be(pendienteId);
+        rows[0].EstadoNuevoId.Should().Be(confirmadoId);
+        rows[0].UsuarioId.Should().Be(1);
+        rows[0].MotivoCancelacion.Should().BeNull();
+
+        rows[1].EstadoAnteriorId.Should().Be(confirmadoId);
+        rows[1].EstadoNuevoId.Should().Be(enPreparacionId);
+        rows[1].UsuarioId.Should().Be(2);
+        rows[1].MotivoCancelacion.Should().BeNull();
+
+        rows[2].EstadoAnteriorId.Should().Be(enPreparacionId);
+        rows[2].EstadoNuevoId.Should().Be(canceladoId);
+        rows[2].UsuarioId.Should().Be(3);
+        rows[2].MotivoCancelacion.Should().Be("Lluvia");
+    }
+
+    [Fact]
+    public async Task CambiarEstadoAsync_DestinoCanceladoSinMotivo_NoCreaFilaEnHistorico()
+    {
+        // Si la validación de "CANCELADO requiere motivo" lanza, el helper
+        // no debe haberse invocado. Misma defensa que transición no
+        // permitida pero específica del path de cancelación.
+        var (service, context) = NewService(
+            nameof(CambiarEstadoAsync_DestinoCanceladoSinMotivo_NoCreaFilaEnHistorico));
+        var pedidoId = Seed(context, PedidoEstados.Pendiente);
+        var canceladoId = context.EstadosPedido.Single(e => e.Codigo == PedidoEstados.Cancelado).Id;
+
+        var act = async () => await service.CambiarEstadoAsync(
+            pedidoId, canceladoId, motivoCancelacion: null, usuarioId: 1);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Debe ingresar un motivo de cancelación.");
+
+        var rows = await context.PedidoEstadosHistorico.ToListAsync();
+        rows.Should().BeEmpty();
+    }
+
+    // ====================================================================
+    // Fin sección Audit (issue #165)
+    // ====================================================================
+
     private sealed class NotImplementedGarrafaService : IGarrafaService
     {
         public Task<GarrafaDto?> GetByIdAsync(ulong id, CancellationToken ct = default) => throw new NotImplementedException();

--- a/tests/ExtraGasMVC.Tests/PedidosControllerCommandTests.cs
+++ b/tests/ExtraGasMVC.Tests/PedidosControllerCommandTests.cs
@@ -448,6 +448,7 @@ public class PedidosControllerCommandTests
         public Task<PedidoDto> UpdateAsync(UpdatePedidoDto pedido, ulong? usuarioId, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<bool> RestoreAsync(ulong id, ulong? usuarioId, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<EstadoPedidoDto>> GetTransicionesDisponiblesAsync(ulong pedidoId, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<IEnumerable<PedidoEstadoHistoricoDto>> GetHistorialEstadosAsync(ulong pedidoId, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<PedidoItemDto> UpdateItemAsync(UpdatePedidoItemDto item, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<CanalVentaDto>> GetCanalesVentaAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<MedioContactoPedidoDto>> GetMediosContactoAsync(CancellationToken ct = default) => throw new NotImplementedException();

--- a/tests/ExtraGasMVC.Tests/PedidosControllerIndexTests.cs
+++ b/tests/ExtraGasMVC.Tests/PedidosControllerIndexTests.cs
@@ -181,6 +181,7 @@ public class PedidosControllerIndexTests
         public Task<bool> RestoreAsync(ulong id, ulong? usuarioId, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<bool> CambiarEstadoAsync(ulong id, ulong nuevoEstadoId, string? motivoCancelacion, ulong? usuarioId, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<EstadoPedidoDto>> GetTransicionesDisponiblesAsync(ulong pedidoId, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<IEnumerable<PedidoEstadoHistoricoDto>> GetHistorialEstadosAsync(ulong pedidoId, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<PedidoItemDto> AddItemAsync(CreatePedidoItemDto item, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<PedidoItemDto> UpdateItemAsync(UpdatePedidoItemDto item, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<bool> RemoveItemAsync(ulong itemId, CancellationToken ct = default) => throw new NotImplementedException();


### PR DESCRIPTION
## Issue

Cierra #165.

## Problema

`pedidos` solo guardaba `estado_pedido_id` + `updated_at` + `updated_by` + `motivo_cancelacion` (cuando aplicaba). Si un pedido recorría `PENDIENTE → CONFIRMADO → EN_PREPARACION → ENTREGADO`, el sistema perdía el rastro de los estados intermedios. Para auditoría (¿cuándo se confirmó? ¿cuánto tiempo estuvo en preparación? ¿quién lo canceló y por qué motivo en cada paso?) no había forma de reconstruirlo.

El sistema ya tiene el patrón append-only en `movimientos_garrafa` (ADR #2) y `producto_precios_historico` (ADR #18). Faltaba aplicarlo a los cambios de estado del pedido — la grieta más visible de las tres.

## Cambios

### Schema

- **`db/migrations/20260831_000002_create_pedido_estados_historico.sql`** — tabla append-only con FKs RESTRICT a `pedidos`, `estados_pedido` (×2) y `usuarios`. Índice `(pedido_id, created_at DESC)` que cubre la query de timeline. `motivo_cancelacion VARCHAR(500)` solo se setea cuando destino = CANCELADO. Idempotente vía `CREATE TABLE IF NOT EXISTS` (índice dentro del CREATE). El archivo usa `000002` porque `000001` (add_productos_row_version) ya existe en el mismo día.

### Capa de datos

- **`Data/Entities/PedidoEstadoHistorico.cs`** — POCO con 4 navs (`Pedido`, `EstadoAnterior`, `EstadoNuevo`, `Usuario`).
- **`Data/Configurations/PedidoEstadoHistoricoConfiguration.cs`** — mapeo snake_case, FKs RESTRICT, índice. Sin `HasQueryFilter`, sin `UpdatedAt` (append-only).
- **`Data/Context/ExtraGasDbContext.cs`** — nuevo `DbSet<PedidoEstadoHistorico> PedidoEstadosHistorico`.

### Capa de servicio

- **`Services/Implementations/PedidoService.cs`**:
  - Helper privado `RegistrarCambioEstadoAsync(pedidoId, estadoAnteriorId, estadoNuevoId, usuarioId, motivo, ct)` — solo `_context.PedidoEstadosHistorico.Add(...)`. NO llama `SaveChanges` por sí mismo (se invoca dentro del `SaveChangesAsync` del caller para atomicidad).
  - `CambiarEstadoAsync` captura `estadoAnteriorId = pedido.EstadoPedidoId` ANTES de pisar el entity y llama al helper antes del SaveChanges final.
  - `AplicarCanjeYConfirmarAsync` (path canje físico, dentro de transacción ambiente) hace lo mismo.
  - `ConfirmarSinCanjeAsync` (caso degenerado VENTA-only) también.
- **`Services/Interfaces/IPedidoService.cs`** — nuevo `GetHistorialEstadosAsync(ulong pedidoId, CancellationToken ct)` que lee del índice, incluye EstadoAnterior/Nuevo + Usuario, ordena `CreatedAt DESC, Id DESC` (tiebreaker estable bajo clock skew), mapea a DTO.

### DTO + AutoMapper

- **`DTOs/PedidoEstadoHistoricoDto.cs`** — DTO con display fields (`EstadoAnteriorCodigo/Nombre/Color`, `EstadoNuevoCodigo/Nombre/Color`, `UsuarioNombre`) para la timeline.
- **`Mappings/MappingProfile.cs`** — `ConfigurePedidoEstadoHistorico()` resuelve los nombres legibles vía Includes del Service.

### API + UI

- **`Controllers/PedidosController.cs`**:
  - Nuevo endpoint `GET /Pedidos/{id}/historial-estados` (JSON, 404 si el pedido no existe, 200 con array si existe pero sin transiciones).
  - `Details` ahora carga el historial y lo pasa a `ViewBag.HistorialEstados` para renderizar la timeline card.
- **`Views/Pedidos/Details.cshtml`** — nueva card "Historial de estados" al final, con badges coloreados (reutilizando el `EstadoNuevoColor`), nombre del usuario y motivo en rojo. Solo se muestra si hay al menos una transición registrada.

### ADR

- **`db/docs/DECISIONES.md`** — ADR #20 documenta:
  - Por qué append-only (consistencia con `movimientos_garrafa` y `producto_precios_historico`).
  - Por qué se descartó el trigger AFTER UPDATE (perderíamos `usuario_id` y `motivo_cancelacion` confiables — los triggers no tienen contexto del usuario actual).
  - Por qué FKs RESTRICT (la trazabilidad es más importante que la limpieza).
  - Por qué `estado_anterior_id` NULLABLE (la app no inserta NULL hoy, pero permite un eventual seed/import sin migración).
  - Por qué NO se inserta fila en `CreateAsync` (solo se registran TRANSICIONES; el estado inicial PENDIENTE es convención).

### Tests

- **`tests/ExtraGasMVC.Tests/PedidoServiceCambiarEstadoTests.cs`** — sección "Audit (issue #165)" con **7 tests nuevos**:
  - `CambiarEstadoAsync_TransicionValida_PersisteFilaEnHistorico` — fila aparece, `estado_anterior_id` refleja el estado previo.
  - `CambiarEstadoAsync_DestinoCanceladoConMotivo_PersisteMotivoEnHistorico` — motivo llega a la fila.
  - `CambiarEstadoAsync_MismoEstado_NoCreaFilaEnHistorico` — no-op sin fila.
  - `CambiarEstadoAsync_PedidoNoExiste_NoCreaFilaEnHistorico` — pedido inexistente sin fila.
  - `CambiarEstadoAsync_TransicionNoPermitida_NoCreaFilaEnHistorico` — transición rechazada sin fila.
  - `CambiarEstadoAsync_FlujoCompleto_CreaUnaFilaPorTransicion` — invariante crítico: 3 transiciones encadenadas, `estado_anterior` de cada fila == `estado_nuevo` de la anterior.
  - `CambiarEstadoAsync_DestinoCanceladoSinMotivo_NoCreaFilaEnHistorico` — validación de motivo corta antes del helper.
- **`tests/ExtraGasMVC.Tests/PedidosControllerCommandTests.cs`** y **`PedidosControllerIndexTests.cs`** — fakes de `IPedidoService` actualizados con `GetHistorialEstadosAsync` (NotImplementedException como el resto de métodos que esos tests no ejercitan).
- **`tests/ExtraGasMVC.Tests/PedidoCanjeIntegrationTests.cs`** — schema mínimo de Testcontainers extendido con la nueva tabla (sin esto, los tests de canje happy-path fallan con "Table doesn't exist" en SaveChanges).

## Validación

- `dotnet build`: 0 errors.
- `dotnet test`: **444/444 passed** (437 previos + 7 nuevos, 0 regresiones). Antes: 441/444 (los 3 de PedidoCanjeIntegrationTests fallaban por la tabla faltante). Ahora pasan.

## Plan de pruebas

- [x] Build limpio.
- [x] Suite completa de tests pasa (444/444).
- [x] Tests de integración de canje pasan contra MySQL 8.0 real vía Testcontainers.

## Relacionado

- #163 (tests CambiarEstadoAsync) — los nuevos tests de audit extienden el mismo archivo.
- #164 (helper EnsurePedidoEditableForItemsAsync) — otro fix de PedidoService de la misma camada.
- ADR #2 (implícito en `movimientos_garrafa`), ADR #18 (`producto_precios_historico`) — el patrón append-only.

## Checklist

- [x] Conventional commit format (`feat(pedidos): ...`).
- [x] Sin trailers `Co-Authored-By`.
- [x] Build y tests pasan.
- [x] ADR documentando la decisión.