### PR TITLE
chore(sonarqube): resolve #178 (32 JS + 2 backend code smells)

### DIFF
--- a/src/ExtraGasMVC/Mappings/MappingProfile.cs
+++ b/src/ExtraGasMVC/Mappings/MappingProfile.cs
@@ -30,24 +30,46 @@ public class MappingProfile : Profile
     // Mapea los nombres legibles de los estados (anterior/nuevo) y del
     // usuario para alimentar la timeline en Details.cshtml y el endpoint
     // /Pedidos/{id}/historial-estados.
+    //
+    // Las lambdas de AutoMapper MapFrom son EXPRESSION TREES, no delegados
+    // regulares: no admiten `?.`, `??`, ni otras features que requieren
+    // semantica no-evaluable. Para bajar la Cognitive Complexity (21 -> un
+    // digito) sin romper expression trees, se extrae cada ternario a un
+    // helper estatico privado y el cuerpo del ConfigureX queda como una
+    // lista plana de invocaciones. Mismo patron que ConfigureMovimientoGarrafa
+    // y ConfigurePedido en este archivo.
     private void ConfigurePedidoEstadoHistorico()
     {
         CreateMap<PedidoEstadoHistorico, PedidoEstadoHistoricoDto>()
-            .ForMember(d => d.EstadoAnteriorCodigo, o => o.MapFrom(s =>
-                s.EstadoAnterior != null ? s.EstadoAnterior.Codigo : null))
-            .ForMember(d => d.EstadoAnteriorNombre, o => o.MapFrom(s =>
-                s.EstadoAnterior != null ? s.EstadoAnterior.Nombre : null))
-            .ForMember(d => d.EstadoAnteriorColor, o => o.MapFrom(s =>
-                s.EstadoAnterior != null ? s.EstadoAnterior.Color : null))
-            .ForMember(d => d.EstadoNuevoCodigo, o => o.MapFrom(s =>
-                s.EstadoNuevo != null ? s.EstadoNuevo.Codigo : string.Empty))
-            .ForMember(d => d.EstadoNuevoNombre, o => o.MapFrom(s =>
-                s.EstadoNuevo != null ? s.EstadoNuevo.Nombre : string.Empty))
-            .ForMember(d => d.EstadoNuevoColor, o => o.MapFrom(s =>
-                s.EstadoNuevo != null ? s.EstadoNuevo.Color : null))
-            .ForMember(d => d.UsuarioNombre, o => o.MapFrom(s =>
-                s.Usuario != null ? s.Usuario.Username : null));
+            .ForMember(d => d.EstadoAnteriorCodigo, o => o.MapFrom(s => EstadoAnteriorCodigo(s)))
+            .ForMember(d => d.EstadoAnteriorNombre, o => o.MapFrom(s => EstadoAnteriorNombre(s)))
+            .ForMember(d => d.EstadoAnteriorColor, o => o.MapFrom(s => EstadoAnteriorColor(s)))
+            .ForMember(d => d.EstadoNuevoCodigo, o => o.MapFrom(s => EstadoNuevoCodigo(s)))
+            .ForMember(d => d.EstadoNuevoNombre, o => o.MapFrom(s => EstadoNuevoNombre(s)))
+            .ForMember(d => d.EstadoNuevoColor, o => o.MapFrom(s => EstadoNuevoColor(s)))
+            .ForMember(d => d.UsuarioNombre, o => o.MapFrom(s => UsuarioNombre(s)));
     }
+
+    private static string? EstadoAnteriorCodigo(PedidoEstadoHistorico s)
+        => s.EstadoAnterior != null ? s.EstadoAnterior.Codigo : null;
+
+    private static string? EstadoAnteriorNombre(PedidoEstadoHistorico s)
+        => s.EstadoAnterior != null ? s.EstadoAnterior.Nombre : null;
+
+    private static string? EstadoAnteriorColor(PedidoEstadoHistorico s)
+        => s.EstadoAnterior != null ? s.EstadoAnterior.Color : null;
+
+    private static string EstadoNuevoCodigo(PedidoEstadoHistorico s)
+        => s.EstadoNuevo != null ? s.EstadoNuevo.Codigo : string.Empty;
+
+    private static string EstadoNuevoNombre(PedidoEstadoHistorico s)
+        => s.EstadoNuevo != null ? s.EstadoNuevo.Nombre : string.Empty;
+
+    private static string? EstadoNuevoColor(PedidoEstadoHistorico s)
+        => s.EstadoNuevo != null ? s.EstadoNuevo.Color : null;
+
+    private static string? UsuarioNombre(PedidoEstadoHistorico s)
+        => s.Usuario != null ? s.Usuario.Username : null;
 
     // Issue #109: mapping de la vista v_saldo_clientes para evitar N+1 en
     // CuentasCorrientes. AutoMapper proyecta las 5 columnas 1:1 (mismo nombre).

--- a/src/ExtraGasMVC/Services/Implementations/PedidoService.cs
+++ b/src/ExtraGasMVC/Services/Implementations/PedidoService.cs
@@ -404,7 +404,7 @@ public class PedidoService : IPedidoService
         // SaveChanges falla, ni el cambio de estado ni la fila de historial
         // quedan persistidas. Atomicidad garantizada por compartir el
         // SaveChanges (no hace falta transacción explícita acá).
-        await RegistrarCambioEstadoAsync(id, estadoAnteriorId, nuevoEstadoId, usuarioId, motivoCancelacion, ct);
+        await RegistrarCambioEstadoAsync(id, estadoAnteriorId, nuevoEstadoId, usuarioId, motivoCancelacion);
 
         await _context.SaveChangesAsync(ct);
 
@@ -781,7 +781,7 @@ public class PedidoService : IPedidoService
         // Append-only audit. ConfirmarSinCanjeAsync no abre transacción
         // propia (es un único SaveChanges); el helper y la mutación del
         // pedido commitean atómicamente juntos.
-        await RegistrarCambioEstadoAsync(pedido.Id, estadoAnteriorId, estadoConfirmadoId, usuarioId, motivo: null, ct);
+        await RegistrarCambioEstadoAsync(pedido.Id, estadoAnteriorId, estadoConfirmadoId, usuarioId, motivo: null);
 
         await _context.SaveChangesAsync(ct);
         return true;
@@ -966,7 +966,7 @@ public class PedidoService : IPedidoService
         // RegistrarCanjePedidoAsync cubre este SaveChanges — si la fila de
         // historial falla por cualquier razón (FK violada, etc.), la
         // transacción rollbackea y el pedido queda en su estado original.
-        await RegistrarCambioEstadoAsync(ctx.PedidoId, estadoAnteriorId, ctx.EstadoConfirmadoId, ctx.UsuarioId, motivo: null, ct);
+        await RegistrarCambioEstadoAsync(ctx.PedidoId, estadoAnteriorId, ctx.EstadoConfirmadoId, ctx.UsuarioId, motivo: null);
 
         await _context.SaveChangesAsync(ct);
     }
@@ -1028,13 +1028,14 @@ public class PedidoService : IPedidoService
     /// persistido en <c>pedidos.motivo_cancelacion</c>; null en cualquier
     /// transición cuyo destino no sea CANCELADO.
     /// </param>
+    // Cuerpo sincronico: solo agrega la fila al change tracker. El SaveChangesAsync
+    // (que SI usa el CancellationToken del caller) ocurre en el llamador.
     private Task RegistrarCambioEstadoAsync(
         ulong pedidoId,
         ulong? estadoAnteriorId,
         ulong estadoNuevoId,
         ulong? usuarioId,
-        string? motivo,
-        CancellationToken ct = default)
+        string? motivo)
     {
         _context.PedidoEstadosHistorico.Add(new PedidoEstadoHistorico
         {

--- a/src/ExtraGasMVC/wwwroot/js/pedidos.js
+++ b/src/ExtraGasMVC/wwwroot/js/pedidos.js
@@ -15,16 +15,6 @@
         DEVOLUCION: 'Devolución'
     };
 
-    var PEDIDO_URLS = {
-        cambiarEstado: null // se setea desde el data-action del primer .js-*-btn presente
-    };
-
-    function esc(s) {
-        return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) {
-            return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
-        });
-    }
-
     function sanitizeActionUrl(action) {
         if (typeof action !== 'string') return null;
         var raw = action.trim();
@@ -35,6 +25,7 @@
             if (parsed.origin !== window.location.origin) return null;
             return parsed.href;
         } catch (e) {
+            console.warn('sanitizeActionUrl: URL inválida', { raw: raw, error: e?.message });
             return null;
         }
     }
@@ -91,13 +82,13 @@
         }).then(function (result) {
             if (!result.isConfirmed) return;
             var campos = {
-                id: btn.getAttribute('data-pedido-id'),
-                nuevoEstadoId: btn.getAttribute('data-nuevo-estado-id')
+                id: btn.dataset.pedidoId,
+                nuevoEstadoId: btn.dataset.nuevoEstadoId
             };
             if (codigosPorItem) {
                 campos.codigosGarrafaJson = JSON.stringify(codigosPorItem);
             }
-            submitPost(btn.getAttribute('data-action'), campos);
+            submitPost(btn.dataset.action, campos);
         });
     }
 
@@ -144,10 +135,10 @@
     // ============================================================
     document.querySelectorAll('.js-remove-item-btn').forEach(function (btn) {
         btn.addEventListener('click', function () {
-            var itemId = btn.getAttribute('data-item-id');
-            var pedidoId = btn.getAttribute('data-pedido-id');
-            var producto = btn.getAttribute('data-producto') || 'este item';
-            var action = btn.getAttribute('data-action');
+            var itemId = btn.dataset.itemId;
+            var pedidoId = btn.dataset.pedidoId;
+            var producto = btn.dataset.producto || 'este item';
+            var action = btn.dataset.action;
             Swal.fire({
                 title: '¿Eliminar item?',
                 html: 'Se eliminará <strong>' + producto + '</strong> del pedido. Esta acción no se puede deshacer.',
@@ -186,9 +177,9 @@
                 reverseButtons: true
             }).then(function (result) {
                 if (result.isConfirmed) {
-                    submitPost(btn.getAttribute('data-action'), {
-                        id: btn.getAttribute('data-pedido-id'),
-                        nuevoEstadoId: btn.getAttribute('data-nuevo-estado-id')
+                    submitPost(btn.dataset.action, {
+                        id: btn.dataset.pedidoId,
+                        nuevoEstadoId: btn.dataset.nuevoEstadoId
                     });
                 }
             });
@@ -214,7 +205,7 @@
                 cancelButtonText: 'Volver',
                 reverseButtons: true,
                 inputValidator: function (value) {
-                    if (!value || !value.trim()) {
+                    if (!value?.trim()) {
                         return 'Debe ingresar un motivo de cancelación';
                     }
                     if (value.length > 500) {
@@ -223,9 +214,9 @@
                 }
             }).then(function (result) {
                 if (result.isConfirmed) {
-                    submitPost(btn.getAttribute('data-action'), {
-                        id: btn.getAttribute('data-pedido-id'),
-                        nuevoEstadoId: btn.getAttribute('data-nuevo-estado-id'),
+                    submitPost(btn.dataset.action, {
+                        id: btn.dataset.pedidoId,
+                        nuevoEstadoId: btn.dataset.nuevoEstadoId,
                         motivoCancelacion: result.value.trim()
                     });
                 }
@@ -239,7 +230,7 @@
     document.querySelectorAll('.js-preparacion-btn').forEach(function (btn) {
         btn.addEventListener('click', function (e) {
             e.preventDefault();
-            var estadoNombre = btn.getAttribute('data-estado-nombre');
+            var estadoNombre = btn.dataset.estadoNombre;
             Swal.fire({
                 title: '¿Cambiar estado?',
                 html: 'El pedido pasará a estado <strong>' + estadoNombre + '</strong>.',
@@ -252,9 +243,9 @@
                 reverseButtons: true
             }).then(function (result) {
                 if (result.isConfirmed) {
-                    submitPost(btn.getAttribute('data-action'), {
-                        id: btn.getAttribute('data-pedido-id'),
-                        nuevoEstadoId: btn.getAttribute('data-nuevo-estado-id')
+                    submitPost(btn.dataset.action, {
+                        id: btn.dataset.pedidoId,
+                        nuevoEstadoId: btn.dataset.nuevoEstadoId
                     });
                 }
             });
@@ -267,8 +258,8 @@
     document.querySelectorAll('.js-confirmar-btn').forEach(function (btn) {
         btn.addEventListener('click', function (e) {
             e.preventDefault();
-            var tieneItems = btn.getAttribute('data-tiene-items') === 'true';
-            var tieneItemsCanje = btn.getAttribute('data-tiene-items-canje') === 'true';
+            var tieneItems = btn.dataset.tieneItems === 'true';
+            var tieneItemsCanje = btn.dataset.tieneItemsCanje === 'true';
 
             if (!tieneItems) {
                 Swal.fire({
@@ -323,8 +314,8 @@
             var codigosPorItem = {};
 
             textareas.forEach(function (ta) {
-                var itemId = ta.getAttribute('data-item-id');
-                var esperada = parseInt(ta.getAttribute('data-esperada'), 10);
+                var itemId = ta.dataset.itemId;
+                var esperada = Number.parseInt(ta.dataset.esperada, 10);
                 var codigos = (ta.value || '')
                     .split(/\r?\n/)
                     .map(function (s) { return s.trim(); })
@@ -410,10 +401,10 @@
         var descuento = document.getElementById('js-descuento');
         var totalDisplay = document.getElementById('js-total');
         var subtotalValue = Number(window.__PEDIDOS_SUBTOTAL__);
-        if (!descuento || !totalDisplay || isNaN(subtotalValue)) return;
+        if (!descuento || !totalDisplay || Number.isNaN(subtotalValue)) return;
 
         function recalcularTotal() {
-            var d = parseFloat(descuento.value) || 0;
+            var d = Number.parseFloat(descuento.value) || 0;
             if (d < 0) d = 0;
             if (d > 100) d = 100;
             var result = subtotalValue - (subtotalValue * d / 100);
@@ -422,9 +413,9 @@
 
         descuento.addEventListener('blur', recalcularTotal);
         descuento.addEventListener('input', function () {
-            var v = parseFloat(descuento.value);
-            if (!isNaN(v) && v > 100) descuento.value = 100;
-            if (!isNaN(v) && v < 0) descuento.value = 0;
+            var v = Number.parseFloat(descuento.value);
+            if (!Number.isNaN(v) && v > 100) descuento.value = 100;
+            if (!Number.isNaN(v) && v < 0) descuento.value = 0;
         });
     })();
 })();


### PR DESCRIPTION
## Linked issue

Closes #178

## Type

- [x] Maintenance/tooling (`chore`)
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Breaking change

## Summary

- **JS cleanup (32 issues)** — `wwwroot/js/pedidos.js`: `.dataset` por `getAttribute` (21), `Number.*` por globales numéricos (6), borrado de `PEDIDO_URLS`/`esc`/catch vacío (4), opcional chain (1). Sin cambios de comportamiento — `.dataset.x` es semánticamente equivalente a `getAttribute('data-x')` para `<element data-x="">`.
- **Backend mecánico (1 issue)** — `PedidoService.RegistrarCambioEstadoAsync`: sacar el `CancellationToken ct` no usado (cuerpo sincrónico, `SaveChangesAsync` lo aplica el caller). Actualiza los 3 call sites posicionales.
- **Backend refactor (1 issue CRITICAL)** — `MappingProfile.ConfigurePedidoEstadoHistorico`: extraer los 7 ternarios a helpers estáticos privados para bajar Cognitive Complexity de 21 a ≤2. Patrón consistente con `ConfigureMovimientoGarrafa` y `ConfigurePedido` ya en el archivo.

## Changes

| File | Change |
|------|--------|
| `src/ExtraGasMVC/wwwroot/js/pedidos.js` | 32 fixes mecánicos: `.dataset`, `Number.parseInt`/`parseFloat`/`isNaN`, `?.`, `console.warn` en catch, baja `PEDIDO_URLS` y `esc` |
| `src/ExtraGasMVC/Services/Implementations/PedidoService.cs` | Saca `ct` no usado y propaga el cambio a los 3 callers (líneas 407, 784, 969) |
| `src/ExtraGasMVC/Mappings/MappingProfile.cs` | 7 `private static` helpers (`EstadoAnteriorCodigo`, …, `UsuarioNombre`) para bajar CC |

## Diff size

- 3 archivos, **+70 / −56** líneas (≈126 netas) — bien por debajo del budget 400.
- 3 work-unit commits, cada uno toca un archivo distinto y revierte limpio.

## Test Plan

- [x] `node --check src/ExtraGasMVC/wwwroot/js/pedidos.js` — sintaxis OK
- [x] `dotnet build src/ExtraGasMVC/ExtraGasMVC.csproj` — 0 errores, los mismos 3 warnings preexistentes (NU1903 AutoMapper ×2, CS8602 en Recepciones/Create.cshtml que NO toqué)
- [x] `dotnet build` no toca tests pero la lógica de `RegistrarCambioEstadoAsync` no cambió de comportamiento (cuerpo idéntico, sólo cambió la firma)
- [x] Revisé los 3 callers de `RegistrarCambioEstadoAsync` y todos pasan `ct` como último argumento posicional → drop consistente
- [x] Diff del JS es local a un solo archivo, todas las conversiones `getAttribute('data-x') → dataset.x` son literales 1:1

## Contributor Checklist

- [x] Issue aprobada (#178) marcada con `status:approved`
- [x] Tipo `chore` (limpieza masiva pre-existente; tracked desde #136/#158/#161)
- [x] Conventional commit format (`chore(sonarqube): ...`, `refactor(mappings): ...`)
- [x] Sin trailers `Co-Authored-By`
- [x] Single-PR (≈126 líneas < budget 400, no requiere chained-PR)

## Notas para el reviewer

- **Cobertura nueva**: agregar 7 helpers privados en `MappingProfile` no testeados podría bajar marginalmente `new_coverage`. El umbral del proyecto está en **65%** y actualmente marca **63.2%**. Si el nuevo análisis lo deja arriba del umbral, OK; si lo deja abajo (probable, pero cerca), lo levantamos en otra iteración con tests al mapping — fuera de scope de este PR.
- **AutoMapper expression trees**: el refactor de `ConfigurePedidoEstadoHistorico` intentó primero usar `?.` y `??`, pero **CS8072** detiene la build porque las lambdas de `MapFrom` son expression trees (no delegados). El patrón de extraer a helper estático era el correcto desde el inicio — coherente con el resto del archivo.
- **`S1172` y `S3776` "old code"**: estas dos issues ya no cuentan para el Quality Gate `new_violations` porque PRs posteriores las envejecieron. Pero el tracker #178 las listaba en su snapshot, y resolverlas no rompe nada. Quedan cubiertas.

## Verificación del Quality Gate post-merge

Para confirmar que el gate vuelve a OK, correr:

```bash
SONAR_TOKEN="squ_..." ./scripts/sonar-analyze.sh
```

(o esperar el análisis del CI). Cierre aceptable cuando:

- `new_violations = 0` (umbral 0)
- `new_coverage >= 65 %` (Quality Gate `Sonar way - extragas`)
- `new_duplicated_lines_density <= 3 %`

Dashboard vivo: https://sonarqube.elflacoseba.online/dashboard?id=extragas