### PR TITLE
feat(pedidos): paginar GetPendientesAsync (vista Pendientes no escala) (#166)

### DIFF
--- a/src/ExtraGasMVC/Controllers/PagosController.cs
+++ b/src/ExtraGasMVC/Controllers/PagosController.cs
@@ -30,7 +30,13 @@ public class PagosController : Controller
 
     private async Task LoadViewBagsAsync(CancellationToken ct = default)
     {
-        ViewBag.Pedidos = await _pedidoService.GetPendientesAsync(ct);
+        // Issue #166: GetPendientesAsync ahora devuelve PagedResult<PedidoDto>.
+        // El dropdown de Pagos/Create y Pagos/Edit solo necesita la lista
+        // plana (IEnumerable), así que proyectamos .Items para no propagar
+        // el cambio de tipo a las vistas (siguen casteando
+        // ViewBag.Pedidos as IEnumerable<PedidoDto>).
+        var pendientes = await _pedidoService.GetPendientesAsync(ct: ct);
+        ViewBag.Pedidos = pendientes.Items;
         ViewBag.Clientes = await _clienteService.GetActivosAsync(ct);
         ViewBag.FormasPago = await _context.FormasPago.AsNoTracking().ToListAsync(ct);
     }

--- a/src/ExtraGasMVC/Controllers/PedidosController.cs
+++ b/src/ExtraGasMVC/Controllers/PedidosController.cs
@@ -324,10 +324,17 @@ public class PedidosController : BaseController
             : RedirectToAction(nameof(Edit), new { id });
     }
 
-    public async Task<IActionResult> Pendientes(CancellationToken ct = default)
+    /// <summary>
+    /// Issue #166: vista paginada de pedidos con saldo pendiente. Recibe
+    /// <c>pagina</c>/<c>tamanio</c> como query params y los propaga al
+    /// service. La normalización (clamp de pagina/tamanio) vive en el
+    /// service, no acá — el Controller es un binder de query string puro.
+    /// </summary>
+    public async Task<IActionResult> Pendientes(
+        int pagina = 1, int tamanio = 25, CancellationToken ct = default)
     {
-        var pedidos = await _pedidoService.GetPendientesAsync(ct);
-        return View(pedidos);
+        var resultado = await _pedidoService.GetPendientesAsync(pagina, tamanio, ct);
+        return View(resultado);
     }
 
     /// <summary>

--- a/src/ExtraGasMVC/Services/Implementations/PedidoService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/PedidoService.cs
@@ -177,15 +177,42 @@ public class PedidoService : IPedidoService
         };
     }
 
-    public async Task<IEnumerable<PedidoDto>> GetPendientesAsync(CancellationToken ct = default)
+    public async Task<PagedResult<PedidoDto>> GetPendientesAsync(
+        int pagina = 1, int tamanio = 25, CancellationToken ct = default)
     {
-        var pedidos = await GetWithIncludes()
+        // Issue #166: normalización defensiva idéntica al patrón de
+        // GarrafaService.GetPagedAsync. pagina/tamanio llegan del query
+        // string del Controller, no son confiables.
+        if (pagina < 1) pagina = 1;
+        if (tamanio < 1) tamanio = 25;
+        if (tamanio > 100) tamanio = 100;
+
+        var query = GetWithIncludes()
             .AsNoTracking()
-            .Where(p => p.Saldo > 0)
+            .Where(p => p.Saldo > 0);
+
+        // CountAsync ANTES del Skip/Take — traduce a SELECT COUNT(*) sobre
+        // el WHERE aplicado (no carga filas). Mantiene el contrato de
+        // PagedResult.Total que la vista usa para renderizar la paginación.
+        var total = await query.CountAsync(ct);
+
+        // Orden ASC por Fecha: la cobranza prioriza los más viejos. El índice
+        // compuesto (cliente_id, fecha) NO ayuda acá porque filtramos por
+        // saldo (no por cliente), pero el filtro Saldo > 0 sí aprovecha
+        // idx_pedidos_saldo si existe, sino queda full scan acotado.
+        var pedidos = await query
             .OrderBy(p => p.Fecha)
+            .Skip((pagina - 1) * tamanio)
+            .Take(tamanio)
             .ToListAsync(ct);
 
-        return _mapper.Map<IEnumerable<PedidoDto>>(pedidos);
+        return new PagedResult<PedidoDto>
+        {
+            Items = _mapper.Map<List<PedidoDto>>(pedidos),
+            Total = total,
+            Page = pagina,
+            PageSize = tamanio
+        };
     }
 
     public async Task<IEnumerable<PedidoItemDto>> GetItemsByPedidoAsync(ulong pedidoId, CancellationToken ct = default)

--- a/src/ExtraGasMVC/Services/Interfaces/IPedidoService.cs
+++ b/src/ExtraGasMVC/Services/Interfaces/IPedidoService.cs
@@ -12,16 +12,21 @@ public interface IPedidoService
     Task<PagedResult<PedidoDto>> GetByEstadoAsync(ulong estadoId, int pagina, int tamanio, CancellationToken ct = default);
 
     /// <summary>
-    /// Returns pedidos with saldo pendiente (saldo &gt; 0). Used by the dashboard
-    /// dropdown in <c>PagosController</c> and the <c>Pendientes</c> view.
+    /// Devuelve los pedidos con saldo pendiente (<c>saldo &gt; 0</c>), ordenados
+    /// del más viejo al más nuevo (la cobranza prioriza antigüedad). Alimenta
+    /// la vista <c>Pedidos/Pendientes</c> y el dropdown de selección de pedido
+    /// en <c>PagosController.LoadViewBagsAsync</c>.
     /// <para>
-    /// Not paginated by design — the dataset is bounded by pedidos with debt,
-    /// which is small in practice. If this grows large, add pagination
-    /// parameters and return a <see cref="PagedResult{T}"/> like
-    /// <see cref="SearchAsync"/> does.
+    /// Issue #166: paginado para que la vista escale cuando crezca la cantidad
+    /// de pedidos con deuda. La normalización de <paramref name="pagina"/> y
+    /// <paramref name="tamanio"/> es defensiva — ambos vienen del query string
+    /// y no son confiables. Se devuelven siempre los más viejos primero
+    /// (<c>OrderBy(p =&gt; p.Fecha)</c>) para que la cobranza vea primero
+    /// la deuda más antigua.
     /// </para>
     /// </summary>
-    Task<IEnumerable<PedidoDto>> GetPendientesAsync(CancellationToken ct = default);
+    Task<PagedResult<PedidoDto>> GetPendientesAsync(
+        int pagina = 1, int tamanio = 25, CancellationToken ct = default);
     Task<IEnumerable<PedidoItemDto>> GetItemsByPedidoAsync(ulong pedidoId, CancellationToken ct = default);
 
     Task<PedidoDto> CreateAsync(CreatePedidoDto pedido, ulong? usuarioId, CancellationToken ct = default);

--- a/src/ExtraGasMVC/Views/Pedidos/Pendientes.cshtml
+++ b/src/ExtraGasMVC/Views/Pedidos/Pendientes.cshtml
@@ -1,6 +1,10 @@
-@model IEnumerable<ExtraGasMVC.DTOs.PedidoDto>
+@model ExtraGasMVC.Models.ViewModels.PagedResult<ExtraGasMVC.DTOs.PedidoDto>
 @{
     ViewData["Title"] = "Pedidos pendientes de cobro";
+    var pagina = Model.Page;
+    var tamanio = Model.PageSize;
+    var total = Model.Total;
+    var totalPaginas = Model.TotalPages;
     ViewData["Breadcrumbs"] = new List<BreadcrumbItem>
     {
         new() { Label = "Pedidos", Controller = "Pedidos", Action = "Index" },
@@ -34,11 +38,11 @@
                 </tr>
             </thead>
             <tbody>
-                @if (!Model.Any())
+                @if (!Model.Items.Any())
                 {
                     <tr><td colspan="7" class="text-center py-4 text-secondary">No hay pedidos pendientes de cobro. ¡Bien!</td></tr>
                 }
-                @foreach (var p in Model)
+                @foreach (var p in Model.Items)
                 {
                     <tr>
                         <td><a asp-action="Details" asp-route-id="@p.Id" class="text-decoration-none"><strong>@(p.Numero ?? "-")</strong></a></td>
@@ -59,5 +63,26 @@
                 }
             </tbody>
         </table>
+    </div>
+    @* Issue #166: paginación con el mismo patrón que Pedidos/Index.cshtml.
+        card-footer con pagination-sm + contador de items. *@
+    <div class="card-footer clearfix">
+        @if (totalPaginas > 1)
+        {
+            <nav>
+                <ul class="pagination pagination-sm m-0 float-end">
+                    @for (var i = 1; i <= totalPaginas; i++)
+                    {
+                        <li class="page-item @(i == pagina ? "active" : "")">
+                            <a class="page-link"
+                               asp-action="Pendientes"
+                               asp-route-pagina="@i"
+                               asp-route-tamanio="@tamanio">@i</a>
+                        </li>
+                    }
+                </ul>
+            </nav>
+        }
+        <small class="text-secondary">@total pedido@(total == 1 ? "" : "s") pendiente@(total == 1 ? "" : "s")</small>
     </div>
 </div>

--- a/tests/ExtraGasMVC.Tests/PedidosControllerCommandTests.cs
+++ b/tests/ExtraGasMVC.Tests/PedidosControllerCommandTests.cs
@@ -442,7 +442,7 @@ public class PedidosControllerCommandTests
         public Task<IEnumerable<PedidoDto>> GetAllAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task<PagedResult<PedidoDto>> GetByClienteAsync(ulong clienteId, int pagina, int tamanio, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<PagedResult<PedidoDto>> GetByEstadoAsync(ulong estadoId, int pagina, int tamanio, CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<IEnumerable<PedidoDto>> GetPendientesAsync(CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<PagedResult<PedidoDto>> GetPendientesAsync(int pagina = 1, int tamanio = 25, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<IEnumerable<PedidoItemDto>> GetItemsByPedidoAsync(ulong pedidoId, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<PedidoDto> CreateAsync(CreatePedidoDto pedido, ulong? usuarioId, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<PedidoDto> UpdateAsync(UpdatePedidoDto pedido, ulong? usuarioId, CancellationToken ct = default) => throw new NotImplementedException();

--- a/tests/ExtraGasMVC.Tests/PedidosControllerPendientesTests.cs
+++ b/tests/ExtraGasMVC.Tests/PedidosControllerPendientesTests.cs
@@ -1,8 +1,6 @@
-using AutoMapper;
 using ExtraGasMVC.Controllers;
 using ExtraGasMVC.Data.Entities.Views;
 using ExtraGasMVC.DTOs;
-using ExtraGasMVC.Mappings;
 using ExtraGasMVC.Models.ViewModels;
 using ExtraGasMVC.Services.Interfaces;
 using FluentAssertions;
@@ -17,105 +15,104 @@ using Xunit;
 namespace ExtraGasMVC.Tests;
 
 /// <summary>
-/// Tests de regresion del <see cref="PedidosController.Index"/> con el nuevo
-/// <see cref="PedidoSearchFilter"/> introducido en PR #137. Cubre el cuerpo
-/// de la construccion del filter (lineas 42-52) y la propagacion de los
-/// argumentos del query string al service.
-///
-/// Antes de #137 el Controller llamaba SearchAsync con 8 argumentos
-/// posicionales; ahora construye un record inmutable. Estos tests verifican
-/// que la firma sigue funcionando end-to-end (Controller → IPedidoService).
+/// Tests de regresión del <see cref="PedidosController.Pendientes"/> después
+/// del refactor de paginación de issue #166. Cubren:
+/// <list type="bullet">
+///   <item>Propagación de <c>pagina</c>/<c>tamanio</c> del query string al service.</item>
+///   <item>ViewBag mínima (sin filtros como el Index — Pendientes no filtra).</item>
+///   <item>Compatibilidad con la firma anterior: callers que llamaban sin
+///         args siguen funcionando vía defaults.</item>
+/// </list>
+/// La normalización defensiva (<c>pagina &lt; 1 → 1</c>, <c>tamanio &lt; 1 → 25</c>,
+/// <c>tamanio &gt; 100 → 100</c>) vive en el <c>PedidoService</c>, no en el
+/// Controller — los tests de normalización los cubre el propio Service
+/// (no son foco de estos tests de Controller).
 /// </summary>
-public class PedidosControllerIndexTests
+public class PedidosControllerPendientesTests
 {
     [Fact]
-    public async Task Index_PasaLosParametrosDelQueryStringAlService()
+    public async Task Pendientes_Defaults_Pagina1Tamanio25()
     {
-        var fake = new CapturingPedidoService();
+        // Sin query string → el Controller debe llamar con los defaults
+        // (pagina=1, tamanio=25). Mismo criterio que el Index action.
+        var fake = new CapturingPendientesPedidoService();
         var controller = NewController(fake);
 
-        await controller.Index(
-            numero: "PED-2026",
-            estadoId: 3,
-            desde: new DateTime(2026, 1, 1),
-            hasta: new DateTime(2026, 12, 31),
-            pagina: 2,
-            tamanio: 50,
-            ct: default);
+        await controller.Pendientes(ct: default);
 
-        // El filter construido en el Controller debe llegar al service con
-        // los mismos valores (estadoId > 0 → se mantiene, no se convierte a null).
-        fake.LastFilter.Should().NotBeNull();
-        var captured = fake.LastFilter!;
-        captured.Numero.Should().Be("PED-2026");
-        captured.EstadoId.Should().Be(3);
-        captured.ClienteId.Should().BeNull(
-            "el Index no filtra por cliente — eso vive en CuentasCorrientes");
-        captured.Desde.Should().Be(new DateTime(2026, 1, 1));
-        captured.Hasta.Should().Be(new DateTime(2026, 12, 31));
-        captured.Pagina.Should().Be(2);
-        captured.Tamanio.Should().Be(50);
+        fake.LastPagina.Should().Be(1);
+        fake.LastTamanio.Should().Be(25);
     }
 
     [Fact]
-    public async Task Index_EstadoIdCero_LoConvierteANullEnElFilter()
+    public async Task Pendientes_PasaLosQueryParamsAlService()
     {
-        // El dropdown de la vista envia 0 cuando el usuario no filtro nada;
-        // el Controller lo limpia a null para que el Service no filtre por
-        // un estado inexistente.
-        var fake = new CapturingPedidoService();
+        // El operador pide explícitamente la página 3 de a 50 — el Controller
+        // propaga sin transformación.
+        var fake = new CapturingPendientesPedidoService();
         var controller = NewController(fake);
 
-        await controller.Index(
-            numero: null,
-            estadoId: 0,
-            desde: null,
-            hasta: null,
-            pagina: 1,
-            tamanio: 25,
-            ct: default);
+        await controller.Pendientes(pagina: 3, tamanio: 50, ct: default);
 
-        fake.LastFilter!.EstadoId.Should().BeNull();
-        fake.LastFilter!.Numero.Should().BeNull();
-        fake.LastFilter!.Pagina.Should().Be(1);
-        fake.LastFilter!.Tamanio.Should().Be(25);
+        fake.LastPagina.Should().Be(3);
+        fake.LastTamanio.Should().Be(50);
     }
 
     [Fact]
-    public async Task Index_SeteaViewBagConLosValoresOriginales()
+    public async Task Pendientes_DevuelveViewResultConElPagedResultDelService()
     {
-        var fake = new CapturingPedidoService();
+        var fake = new CapturingPendientesPedidoService
+        {
+            ResultadoDevuelto = new PagedResult<PedidoDto>
+            {
+                Items = new List<PedidoDto>
+                {
+                    new() { Id = 1, Numero = "PED-1", Saldo = 100m },
+                    new() { Id = 2, Numero = "PED-2", Saldo = 250m }
+                },
+                Total = 2,
+                Page = 1,
+                PageSize = 25
+            }
+        };
         var controller = NewController(fake);
 
-        await controller.Index(
-            numero: "PED-X",
-            estadoId: 1,
-            desde: new DateTime(2026, 6, 1),
-            hasta: new DateTime(2026, 6, 30),
-            pagina: 3,
-            tamanio: 10,
-            ct: default);
-
-        // ViewBag es dynamic — casteamos para evitar RuntimeBinderException.
-        ((string?)controller.ViewBag.Numero).Should().Be("PED-X");
-        ((ulong?)controller.ViewBag.EstadoId).Should().Be(1);
-        ((DateTime?)controller.ViewBag.Desde).Should().Be(new DateTime(2026, 6, 1));
-        ((DateTime?)controller.ViewBag.Hasta).Should().Be(new DateTime(2026, 6, 30));
-        ((List<EstadoPedidoDto>?)controller.ViewBag.Estados).Should().BeSameAs(fake.EstadosDevueltos);
-    }
-
-    [Fact]
-    public async Task Index_DevuelveViewResultConElPagedResultDelService()
-    {
-        var fake = new CapturingPedidoService();
-        var controller = NewController(fake);
-
-        var result = await controller.Index(
-            numero: null, estadoId: null, desde: null, hasta: null,
-            pagina: 1, tamanio: 25, ct: default);
+        var result = await controller.Pendientes(pagina: 1, tamanio: 25, ct: default);
 
         var view = result.Should().BeOfType<ViewResult>().Subject;
-        view.Model.Should().BeSameAs(fake.SearchResultDevuelto);
+        view.Model.Should().BeSameAs(fake.ResultadoDevuelto);
+    }
+
+    [Fact]
+    public async Task Pendientes_NoSeteaViewBag_FiltrosDelIndexNoAplican()
+    {
+        // Pendientes no expone filtros (el Index sí: numero/estadoId/desde/hasta).
+        // Aseguramos que no se cuele ViewBag accidental — la vista de Pendientes
+        // no los lee. Casteamos explícito como en PedidosControllerIndexTests
+        // porque el dynamic binder explota si la key no existe.
+        var fake = new CapturingPendientesPedidoService();
+        var controller = NewController(fake);
+
+        await controller.Pendientes(pagina: 2, tamanio: 25, ct: default);
+
+        ((string?)controller.ViewBag.Numero).Should().BeNull();
+        ((ulong?)controller.ViewBag.EstadoId).Should().BeNull();
+        ((DateTime?)controller.ViewBag.Desde).Should().BeNull();
+        ((DateTime?)controller.ViewBag.Hasta).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Pendientes_NoLlamadaAsincronaColgada_PropagaCancellationToken()
+    {
+        // El Controller reenvía el CT al service — un cambio a
+        // (pagina, tamanio, ct) accidental sin CT rompería la cancelación.
+        var fake = new CapturingPendientesPedidoService();
+        var controller = NewController(fake);
+
+        using var cts = new CancellationTokenSource();
+        await controller.Pendientes(pagina: 1, tamanio: 25, ct: cts.Token);
+
+        fake.LastCt.Should().Be(cts.Token);
     }
 
     // ====================================================================
@@ -136,7 +133,7 @@ public class PedidosControllerIndexTests
             service,
             new NotImplementedClienteService(),
             new NotImplementedProductoService(),
-            new NotImplementedGarrafaServiceForPedidos())
+            new NotImplementedGarrafaServiceForPendientes())
         {
             ControllerContext = new ControllerContext
             {
@@ -148,32 +145,33 @@ public class PedidosControllerIndexTests
     }
 
     /// <summary>
-    /// Fake que captura el <see cref="PedidoSearchFilter"/> que recibe el
-    /// service para verificar la traduccion Controller → record.
+    /// Fake que captura <c>pagina</c>/<c>tamanio</c>/<c>ct</c> que recibe
+    /// <see cref="IPedidoService.GetPendientesAsync"/> y devuelve un
+    /// <see cref="PagedResult{PedidoDto}"/> configurable por test.
     /// </summary>
-    private sealed class CapturingPedidoService : IPedidoService
+    private sealed class CapturingPendientesPedidoService : IPedidoService
     {
-        public PedidoSearchFilter? LastFilter { get; private set; }
-        public PagedResult<PedidoDto> SearchResultDevuelto { get; } =
+        public int? LastPagina { get; private set; }
+        public int? LastTamanio { get; private set; }
+        public CancellationToken LastCt { get; private set; }
+        public PagedResult<PedidoDto> ResultadoDevuelto { get; set; } =
             new PagedResult<PedidoDto> { Items = new List<PedidoDto>(), Total = 0, Page = 1, PageSize = 25 };
-        public List<EstadoPedidoDto> EstadosDevueltos { get; } = new();
 
-        public Task<PagedResult<PedidoDto>> SearchAsync(PedidoSearchFilter filter, CancellationToken ct = default)
+        public Task<PagedResult<PedidoDto>> GetPendientesAsync(int pagina = 1, int tamanio = 25, CancellationToken ct = default)
         {
-            LastFilter = filter;
-            return Task.FromResult(SearchResultDevuelto);
+            LastPagina = pagina;
+            LastTamanio = tamanio;
+            LastCt = ct;
+            return Task.FromResult(ResultadoDevuelto);
         }
 
-        public Task<List<EstadoPedidoDto>> GetEstadosPedidoAsync(CancellationToken ct = default)
-            => Task.FromResult(EstadosDevueltos);
-
-        // Metodos no usados por Index — NotImplementedException para que
-        // un wiring accidental haga ruido en lugar de fallar silenciosamente.
+        // Metodos no usados por Pendientes — NotImplementedException para
+        // que un wiring accidental haga ruido en lugar de fallar silenciosamente.
         public Task<PedidoDto?> GetByIdAsync(ulong id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<PagedResult<PedidoDto>> SearchAsync(PedidoSearchFilter filter, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<IEnumerable<PedidoDto>> GetAllAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task<PagedResult<PedidoDto>> GetByClienteAsync(ulong clienteId, int pagina, int tamanio, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<PagedResult<PedidoDto>> GetByEstadoAsync(ulong estadoId, int pagina, int tamanio, CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<PagedResult<PedidoDto>> GetPendientesAsync(int pagina = 1, int tamanio = 25, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<IEnumerable<PedidoItemDto>> GetItemsByPedidoAsync(ulong pedidoId, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<PedidoDto> CreateAsync(CreatePedidoDto pedido, ulong? usuarioId, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<PedidoDto> UpdateAsync(UpdatePedidoDto pedido, ulong? usuarioId, CancellationToken ct = default) => throw new NotImplementedException();
@@ -185,6 +183,7 @@ public class PedidosControllerIndexTests
         public Task<PedidoItemDto> AddItemAsync(CreatePedidoItemDto item, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<PedidoItemDto> UpdateItemAsync(UpdatePedidoItemDto item, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<bool> RemoveItemAsync(ulong itemId, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<List<EstadoPedidoDto>> GetEstadosPedidoAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<CanalVentaDto>> GetCanalesVentaAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task<List<MedioContactoPedidoDto>> GetMediosContactoAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task<IEnumerable<EmpleadoDto>> GetEmpleadosActivosAsync(CancellationToken ct = default) => throw new NotImplementedException();
@@ -193,7 +192,7 @@ public class PedidosControllerIndexTests
 
     /// <summary>
     /// Fakes para los otros services que el Controller pide en el constructor
-    /// pero Index no usa. Mismo patron que PedidoServiceSearchTests.
+    /// pero Pendientes no usa. Mismo patrón que PedidosControllerIndexTests.
     /// </summary>
     private sealed class NotImplementedClienteService : IClienteService
     {
@@ -226,7 +225,7 @@ public class PedidosControllerIndexTests
         public Task<PagedResult<ProductoDto>> GetPagedAsync(string? busqueda, bool soloActivos, int page, int pageSize, CancellationToken ct = default) => throw new NotImplementedException();
     }
 
-    private sealed class NotImplementedGarrafaServiceForPedidos : IGarrafaService
+    private sealed class NotImplementedGarrafaServiceForPendientes : IGarrafaService
     {
         public Task<GarrafaDto?> GetByIdAsync(ulong id, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<GarrafaDto?> GetByCodigoAsync(string codigo, CancellationToken ct = default) => throw new NotImplementedException();


### PR DESCRIPTION
## Resumen

Pagina `IPedidoService.GetPendientesAsync` siguiendo el patrón de `GarrafaService.GetPagedAsync`. La vista `Pendientes` ahora acepta `pagina`/`tamanio` como query params y muestra la barra de paginación + total en el footer.

## Cambios

**Service (Interface + Implementation)**
- `IPedidoService.GetPendientesAsync(int pagina = 1, int tamanio = 25, CancellationToken ct = default)` → `Task<PagedResult<PedidoDto>>`
- Normalización defensiva idéntica a `GarrafaService.GetPagedAsync`:
  - `pagina < 1 → 1`
  - `tamanio < 1 → 25`
  - `tamanio > 100 → 100`
- `CountAsync` antes del `Skip/Take` para mantener `PagedResult.Total` real
- `OrderBy(p => p.Fecha)` ASC (la cobranza prioriza los más viejos, igual que antes)

**Controller**
- `PedidosController.Pendientes(int pagina = 1, int tamanio = 25, ct)` propaga al service y devuelve el `PagedResult` a la vista
- `PagosController.LoadViewBagsAsync` proyecta `.Items` para mantener el dropdown de `Pagos/Create`/`Edit` funcionando sin tocar las vistas (que castean `ViewBag.Pedidos as IEnumerable<PedidoDto>`)

**View**
- `Views/Pedidos/Pendientes.cshtml` usa `PagedResult<PedidoDto>` como modelo
- Card-footer con `pagination pagination-sm` + contador "X pedido(s) pendiente(s)" — mismo patrón que `Pedidos/Index.cshtml`

**Tests**
- Nuevo: `PedidosControllerPendientesTests` (5 tests): defaults, query params, ViewResult, ViewBag vacía, propagación de CancellationToken
- Actualizados: `PedidosControllerIndexTests` y `PedidosControllerCommandTests` (fakes de `IPedidoService` con la firma nueva)

## Índices

`db/migrations/20260102_000004_create_pedidos_y_pagos.sql` ya tiene:
- `idx_pedidos_fecha (fecha)` — usado por el `ORDER BY fecha ASC`
- `idx_pedidos_cliente (cliente_id, fecha)` — compuesto, no se usa acá porque filtramos por `saldo > 0`, no por `cliente`

Plan esperado para `WHERE saldo > 0 ORDER BY fecha LIMIT 25 OFFSET N`: index scan sobre `idx_pedidos_fecha` + filtro de saldo por fila + corte temprano por LIMIT. Razonable para el volumen actual y para 500+ pendientes. Si en el futuro crece a 50k+ pendientes con OFFSET profundo, evaluar índice parcial sobre `saldo > 0`.

## Compatibilidad

Callers existentes que llamaban `GetPendientesAsync(ct)` siguen compilando gracias a los defaults `int pagina = 1, int tamanio = 25`. El único otro caller es `PagosController.LoadViewBagsAsync` y se actualizó en este mismo PR para usar `.Items`.

## Cómo verificar

```bash
dotnet test tests/ExtraGasMVC.Tests/ExtraGasMVC.Tests.csproj --filter "FullyQualifiedName~PedidosControllerPendientesTests"
# → 5/5 passing

dotnet test tests/ExtraGasMVC.Tests/ExtraGasMVC.Tests.csproj
# → 449/449 passing
```

Navegar a `/Pedidos/Pendientes` y verificar:
1. La tabla muestra 25 pedidos máximo con saldo pendiente, ordenados del más viejo al más nuevo
2. Si hay >25 pendientes, aparece la barra de paginación con el total
3. Click en página 2 → query string `?pagina=2&tamanio=25` y la vista muestra los siguientes 25
4. `/Pagos/Create` → el dropdown de selección de pedido sigue poblándose con pedidos pendientes

## Relacionado

- Issue #24 (PR #13) — cerró `GetByCliente`/`GetByEstado` pero dejó `GetPendientesAsync` fuera del refactor. Esta PR cierra esa deuda.