### PR TITLE
refactor(pedidos): tipar parámetro dynamic en ValidarCodigoContraReglasDeCanje (#167)

### DIFF
--- a/src/ExtraGasMVC/Services/Implementations/PedidoService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/PedidoService.cs
@@ -55,6 +55,20 @@ public class PedidoService : IPedidoService
         ulong EstadoConfirmadoId,
         ulong? UsuarioId);
 
+    /// <summary>
+    /// Projection of <c>garrafas</c> joined with <c>estados_garrafa</c> for the
+    /// canje validation flow. Captures only the columns needed by
+    /// <see cref="ValidarCodigoContraReglasDeCanje"/> so EF Core can translate
+    /// the <c>.Select(...)</c> to a single SQL query. Replaces the previous
+    /// anonymous type passed as <c>dynamic</c> (issue #167).
+    /// </summary>
+    private sealed record GarrafaCanjeInfo(
+        ulong Id,
+        string Codigo,
+        ulong EstadoGarrafaId,
+        ulong? ClienteId,
+        string EstadoCodigo);
+
     public PedidoService(
         ExtraGasDbContext context,
         IMapper mapper,
@@ -869,7 +883,7 @@ public class PedidoService : IPedidoService
             .AsNoTracking()
             .Include(g => g.EstadoGarrafa)
             .Where(g => codigos.Contains(g.Codigo))
-            .Select(g => new { g.Id, g.Codigo, g.EstadoGarrafaId, g.ClienteId, EstadoCodigo = g.EstadoGarrafa!.Codigo })
+            .Select(g => new GarrafaCanjeInfo(g.Id, g.Codigo, g.EstadoGarrafaId, g.ClienteId, g.EstadoGarrafa!.Codigo))
             .ToListAsync(ct);
 
         var encontrados = garrafas.ToDictionary(g => g.Codigo, g => g, StringComparer.Ordinal);
@@ -890,7 +904,7 @@ public class PedidoService : IPedidoService
     /// del mismo cliente del pedido.
     /// </summary>
     private static void ValidarCodigoContraReglasDeCanje(
-        string codigo, dynamic garrafa, PedidoItem item, Pedido pedido)
+        string codigo, GarrafaCanjeInfo garrafa, PedidoItem item, Pedido pedido)
     {
         if (item.TipoLinea == TipoLinea.ENTREGA)
         {


### PR DESCRIPTION
## Resumen

Refactor de calidad tipado en `PedidoService.ValidarCodigoContraReglasDeCanje` (issue #167): el parámetro que se proyectaba como `dynamic` desde el `.Select(...)` del join `garrafas` × `estados_garrafa` ahora es un `record` privado concreto, restaurando análisis estático y refactor-safety.

## Cambios

- **`src/ExtraGasMVC/Services/Implementations/PedidoService.cs`** (+16 / -2)
  - Nuevo `private sealed record GarrafaCanjeInfo(ulong Id, string Codigo, ulong EstadoGarrafaId, ulong? ClienteId, string EstadoCodigo)` junto al `CanjeConfirmacionContext` existente (mismo patrón interno, misma visibilidad).
  - `ValidarCodigosContraInventarioAsync`: el `.Select(...)` ahora materializa `GarrafaCanjeInfo` en lugar del tipo anónimo anterior.
  - `ValidarCodigoContraReglasDeCanje`: la firma cambia de `dynamic garrafa` a `GarrafaCanjeInfo garrafa`. El cuerpo del método no se toca (mismas reglas de canje para `ENTREGA` y `DEVOLUCION`).
  - El `ToDictionary(..., StringComparer.Ordinal)` se conserva: los códigos de garrafa siguen siendo case-sensitive por convención.

Sin cambios de schema, sin migración, sin tocar API pública (el método y el record son `private`).

## Criterios de aceptación

- [x] `private sealed record GarrafaCanjeInfo(...)` agregado junto al `CanjeConfirmacionContext` (línea 49)
- [x] Firma de `ValidarCodigoContraReglasDeCanje` cambiada: `GarrafaCanjeInfo` en lugar de `dynamic`
- [x] Query en `ValidarCodigosContraInventarioAsync` usa `new GarrafaCanjeInfo(...)` en el `.Select(...)`
- [x] Tests `CodigoInexistente` y `GarrafaNoPerteneceAlCliente` siguen pasando (ver "Tests" abajo)
- [x] SonarQube: ningún warning nuevo en `PedidoService.cs` (los 3 warnings del build son preexistentes: `NU1903` AutoMapper, `CS8602` Razor `Recepciones/Create.cshtml`, Sonar targets faltante en CI local)

## Tests

- `dotnet test --filter "FullyQualifiedName~PedidoCanjeIntegrationTests"`: **9/9 pasados** en 3 s.
  - Incluye los dos tests nombrados en los criterios de aceptación: `RegistrarCanjePedidoAsync_CodigoInexistente_LanzaInvalidOperationException` y `RegistrarCanjePedidoAsync_GarrafaNoPerteneceAlCliente_LanzaInvalidOperationException`.
- `dotnet test --filter "FullyQualifiedName~Pedido"`: **95/95 pasados** en 14 s (suite completa del módulo Pedidos).

Sin cambios en los tests: el refactor es interno y la firma pública del servicio no se ve afectada.

## Severidad y motivación

🟡 Medio — refactor de calidad (issue #167). No corrige bugs pero:

- Habilita rename seguro de `EstadoCodigo` / `ClienteId` (compilador valida).
- Saca a `PedidoService.cs` del catálogo SonarQube S3242/S3963 (tipado implícito vía `dynamic`).
- Consolida el patrón de proyecciones del módulo: ya todas las proyecciones del canje usan `record` o tipos concretos.
- Reduce la "carga cognitiva" de leer la proyección: un solo lugar declara qué columnas entran en juego.

## Archivos afectados

- `src/ExtraGasMVC/Services/Implementations/PedidoService.cs` (+16 / -2)

## Relacionado

- #138 (TRACKER Cubrir flujo de canje con tests de integración) — los 9 tests de `PedidoCanjeIntegrationTests` son la red de seguridad de este refactor.

Closes #167
