### PR TITLE
fix(pedidos): clean up SonarQube code smells in wwwroot/js/pedidos.js (#176)

### DIFF
--- a/src/ExtraGasMVC/wwwroot/js/pedidos.js
+++ b/src/ExtraGasMVC/wwwroot/js/pedidos.js
@@ -15,16 +15,6 @@
         DEVOLUCION: 'Devolución'
     };
 
-    var PEDIDO_URLS = {
-        cambiarEstado: null // se setea desde el data-action del primer .js-*-btn presente
-    };
-
-    function esc(s) {
-        return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) {
-            return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
-        });
-    }
-
     function sanitizeActionUrl(action) {
         if (typeof action !== 'string') return null;
         var raw = action.trim();
@@ -91,13 +81,13 @@
         }).then(function (result) {
             if (!result.isConfirmed) return;
             var campos = {
-                id: btn.getAttribute('data-pedido-id'),
-                nuevoEstadoId: btn.getAttribute('data-nuevo-estado-id')
+                id: btn.dataset.pedidoId,
+                nuevoEstadoId: btn.dataset.nuevoEstadoId
             };
             if (codigosPorItem) {
                 campos.codigosGarrafaJson = JSON.stringify(codigosPorItem);
             }
-            submitPost(btn.getAttribute('data-action'), campos);
+            submitPost(btn.dataset.action, campos);
         });
     }
 
@@ -144,10 +134,10 @@
     // ============================================================
     document.querySelectorAll('.js-remove-item-btn').forEach(function (btn) {
         btn.addEventListener('click', function () {
-            var itemId = btn.getAttribute('data-item-id');
-            var pedidoId = btn.getAttribute('data-pedido-id');
-            var producto = btn.getAttribute('data-producto') || 'este item';
-            var action = btn.getAttribute('data-action');
+            var itemId = btn.dataset.itemId;
+            var pedidoId = btn.dataset.pedidoId;
+            var producto = btn.dataset.producto || 'este item';
+            var action = btn.dataset.action;
             Swal.fire({
                 title: '¿Eliminar item?',
                 html: 'Se eliminará <strong>' + producto + '</strong> del pedido. Esta acción no se puede deshacer.',
@@ -186,9 +176,9 @@
                 reverseButtons: true
             }).then(function (result) {
                 if (result.isConfirmed) {
-                    submitPost(btn.getAttribute('data-action'), {
-                        id: btn.getAttribute('data-pedido-id'),
-                        nuevoEstadoId: btn.getAttribute('data-nuevo-estado-id')
+                    submitPost(btn.dataset.action, {
+                        id: btn.dataset.pedidoId,
+                        nuevoEstadoId: btn.dataset.nuevoEstadoId
                     });
                 }
             });
@@ -223,9 +213,9 @@
                 }
             }).then(function (result) {
                 if (result.isConfirmed) {
-                    submitPost(btn.getAttribute('data-action'), {
-                        id: btn.getAttribute('data-pedido-id'),
-                        nuevoEstadoId: btn.getAttribute('data-nuevo-estado-id'),
+                    submitPost(btn.dataset.action, {
+                        id: btn.dataset.pedidoId,
+                        nuevoEstadoId: btn.dataset.nuevoEstadoId,
                         motivoCancelacion: result.value.trim()
                     });
                 }
@@ -239,7 +229,7 @@
     document.querySelectorAll('.js-preparacion-btn').forEach(function (btn) {
         btn.addEventListener('click', function (e) {
             e.preventDefault();
-            var estadoNombre = btn.getAttribute('data-estado-nombre');
+            var estadoNombre = btn.dataset.estadoNombre;
             Swal.fire({
                 title: '¿Cambiar estado?',
                 html: 'El pedido pasará a estado <strong>' + estadoNombre + '</strong>.',
@@ -252,9 +242,9 @@
                 reverseButtons: true
             }).then(function (result) {
                 if (result.isConfirmed) {
-                    submitPost(btn.getAttribute('data-action'), {
-                        id: btn.getAttribute('data-pedido-id'),
-                        nuevoEstadoId: btn.getAttribute('data-nuevo-estado-id')
+                    submitPost(btn.dataset.action, {
+                        id: btn.dataset.pedidoId,
+                        nuevoEstadoId: btn.dataset.nuevoEstadoId
                     });
                 }
             });
@@ -267,8 +257,8 @@
     document.querySelectorAll('.js-confirmar-btn').forEach(function (btn) {
         btn.addEventListener('click', function (e) {
             e.preventDefault();
-            var tieneItems = btn.getAttribute('data-tiene-items') === 'true';
-            var tieneItemsCanje = btn.getAttribute('data-tiene-items-canje') === 'true';
+            var tieneItems = btn.dataset.tieneItems === 'true';
+            var tieneItemsCanje = btn.dataset.tieneItemsCanje === 'true';
 
             if (!tieneItems) {
                 Swal.fire({
@@ -323,8 +313,8 @@
             var codigosPorItem = {};
 
             textareas.forEach(function (ta) {
-                var itemId = ta.getAttribute('data-item-id');
-                var esperada = parseInt(ta.getAttribute('data-esperada'), 10);
+                var itemId = ta.dataset.itemId;
+                var esperada = Number.parseInt(ta.dataset.esperada, 10);
                 var codigos = (ta.value || '')
                     .split(/\r?\n/)
                     .map(function (s) { return s.trim(); })
@@ -369,9 +359,7 @@
             // Serializar a JSON y cerrar modal. El submit lo dispara el
             // botón Confirmar (con SweetAlert) desde el handler de la card.
             var modalEl = document.getElementById('js-canje-garrafas-modal');
-            if (modalEl && window.bootstrap) {
-                bootstrap.Modal.getOrCreateInstance(modalEl).hide();
-            }
+            window.bootstrap?.Modal?.getOrCreateInstance(modalEl)?.hide();
 
             // Disparar el submit. Usamos el primer botón confirmar de la
             // página (solo hay uno en Edit.cshtml).
@@ -410,10 +398,10 @@
         var descuento = document.getElementById('js-descuento');
         var totalDisplay = document.getElementById('js-total');
         var subtotalValue = Number(window.__PEDIDOS_SUBTOTAL__);
-        if (!descuento || !totalDisplay || isNaN(subtotalValue)) return;
+        if (!descuento || !totalDisplay || Number.isNaN(subtotalValue)) return;
 
         function recalcularTotal() {
-            var d = parseFloat(descuento.value) || 0;
+            var d = Number.parseFloat(descuento.value) || 0;
             if (d < 0) d = 0;
             if (d > 100) d = 100;
             var result = subtotalValue - (subtotalValue * d / 100);
@@ -422,9 +410,9 @@
 
         descuento.addEventListener('blur', recalcularTotal);
         descuento.addEventListener('input', function () {
-            var v = parseFloat(descuento.value);
-            if (!isNaN(v) && v > 100) descuento.value = 100;
-            if (!isNaN(v) && v < 0) descuento.value = 0;
+            var v = Number.parseFloat(descuento.value);
+            if (!Number.isNaN(v) && v > 100) descuento.value = 100;
+            if (!Number.isNaN(v) && v < 0) descuento.value = 0;
         });
     })();
 })();


### PR DESCRIPTION
## Resumen

Limpieza de los 31 code smells que SonarQube Clean-as-You-Code marcó en código nuevo del archivo `src/ExtraGasMVC/wwwroot/js/pedidos.js` (introducido en el PR #175).

Cambios 100% mecánicos / refactor — sin impacto funcional.

## Cambios

| Regla | Severidad | Cantidad | Acción |
|-------|-----------|----------|--------|
| `javascript:S7761` (`.dataset` sobre `getAttribute`) | MAJOR | 21 | reemplazo mecánico |
| `javascript:S1854` (useless assignment) | MAJOR | 1 | borrado de `PEDIDO_URLS` |
| `javascript:S1481` (código sin uso) | MINOR | 2 | borrado de `PEDIDO_URLS` + `esc()` |
| `javascript:S7773` (`Number.*` numéricos) | MINOR | 6 | `parseInt`/`parseFloat`/`isNaN` → `Number.*` |
| `javascript:S6582` (optional chaining) | MINOR | 1 | `window.bootstrap?.Modal?.getOrCreateInstance(modalEl)?.hide()` |

**Net diff:** -39 / +27 = **-12 líneas**.

## Por qué se puede borrar

- **`PEDIDO_URLS`**: único uso del identificador en todo el repo (verificado con grep). Definida como `{ cambiarEstado: null }` y nunca escrita/leída.
- **`esc()`**: definida pero nunca invocada dentro de `pedidos.js`. El único `esc()` que se usa en runtime vive en `wwwroot/js/recepciones.js`, que tiene su propia copia local — fuera del scope de esta issue.

## Por qué optional chaining es seguro

```diff
- if (modalEl && window.bootstrap) {
-     bootstrap.Modal.getOrCreateInstance(modalEl).hide();
- }
+ window.bootstrap?.Modal?.getOrCreateInstance(modalEl)?.hide();
```

El `if` original cortaba cuando `bootstrap` no existía. El `?.` colapsa exactamente esa guarda — si `bootstrap` falta, no se ejecuta nada. Mismo comportamiento, una línea en vez de tres.

El bloque "abrir modal" (líneas 280-295) **no** se convirtió porque tiene un `else` explícito con fallback a `enviarCambioEstado(btn, null)`, así que aplanar con `?.` cambiaría la semántica.

## Verificación

- `node --check wwwroot/js/pedidos.js` → **JS_OK**
- `dotnet build src/ExtraGasMVC` → **Build succeeded**, 0 errors (3 warnings preexistentes ajenos)
- `grep` final en `pedidos.js`: 0× `getAttribute`, 0× `parseInt/parseFloat/isNaN` sin prefijo `Number.`, 0× `PEDIDO_URLS`, 0× `esc(`

## Acceptance Criteria (de la issue)

- [x] Cero uso de `getAttribute("data-*")` — todo reemplazado por `.dataset.*`
- [x] Cero referencias a `PEDIDO_URLS` y `esc` (verificado que eran código muerto)
- [x] Todas las llamadas numéricas globales usan las variantes `Number.*`
- [x] Sin cambios de comportamiento funcional

## Quality Gate

Pendiente: re-analizar con SonarQube al mergear para confirmar Gate PASSED en `Sonar way - extragas` (umbral new_coverage ≥ 65%).

## Referencias

- Issue: #176
- PR introductorio del archivo: #175 (commit `0e79493`)
- Issue relacionada (módulo Pedidos): #168
